### PR TITLE
Continue respecting older style file config

### DIFF
--- a/lib/cc/config/yaml.rb
+++ b/lib/cc/config/yaml.rb
@@ -55,7 +55,7 @@ module CC
       #
       # We need to munge from the latter to the former when/if we encounter it
       def convert_to_legacy_file_config(config)
-        if config.keys.size == 1 && config.key?("file")
+        if config.is_a?(Hash) && config.keys.size == 1 && config.key?("file")
           config["file"]
         else
           config

--- a/spec/cc/config/yaml_spec.rb
+++ b/spec/cc/config/yaml_spec.rb
@@ -76,6 +76,19 @@ describe CC::Config::YAML do
       expect(rubocop).to be_present
       expect(rubocop.config["config"]).to eq("foo.rb")
     end
+
+    it "respects legacy file config values" do
+      yaml = load_cc_yaml(<<-EOYAML)
+      plugins:
+        rubocop:
+          enabled: true
+          config: "foo.rb"
+      EOYAML
+
+      rubocop = yaml.engines.detect { |e| e.name == "rubocop" }
+      expect(rubocop).to be_present
+      expect(rubocop.config["config"]).to eq("foo.rb")
+    end
   end
 
   describe "#exclude_patterns" do


### PR DESCRIPTION
Many configs in the wild use this style, and some plugins still document
it as the preferred style. We were crashing on these because the code
assumed this was a hash.