### PR TITLE
Increase default engine memory to 1GB

### DIFF
--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -20,7 +20,7 @@ module CC
     class Engine
       Error = Class.new(StandardError)
 
-      DEFAULT_MEMORY_LIMIT = 512_000_000
+      DEFAULT_MEMORY_LIMIT = 1_024_000_000
 
       def initialize(name, metadata, config, label)
         @name = name

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -26,7 +26,7 @@ module CC::Analyzer
         expect(container).to receive(:run).with(including(
           "--cap-drop", "all",
           "--label", "com.codeclimate.label=a-label",
-          "--memory", "512000000",
+          "--memory", "1024000000",
           "--memory-swap", "-1",
           "--net", "none",
           "--rm",


### PR DESCRIPTION
512MB is pretty restrictive, and will become more restrictive in Quality
Model with us adding parsers for more memory-hungry languages like Java.

I think 1 GB is eminitely reasonable as a default for CLI usage. Our
defaults for hosted analysis are already higher than this.