### PR TITLE
Fix config handling of `analyze -e`.

### DIFF
--- a/lib/cc/config/engine.rb
+++ b/lib/cc/config/engine.rb
@@ -3,7 +3,8 @@ module CC
     class Engine
       DEFAULT_CHANNEL = "stable".freeze
 
-      attr_reader :name, :channel, :config, :exclude_patterns
+      attr_accessor :channel
+      attr_reader :name, :config, :exclude_patterns
       attr_writer :enabled
 
       def initialize(name, enabled: false, channel: nil, config: nil, exclude_patterns: [])
@@ -24,6 +25,10 @@ module CC
 
       def container_label
         @container_label ||= SecureRandom.uuid
+      end
+
+      def hash
+        name.hash
       end
 
       def eql?(other)

--- a/spec/cc/cli/analyze_spec.rb
+++ b/spec/cc/cli/analyze_spec.rb
@@ -2,8 +2,130 @@ require "spec_helper"
 
 module CC::CLI
   describe Analyze do
+    include FileSystemHelpers
+
+    around do |test|
+      within_temp_dir { test.call }
+    end
+
     describe "#run" do
-      # TODO: this was entirely re-written
+      it "sends expected engines to bridge" do
+        write_cc_yaml(<<-EOYAML)
+        {}
+        EOYAML
+
+        expect_bridge(
+          config: match_engines([
+            CC::Config::Engine.new("structure", enabled: true, config: { "enabled" => true, "channel" => "stable" }),
+            CC::Config::Engine.new("duplication", enabled: true, channel: "cronopio", config: { "enabled" => true, "channel" => "cronopio" }),
+          ])
+        )
+
+        command = described_class.new
+        command.run
+      end
+
+      it "respects -e for an unconfigured engine" do
+        write_cc_yaml(<<-EOYAML)
+        plugins:
+          rubocop:
+            enabled: true
+        EOYAML
+
+        expect_bridge(
+          config: match_engines([
+            CC::Config::Engine.new("structure", enabled: false, config: { "enabled" => true, "channel" => "stable" }),
+            CC::Config::Engine.new("duplication", enabled: false, channel: "cronopio", config: { "enabled" => true, "channel" => "cronopio" }),
+            CC::Config::Engine.new("rubocop", enabled: false, channel: "stable", config: { "enabled" => true }),
+            CC::Config::Engine.new("eslint", enabled: true, channel: "stable"),
+          ])
+        )
+
+        command = described_class.new(["-e", "eslint"])
+        command.run
+      end
+
+      it "respects -e for an already configured engine" do
+        write_cc_yaml(<<-EOYAML)
+        plugins:
+          rubocop:
+            enabled: true
+            config:
+              file: myconfig.yml
+        EOYAML
+
+        expect_bridge(
+          config: match_engines([
+            CC::Config::Engine.new("structure", enabled: false, config: { "enabled" => true, "channel" => "stable" }),
+            CC::Config::Engine.new("duplication", enabled: false, channel: "cronopio", config: { "enabled" => true, "channel" => "cronopio" }),
+            CC::Config::Engine.new("rubocop", enabled: true, channel: "stable", config: { "enabled" => true, "config" => "myconfig.yml" }),
+          ])
+        )
+
+        command = described_class.new(["-e", "rubocop"])
+        command.run
+      end
+
+      it "respects multiple -e" do
+        write_cc_yaml(<<-EOYAML)
+        plugins:
+          rubocop:
+            enabled: true
+            exclude_patterns:
+            - foo
+        EOYAML
+
+        expect_bridge(
+          config: match_engines([
+            CC::Config::Engine.new("structure", enabled: false, config: { "enabled" => true, "channel" => "stable" }),
+            CC::Config::Engine.new("duplication", enabled: false, channel: "cronopio", config: { "enabled" => true, "channel" => "cronopio" }),
+            CC::Config::Engine.new("rubocop", enabled: true, channel: "stable", exclude_patterns: ["foo"], config: { "enabled" => true, "exclude_patterns" => ["foo"] }),
+            CC::Config::Engine.new("eslint", enabled: true, channel: "stable"),
+          ])
+        )
+
+        command = described_class.new(["-e", "eslint", "-e", "rubocop"])
+        command.run
+      end
+
+      it "respects multiple -e with channel" do
+        write_cc_yaml(<<-EOYAML)
+        plugins:
+          rubocop:
+            enabled: true
+            exclude_patterns:
+            - foo
+        EOYAML
+
+        expect_bridge(
+          config: match_engines([
+            CC::Config::Engine.new("structure", enabled: false, config: { "enabled" => true, "channel" => "stable" }),
+            CC::Config::Engine.new("duplication", enabled: true, channel: "cronopio", config: { "enabled" => true, "channel" => "cronopio" }),
+            CC::Config::Engine.new("rubocop", enabled: true, channel: "foo", exclude_patterns: ["foo"], config: { "enabled" => true, "exclude_patterns" => ["foo"] }),
+            CC::Config::Engine.new("eslint", enabled: true, channel: "bar"),
+          ])
+        )
+
+        command = described_class.new(["-e", "duplication", "-e", "eslint:bar", "-e", "rubocop:foo"])
+        command.run
+      end
+    end
+
+    def write_cc_yaml(yaml)
+      make_file(CC::Config::YAMLAdapter::DEFAULT_PATH, yaml)
+    end
+
+    def expect_bridge(config:)
+      stub_bridge = double(:bridge)
+      expect(stub_bridge).to receive(:run)
+
+      expect(CC::Analyzer::Bridge).to receive(:new) do |args|
+        expect(args[:config]).to config
+        expect(args[:formatter]).to be_a_kind_of(CC::Analyzer::Formatters::Formatter)
+        expect(args[:listener]).to be_an_instance_of(CC::Analyzer::CompositeContainerListener)
+        expect(args[:registry]).to be_an_instance_of(CC::EngineRegistry)
+        stub_bridge
+      end
     end
   end
 end

--- a/spec/support/engine_list_matcher.rb
+++ b/spec/support/engine_list_matcher.rb
@@ -1,0 +1,60 @@
+# expect(config).to match_engines([
+#  Engine.new("duplication", enabled: true)
+#  Engine.new("rubocop", enabled: true, config: foo),
+# ])
+RSpec::Matchers.define(:match_engines) do |expected|
+  match do |actual|
+    missing_engines(actual.engines, expected).empty? &&
+      extra_engines(actual.engines, expected).empty? &&
+      misconfigured_engines(actual.engines, expected).empty?
+  end
+
+  failure_message do |actual|
+    msg = "expect to match engine list:\n"
+
+    if (missing = missing_engines(actual.engines, expected)).any?
+      msg << "  - missing engines: #{missing.map(&:name).inspect}\n"
+    end
+
+    if (extra = extra_engines(actual.engines, expected)).any?
+      msg << "  - extra engines: #{extra.map(&:name).inspect}\n"
+    end
+
+    misconfigured_msgs(actual.engines, expected).each do |engine_msg|
+      msg << "  - #{engine_msg}\n"
+    end
+
+    msg
+  end
+
+  def missing_engines(actual, expected)
+    expected - actual
+  end
+
+  def extra_engines(actual, expected)
+    actual - expected
+  end
+
+  def misconfigured_engines(actual, expected)
+    actual.select do |engine|
+      expected_engine = expected.detect { |e| e == engine }
+      expected_engine && (
+        expected_engine.enabled? != engine.enabled? ||
+          expected_engine.channel != engine.channel ||
+          expected_engine.exclude_patterns != engine.exclude_patterns ||
+          expected_engine.config != engine.config
+      )
+    end
+  end
+
+  def misconfigured_msgs(actual, expected)
+    misconfigured_engines(actual, expected).flat_map do |engine|
+      expected_engine = expected.detect { |e| e == engine }
+      [:enabled?, :channel, :config, :exclude_patterns].map do |attr|
+        if expected_engine.send(attr) != engine.send(attr)
+          "expected #{engine.name}.#{attr} to be #{expected_engine.send(attr).inspect}, got #{engine.send(attr).inspect}."
+        end
+      end
+    end.compact
+  end
+end


### PR DESCRIPTION
We had a regression in QM with respecting engine config when only
certain engines are selected for running with `-e` or `--engine`.

The change here makes it so that `-e` will not reset any
already-specified config for an engine, but will still add a new engine
with default config when the named engine wasn't already configured.