### PR TITLE
Config: update validation for some plugin config

### DIFF
--- a/lib/cc/config/validation/engine_validator.rb
+++ b/lib/cc/config/validation/engine_validator.rb
@@ -32,7 +32,9 @@ module CC
           validate_key_type("config", [String, Hash])
           validate_key_type("exclude_patterns", [Array])
 
-          warn_unrecognized_keys(%w[enabled channel config exclude_patterns])
+          validate_checks
+
+          warn_unrecognized_keys(%w[enabled channel checks config exclude_patterns])
         end
 
         def validate_root
@@ -41,6 +43,16 @@ module CC
             return false
           end
           true
+        end
+
+        def validate_checks
+          return unless validate_key_type("checks", Hash)
+
+          data.fetch("checks", {}).each do |check_name, check_data|
+            validator = CheckValidator.new(check_data)
+            errors.push(*validator.errors)
+            warnings.push(*validator.warnings)
+          end
         end
       end
     end

--- a/lib/cc/config/validation/engine_validator.rb
+++ b/lib/cc/config/validation/engine_validator.rb
@@ -33,8 +33,9 @@ module CC
           validate_key_type("exclude_patterns", [Array])
 
           validate_checks
+          validate_exclude_fingerprints
 
-          warn_unrecognized_keys(%w[enabled channel checks config exclude_patterns])
+          warn_unrecognized_keys(%w[enabled channel checks config exclude_fingerprints exclude_patterns])
         end
 
         def validate_root
@@ -52,6 +53,13 @@ module CC
             validator = CheckValidator.new(check_data)
             errors.push(*validator.errors)
             warnings.push(*validator.warnings)
+          end
+        end
+
+        def validate_exclude_fingerprints
+          validate_key_type("exclude_fingerprints", Array)
+          if data.key?("exclude_fingerprints")
+            warnings << "'exclude_fingerprints' is deprecated, and support may be removed in the future"
           end
         end
       end

--- a/spec/cc/config/validation/json_spec.rb
+++ b/spec/cc/config/validation/json_spec.rb
@@ -264,6 +264,39 @@ describe CC::Config::Validation::JSON do
     end
   end
 
+  describe "exclude_fingerprints" do
+    it "warns for valid usage" do
+      validator = validate_json(<<-EOJSON)
+      {
+        "plugins": {
+          "rubocop": {
+            "exclude_fingerprints": [ "foo" ]
+          }
+        }
+      }
+      EOJSON
+
+      expect(validator).to be_valid
+      expect(validator.warnings).to include(/'exclude_fingerprints' is deprecated/)
+    end
+
+    it "errors for the wrong type" do
+      validator = validate_json(<<-EOJSON)
+      {
+        "plugins": {
+          "rubocop": {
+            "exclude_fingerprints": "foo"
+          }
+        }
+      }
+      EOJSON
+
+      expect(validator).not_to be_valid
+      expect(validator.errors).to include("engine rubocop: 'exclude_fingerprints' must be an array")
+    end
+  end
+
+
   def validate_json(json, registry = nil)
     Tempfile.open("") do |tmp|
       tmp.puts(json)

--- a/spec/cc/config/validation/json_spec.rb
+++ b/spec/cc/config/validation/json_spec.rb
@@ -231,6 +231,39 @@ describe CC::Config::Validation::JSON do
     end
   end
 
+  describe "engine checks" do
+    it "is valid for valid usage" do
+      validator = validate_json(<<-EOJSON)
+      {
+        "plugins": {
+          "rubocop": {
+            "checks": {
+              "Foo": { "enabled": false }
+            }
+          }
+        }
+      }
+      EOJSON
+
+      expect(validator).to be_valid
+    end
+
+    it "errors for the wrong type" do
+      validator = validate_json(<<-EOJSON)
+      {
+        "plugins": {
+          "rubocop": {
+            "checks": [ "Foo" ]
+          }
+        }
+      }
+      EOJSON
+
+      expect(validator).not_to be_valid
+      expect(validator.errors).to include("engine rubocop: 'checks' must be a hash")
+    end
+  end
+
   def validate_json(json, registry = nil)
     Tempfile.open("") do |tmp|
       tmp.puts(json)

--- a/spec/cc/config/validation/yaml_spec.rb
+++ b/spec/cc/config/validation/yaml_spec.rb
@@ -270,6 +270,31 @@ describe CC::Config::Validation::YAML do
     end
   end
 
+  describe "exclude_fingerprints" do
+    it "warns for valid usage" do
+      validator = validate_yaml(<<-EOYAML)
+      plugins:
+        rubocop:
+          exclude_fingerprints:
+            - foo
+      EOYAML
+
+      expect(validator).to be_valid
+      expect(validator.warnings).to include(/'exclude_fingerprints' is deprecated/)
+    end
+
+    it "errors for the wrong type" do
+      validator = validate_yaml(<<-EOYAML)
+      plugins:
+        rubocop:
+          exclude_fingerprints: Foo
+      EOYAML
+
+      expect(validator).not_to be_valid
+      expect(validator.errors).to include("engine rubocop: 'exclude_fingerprints' must be an array")
+    end
+  end
+
   def validate_yaml(yaml, registry = nil)
     Tempfile.open("") do |tmp|
       tmp.puts(yaml)

--- a/spec/cc/config/validation/yaml_spec.rb
+++ b/spec/cc/config/validation/yaml_spec.rb
@@ -244,6 +244,32 @@ describe CC::Config::Validation::YAML do
     end
   end
 
+  describe "engine checks" do
+    it "is valid for valid usage" do
+      validator = validate_yaml(<<-EOYAML)
+      plugins:
+        rubocop:
+          checks:
+            Foo:
+              enabled: false
+      EOYAML
+
+      expect(validator).to be_valid
+    end
+
+    it "errors for the wrong type" do
+      validator = validate_yaml(<<-EOYAML)
+      plugins:
+        rubocop:
+          checks:
+            - Foo
+      EOYAML
+
+      expect(validator).not_to be_valid
+      expect(validator.errors).to include("engine rubocop: 'checks' must be a hash")
+    end
+  end
+
   def validate_yaml(yaml, registry = nil)
     Tempfile.open("") do |tmp|
       tmp.puts(yaml)


### PR DESCRIPTION
We still support checks within plugins for filtering, and also support exclude_patterns (although it's deprecated). This updates our validation checks to say the appropriate things.