### PR TITLE
QUA-567: Update Docker version from 17.12.1 to 20.10.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk --no-cache upgrade && \
       rm -fr /usr/share/ri
 
 RUN wget -q -O /tmp/docker.tgz \
-    https://download.docker.com/linux/static/stable/x86_64/docker-17.12.1-ce.tgz && \
+    https://download.docker.com/linux/static/stable/x86_64/docker-20.10.9.tgz && \
     tar -C /tmp -xzvf /tmp/docker.tgz && \
     mv /tmp/docker/docker /bin/docker && \
     chmod +x /bin/docker && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk --no-cache upgrade && \
       rm -fr /usr/share/ri
 
 RUN wget -q -O /tmp/docker.tgz \
-    https://download.docker.com/linux/static/stable/x86_64/docker-20.10.9.tgz && \
+    https://download.docker.com/linux/static/stable/x86_64/docker-20.10.17.tgz && \
     tar -C /tmp -xzvf /tmp/docker.tgz && \
     mv /tmp/docker/docker /bin/docker && \
     chmod +x /bin/docker && \


### PR DESCRIPTION
Updates used Docker version from 17.12.1 to ~~20.10.9~~ 20.10.17.  May fix #1053 

Related issue: https://codeclimate.atlassian.net/browse/QUA-657

