### PR TITLE
QUA-870: metrics engines names cleanup and add repo_id

### DIFF
--- a/lib/cc/analyzer/statsd_container_listener.rb
+++ b/lib/cc/analyzer/statsd_container_listener.rb
@@ -31,27 +31,22 @@ module CC
 
       attr_reader :statsd
 
-      def increment(engine, metric_name)
+      def increment(engine, action)
         tags = engine_tags(engine)
-        # rubocop:disable Style/HashSyntax
-        metrics(engine, metric_name).each { |metric| statsd.increment(metric, tags: tags) }
-        # rubocop:enable Style/HashSyntax
+        metric = metric_name(engine, action)
+
+        statsd.increment(metric, tags: tags)
       end
 
-      def timing(engine, metric_name, millis)
+      def timing(engine, action, millis)
         tags = engine_tags(engine)
-        # rubocop:disable Style/HashSyntax
-        metrics(engine, metric_name).each { |metric| statsd.timing(metric, millis, tags: tags) }
-        # rubocop:enable Style/HashSyntax
+        metric = metric_name(engine, action)
+
+        statsd.timing(metric, millis, tags: tags)
       end
 
-      def metrics(engine, metric_name)
-        [
-          "engines.#{metric_name}",
-          "engines.names.#{engine.name}.#{metric_name}",
-        ].tap do |metrics|
-          metrics << "engines.names.#{engine.name}.#{engine.channel}.#{metric_name}" if engine_channel_present?(engine)
-        end
+      def metric_name(engine, action)
+        "engines.#{action}"
       end
 
       def engine_tags(engine)

--- a/lib/cc/analyzer/statsd_container_listener.rb
+++ b/lib/cc/analyzer/statsd_container_listener.rb
@@ -1,12 +1,12 @@
 module CC
   module Analyzer
     class StatsdContainerListener < ContainerListener
-      # rubocop:disable Lint/MethodMissingSuper
+      # rubocop:disable Lint/MissingSuper
       def initialize(statsd, repo_id: nil)
         @statsd = statsd
         @repo_id = repo_id
       end
-      # rubocop:enable Lint/MethodMissingSuper
+      # rubocop:enable Lint/MissingSuper
 
       def started(engine, _details)
         increment(engine, "started")

--- a/lib/cc/analyzer/statsd_container_listener.rb
+++ b/lib/cc/analyzer/statsd_container_listener.rb
@@ -1,10 +1,12 @@
 module CC
   module Analyzer
     class StatsdContainerListener < ContainerListener
+      # rubocop:disable Lint/MethodMissingSuper
       def initialize(statsd, repo_id: nil)
         @statsd = statsd
         @repo_id = repo_id
       end
+      # rubocop:enable Lint/MethodMissingSuper
 
       def started(engine, _details)
         increment(engine, "started")
@@ -34,19 +36,23 @@ module CC
 
       def increment(engine, action)
         tags = engine_tags(engine)
-        metric = metric_name(engine, action)
+        metric = metric_name(action)
 
+        # rubocop:disable Style/HashSyntax
         statsd.increment(metric, tags: tags)
+        # rubocop:enable Style/HashSyntax
       end
 
       def timing(engine, action, millis)
         tags = engine_tags(engine)
-        metric = metric_name(engine, action)
+        metric = metric_name(action)
 
+        # rubocop:disable Style/HashSyntax
         statsd.timing(metric, millis, tags: tags)
+        # rubocop:enable Style/HashSyntax
       end
 
-      def metric_name(engine, action)
+      def metric_name(action)
         "engines.#{action}"
       end
 

--- a/lib/cc/analyzer/statsd_container_listener.rb
+++ b/lib/cc/analyzer/statsd_container_listener.rb
@@ -1,8 +1,9 @@
 module CC
   module Analyzer
     class StatsdContainerListener < ContainerListener
-      def initialize(statsd)
+      def initialize(statsd, repo_id: nil)
         @statsd = statsd
+        @repo_id = repo_id
       end
 
       def started(engine, _details)
@@ -29,7 +30,7 @@ module CC
 
       private
 
-      attr_reader :statsd
+      attr_reader :statsd, :repo_id
 
       def increment(engine, action)
         tags = engine_tags(engine)
@@ -52,6 +53,7 @@ module CC
       def engine_tags(engine)
         ["engine:#{engine.name}"].tap do |tags|
           tags << "channel:#{engine.channel}" if engine_channel_present?(engine)
+          tags << "repo_id:#{repo_id}" if repo_id.present?
         end
       end
 

--- a/spec/cc/analyzer/statsd_container_listener_spec.rb
+++ b/spec/cc/analyzer/statsd_container_listener_spec.rb
@@ -70,9 +70,9 @@ module CC::Analyzer
           statsd = double(timing: nil, increment: nil)
           result = double(duration: 10, timed_out?: false, maximum_output_exceeded?: false, exit_status: 0)
 
-          expect(statsd).to receive(:timing).with("engines.names.engine.stable.time", 10, tags: ["engine:engine", "channel:stable"])
-          expect(statsd).to receive(:increment).with("engines.names.engine.stable.finished", tags: ["engine:engine", "channel:stable"])
-          expect(statsd).to receive(:increment).with("engines.names.engine.stable.result.success", tags: ["engine:engine", "channel:stable"])
+          expect(statsd).to receive(:timing).with("engines.time", 10, tags: ["engine:engine", "channel:stable"])
+          expect(statsd).to receive(:increment).with("engines.finished", tags: ["engine:engine", "channel:stable"])
+          expect(statsd).to receive(:increment).with("engines.result.success", tags: ["engine:engine", "channel:stable"])
 
           listener = StatsdContainerListener.new(statsd)
           listener.finished(engine, nil, result)

--- a/spec/cc/analyzer/statsd_container_listener_spec.rb
+++ b/spec/cc/analyzer/statsd_container_listener_spec.rb
@@ -78,6 +78,21 @@ module CC::Analyzer
           listener.finished(engine, nil, result)
         end
       end
+
+      context "when the repo_id is included" do
+        let(:engine) { double(name: "engine") }
+        let(:repo_id) { "123456" }
+
+        it "adds the repo_id to the engine tags" do
+          statsd = double(timing: nil, increment: nil)
+          result = double(duration: 10, timed_out?: false, maximum_output_exceeded?: false, exit_status: 0)
+
+          expect(statsd).to receive(:increment).with("engines.finished", tags: ["engine:engine", "repo_id:#{repo_id}"])
+
+          listener = StatsdContainerListener.new(statsd, repo_id: repo_id)
+          listener.finished(engine, nil, result)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

On #1067 we started tagging the DD metrics, including the engines names on tags. There is no need anymore of including the engine name on the metric name itself.

Also, having the `repo_id` available as a tag, is useful for monitoring.

<img width="1112" alt="Screenshot 2022-12-20 at 14 29 28" src="https://user-images.githubusercontent.com/52419977/208730829-84abf14a-5ca6-4bc2-80a1-054a77f1db29.png">


For reference, these are the changes that would make use of this functionality -> https://github.com/codeclimate/builder/pull/1986