### PR TITLE
Make with prefixes default behaviour

### DIFF
--- a/qlty-cli/src/commands/init.rs
+++ b/qlty-cli/src/commands/init.rs
@@ -40,10 +40,6 @@ pub struct Init {
     /// a path to a local directory(name=directory).
     #[arg(long, value_parser = SourceSpec::new)]
     pub source: Option<SourceSpec>,
-
-    /// Enable plugin prefix detection.
-    #[arg(long)]
-    pub with_prefixes: bool,
 }
 
 impl Init {
@@ -77,7 +73,6 @@ impl Init {
                 skip_plugins: self.skip_plugins,
                 skip_default_source: self.skip_default_source,
                 source: self.source.clone(),
-                with_prefixes: self.with_prefixes,
             })?;
 
             initializer.prepare()?;

--- a/qlty-cli/src/commands/init.rs
+++ b/qlty-cli/src/commands/init.rs
@@ -40,10 +40,22 @@ pub struct Init {
     /// a path to a local directory(name=directory).
     #[arg(long, value_parser = SourceSpec::new)]
     pub source: Option<SourceSpec>,
+
+    /// Warning: this option has been deprecated!
+    /// Enable plugin prefix detection.
+    #[arg(long)]
+    pub with_prefixes: bool,
 }
 
 impl Init {
     pub fn execute(&self, args: &Arguments) -> Result<CommandSuccess, CommandError> {
+        if self.with_prefixes {
+            eprintln!(
+                "{} The --with-prefixes option has been deprecated and is no longer needed.",
+                style("⚠").yellow()
+            );
+        }
+
         if !args.no_upgrade_check {
             QltyRelease::upgrade_check().ok();
         }
@@ -120,7 +132,7 @@ impl Init {
         println!("  {}", style("2. Get help and give feedback").bold());
         println!(
             "     {}",
-            style("Our developers are on Discord: https://qlty.sh/discord").dim()
+            style("Our developers are on Discord: https://discord.gg/DMKEqEJnhD").dim()
         );
         println!();
     }

--- a/qlty-cli/src/commands/init.rs
+++ b/qlty-cli/src/commands/init.rs
@@ -132,7 +132,7 @@ impl Init {
         println!("  {}", style("2. Get help and give feedback").bold());
         println!(
             "     {}",
-            style("Our developers are on Discord: https://discord.gg/DMKEqEJnhD").dim()
+            style("Our developers are on Discord: https://qlty.sh/discord").dim()
         );
         println!();
     }

--- a/qlty-cli/src/commands/init.rs
+++ b/qlty-cli/src/commands/init.rs
@@ -43,7 +43,7 @@ pub struct Init {
 
     /// Warning: this option has been deprecated!
     /// Enable plugin prefix detection.
-    #[arg(long)]
+    #[arg(hide = true, long)]
     pub with_prefixes: bool,
 }
 

--- a/qlty-cli/src/initializer/settings.rs
+++ b/qlty-cli/src/initializer/settings.rs
@@ -7,5 +7,4 @@ pub struct Settings {
     pub skip_plugins: bool,
     pub skip_default_source: bool,
     pub source: Option<SourceSpec>,
-    pub with_prefixes: bool,
 }

--- a/qlty-cli/tests/cmd/init/prefix.toml
+++ b/qlty-cli/tests/cmd/init/prefix.toml
@@ -1,2 +1,2 @@
 bin.name = "qlty"
-args = ["init", "--dry-run", "--skip-default-source", "--source", "local=../plugins", "--no-upgrade-check", "--with-prefixes"]
+args = ["init", "--dry-run", "--skip-default-source", "--source", "local=../plugins", "--no-upgrade-check"]


### PR DESCRIPTION
Removes the `--with-prefixes` flag from `qlty init` and makes the behaviour for prefix during init default.