### PR TITLE
Do not run source upgrade (if upgrading CLI)

### DIFF
--- a/qlty-cli/src/commands/upgrade.rs
+++ b/qlty-cli/src/commands/upgrade.rs
@@ -88,8 +88,6 @@ impl Upgrade {
             self.install(&executable_path)?;
         }
 
-        SourceUpgrade::new().run()?;
-
         self.install_completions().ok();
         self.print_result(&timer, &release);
         CommandSuccess::ok()


### PR DESCRIPTION
This is a bugfix that does change the behavior of `qlty upgrade` in some cases.

Previously, if you ran `qlty upgrade` within a Git repository, it would upgrade the CLI, but then also upgrade the sources.

The problem was if you ran it outside of a `.git` directory: it would upgrade the CLI and then raise the following error:

❌ This subcommand must be run within a Git repository.

Source upgrades can also be performed independently by running:

`qlty upgrade source`

We could also _optionally_ run upgrade sources if within a git directory, but that would require additional code.