### PR TITLE
Sort elements going into cache keys

### DIFF
--- a/qlty-check/src/planner/config_files.rs
+++ b/qlty-check/src/planner/config_files.rs
@@ -16,6 +16,18 @@ pub struct PluginConfigFile {
     pub contents: String,
 }
 
+impl Ord for PluginConfigFile {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.path.cmp(&other.path)
+    }
+}
+
+impl PartialOrd for PluginConfigFile {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl PluginConfigFile {
     pub fn from_path(path: &Path) -> Result<Self> {
         let contents = fs::read_to_string(path)

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -389,7 +389,21 @@ impl std::fmt::Display for PackageFileCandidate {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Clone,
+    Default,
+    Debug,
+    Serialize,
+    Deserialize,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+)]
 pub struct PluginEnvironment {
     #[serde(default)]
     pub name: String,
@@ -399,6 +413,18 @@ pub struct PluginEnvironment {
 
     #[serde(default)]
     pub value: String,
+}
+
+impl Ord for PluginEnvironment {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+impl PartialOrd for PluginEnvironment {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq, Eq, Hash, Default)]

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -389,21 +389,7 @@ impl std::fmt::Display for PackageFileCandidate {
     }
 }
 
-#[derive(
-    Debug,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Clone,
-    Default,
-    Debug,
-    Serialize,
-    Deserialize,
-    Clone,
-    Default,
-    PartialEq,
-    Eq,
-)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default, Eq)]
 pub struct PluginEnvironment {
     #[serde(default)]
     pub name: String,


### PR DESCRIPTION
I noticed locally that in some cases that config files were being added to the cache key in a different order, which produces different cache results. I audited the cache key generation code for iteration and added explicit sorting to try to increase determinism.