### PR TITLE
Prefer QLTY_LOG env var over `--debug` flag

### DIFF
--- a/qlty-cli/src/commands/telemetry.rs
+++ b/qlty-cli/src/commands/telemetry.rs
@@ -1,11 +1,10 @@
 use crate::{
-    telemetry::{segment::Track, SegmentClient},
+    telemetry::{analytics::Track, AnalyticsClient},
     Arguments, CommandError, CommandSuccess,
 };
 use anyhow::{anyhow, Result};
 use clap::Args;
 use qlty_analysis::version::BUILD_PROFILE;
-use qlty_config::Workspace;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
@@ -35,9 +34,6 @@ impl Telemetry {
 
     fn send_track(&self) -> Result<CommandSuccess, CommandError> {
         let payload_path = self.track.clone().unwrap();
-        let current = std::env::current_dir().expect("current dir");
-        let repository_path = Workspace::closest_git_repository_path(&current);
-
         let payload = std::fs::read_to_string(&payload_path).map_err(|err| {
             anyhow!(
                 "Unable to read telemetry payload file: {} ({:?})",
@@ -46,7 +42,7 @@ impl Telemetry {
             )
         })?;
 
-        let client = SegmentClient::new(repository_path.clone())?;
+        let client = AnalyticsClient::new()?;
         let event: Track = serde_json::from_str(&payload).unwrap();
         client.send_track(event)?;
 

--- a/qlty-cli/src/logging.rs
+++ b/qlty-cli/src/logging.rs
@@ -225,14 +225,17 @@ pub fn logs_dir(repository_path: Option<PathBuf>) -> Option<PathBuf> {
 fn env_filter() -> EnvFilter {
     let args = std::env::args().collect::<Vec<String>>();
 
-    if args.contains(&"--debug".to_string()) {
+    if let Ok(log_env) = std::env::var("QLTY_LOG") {
+        EnvFilter::builder()
+            .with_default_directive(default_log_level().into())
+            .parse_lossy(log_env)
+    } else if args.contains(&"--debug".to_string()) {
         EnvFilter::builder()
             .with_default_directive(default_log_level().into())
             .parse_lossy("qlty=debug")
     } else {
         EnvFilter::builder()
             .with_default_directive(default_log_level().into())
-            .with_env_var("QLTY_LOG")
             .from_env_lossy()
     }
 }

--- a/qlty-cli/src/telemetry.rs
+++ b/qlty-cli/src/telemetry.rs
@@ -1,7 +1,7 @@
 use self::sanitize::sanitize_command;
 use crate::arguments::is_subcommand;
 use crate::telemetry::git::repository_identifier;
-use crate::telemetry::segment::{segment_context, segment_user, Track};
+use crate::telemetry::segment::{event_context, event_user, Track};
 use crate::{errors::CommandError, success::CommandSuccess};
 use ::sentry::integrations::panic::message_from_panic_info;
 use anyhow::Result;
@@ -129,10 +129,10 @@ impl Telemetry {
         let message_id = Uuid::new_v4().to_string();
 
         let track = Track {
-            user: segment_user(None, anonymous_id()?),
+            user: event_user(None, anonymous_id()?),
             event: event.to_owned(),
             properties,
-            context: Some(segment_context()),
+            context: Some(event_context()),
             timestamp: Some(OffsetDateTime::now_utc()),
             extra: [("messageId".to_owned(), json!(message_id))]
                 .iter()

--- a/qlty-cli/src/telemetry.rs
+++ b/qlty-cli/src/telemetry.rs
@@ -13,7 +13,7 @@ use serde_json::json;
 use std::path::PathBuf;
 use std::time::Instant;
 use time::OffsetDateTime;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 use uuid::Uuid;
 
 pub mod analytics;
@@ -122,7 +122,7 @@ impl Telemetry {
     }
 
     fn track(&self, event: &str, properties: serde_json::Value) -> Result<()> {
-        debug!("Tracking event (foreground): {}: {:?}", event, properties);
+        trace!("Tracking event (foreground): {}: {:?}", event, properties);
         let message_id = Uuid::new_v4().to_string();
 
         let track = Track {
@@ -151,7 +151,7 @@ impl Telemetry {
 
         std::fs::write(&tempfile_path, payload)?;
         debug!(
-            "Executing: {} {} {} {}",
+            "Tracking event: {} {} {} {}",
             std::env::current_exe()
                 .expect("Could not determine current executable path")
                 .display(),
@@ -202,7 +202,7 @@ impl Telemetry {
 
         std::fs::write(&tempfile_path, payload)?;
         debug!(
-            "Executing: {} {} {} {}",
+            "Tracking panic: {} {} {} {}",
             std::env::current_exe()
                 .expect("Could not determine current executable path")
                 .display(),
@@ -268,7 +268,7 @@ impl Telemetry {
             TelemetryLevel::Off
         } else {
             if is_subcommand("telemetry") {
-                debug!("Telemetry disabled for telemetry subcommand");
+                debug!("Telemetry disabled for telemetry subcommand to avoid infinite loop");
                 return TelemetryLevel::Off;
             }
 

--- a/qlty-cli/src/telemetry/analytics.rs
+++ b/qlty-cli/src/telemetry/analytics.rs
@@ -38,14 +38,16 @@ impl AnalyticsClient {
                 .encode(format!("{}:", WRITE_KEY.unwrap_or_default()))
         );
 
+        let data = serde_json::to_value(message)?;
+
         debug!(
-            "POST {} with Authorization: {}: {:?}",
-            TRACK_URL, http_basic_authorization, message
+            "POST {} with Authorization: {}: {}",
+            TRACK_URL, http_basic_authorization, data
         );
 
         ureq::post(TRACK_URL)
             .set("Authorization", &http_basic_authorization)
-            .send_json(serde_json::to_value(message)?)
+            .send_json(data)
             .map(|_| ())
             .with_context(|| "Failed to send telemetry event")
     }

--- a/qlty-cli/src/telemetry/analytics.rs
+++ b/qlty-cli/src/telemetry/analytics.rs
@@ -8,7 +8,6 @@ use qlty_analysis::version::QLTY_VERSION;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::{Map, Value};
-use std::path::PathBuf;
 use time::OffsetDateTime;
 use tracing::debug;
 
@@ -16,13 +15,11 @@ const WRITE_KEY: Option<&str> = option_env!("CIO_WRITE_KEY");
 const TRACK_URL: &str = "https://cdp.customer.io/v1/track";
 
 #[derive(Clone)]
-pub struct AnalyticsClient {
-    repository_path: Option<PathBuf>,
-}
+pub struct AnalyticsClient;
 
 impl AnalyticsClient {
-    pub fn new(repository_path: Option<PathBuf>) -> Result<Self> {
-        Ok(Self { repository_path })
+    pub fn new() -> Result<Self> {
+        Ok(Self {})
     }
 
     pub fn send_track(&self, track: Track) -> Result<()> {


### PR DESCRIPTION
- Prefer QLTY_LOG env var over `--debug` flag
- Rename references to Segment to analytics, since the protocol is used by other backends
- Remove superfluous separate telemetry log (we log in main log now)
- Simplify some telemetry code that got unnecessarily confusing due to foregrounds vs. background distinction