### PR TITLE
 Support in-place upgrades and support non-curl systems

### DIFF
--- a/qlty-cli/src/upgrade.rs
+++ b/qlty-cli/src/upgrade.rs
@@ -132,8 +132,13 @@ impl QltyRelease {
     }
 
     pub fn run_upgrade_command(&self) -> Result<()> {
+        let exe_path = std::env::current_exe()?;
+        let bin_path = exe_path.parent().unwrap();
         self.upgrade_command()
-            .env("VERSION", &self.version)
+            .env("QLTY_VERSION", &self.version)
+            .env("QLTY_INSTALL_BIN_PATH", bin_path)
+            .env("QLTY_NO_MODIFY_PATH", "1")
+            .stdin_bytes(Self::download_installer()?.as_bytes())
             .run()
             .map(|_| ())
             .map_err(Into::into)
@@ -141,18 +146,34 @@ impl QltyRelease {
 
     fn upgrade_command(&self) -> duct::Expression {
         if cfg!(windows) {
-            cmd!(
-                "powershell",
-                "-c",
-                format!("iwr {} | iex", Self::install_url())
-            )
+            cmd!("powershell", "-Command", "-")
         } else {
-            cmd!("sh", "-c", format!("curl {} | sh", Self::install_url()))
+            cmd!("sh")
         }
     }
 
     fn install_url() -> String {
         std::env::var("QLTY_INSTALL_URL").unwrap_or_else(|_| DEFAULT_INSTALL_URL.to_string())
+    }
+
+    fn installer_user_agent() -> String {
+        // emulate correct user-agent to retrieve install script
+        let prefix = if cfg!(windows) {
+            "WindowsPowerShell"
+        } else {
+            "curl"
+        };
+
+        format!("{}/{}-{}", prefix, USER_AGENT_PREFIX, QLTY_VERSION)
+    }
+
+    fn download_installer() -> Result<String> {
+        ureq::get(&Self::install_url())
+            .set("User-Agent", &Self::installer_user_agent())
+            .call()
+            .with_context(|| format!("Failed to download installer from {}", &Self::install_url()))?
+            .into_string()
+            .map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
Since wget is supported in the install script, do not rely on curl to download the script. Instead download via ureq.