### PR TITLE
Hide JSON output flag

### DIFF
--- a/qlty-cli/src/commands/check.rs
+++ b/qlty-cli/src/commands/check.rs
@@ -94,7 +94,7 @@ pub struct Check {
     fail_level: Level,
 
     /// JSON output
-    #[arg(long)]
+    #[arg(long, hide = true)]
     json: bool,
 
     /// Allow individual plugins to be skipped if they fail or crash

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -61,7 +61,7 @@ pub struct Publish {
     /// Print coverage
     pub print: bool,
 
-    #[arg(long, requires = "print")]
+    #[arg(long, hide = true, requires = "print")]
     /// JSON output
     pub json: bool,
 

--- a/qlty-cli/src/commands/coverage/transform.rs
+++ b/qlty-cli/src/commands/coverage/transform.rs
@@ -38,7 +38,7 @@ pub struct Transform {
     /// Print coverage
     pub print: bool,
 
-    #[arg(long, requires = "print")]
+    #[arg(long, hide = true, requires = "print")]
     /// JSON output
     pub json: bool,
 

--- a/qlty-cli/src/commands/metrics.rs
+++ b/qlty-cli/src/commands/metrics.rs
@@ -62,7 +62,7 @@ pub struct Metrics {
     pub quiet: bool,
 
     /// JSON output
-    #[arg(long)]
+    #[arg(long, hide = true)]
     json: bool,
 
     /// Files to analyze

--- a/qlty-cli/src/commands/smells.rs
+++ b/qlty-cli/src/commands/smells.rs
@@ -46,7 +46,7 @@ pub struct Smells {
     pub quiet: bool,
 
     /// JSON output
-    #[arg(long)]
+    #[arg(long, hide = true)]
     json: bool,
 
     /// Files to analyze


### PR DESCRIPTION
The JSON format is unstable and intended for internal use, so we don't want users to get impacted by depending on a format that changes out from under them.

We are tracking a feature proposal to add an output format for the SARIF standard [here](https://github.com/orgs/qltysh/discussions/1205), which will enable a stable machine-readable output format.