### PR TITLE
Don't automatically enable hadolint

### DIFF
--- a/plugins/linters/hadolint/plugin.toml
+++ b/plugins/linters/hadolint/plugin.toml
@@ -13,7 +13,7 @@ known_good_version = "2.12.0"
 version_command = "hadolint --version"
 issue_url_format = "https://github.com/hadolint/hadolint/wiki/${rule}"
 description = "Dockerfile linter"
-suggested = "targets"
+suggested = "config"
 
 [plugins.definitions.hadolint.drivers.lint]
 script = "hadolint ${target} -f json --no-fail"
@@ -22,4 +22,4 @@ output = "stdout"
 output_format = "hadolint"
 cache_results = true
 batch = true
-suggested = "targets"
+suggested = "config"


### PR DESCRIPTION
The latest release of Hadolint is ~2 years old and it segfaults on MacOS Sequoia. To avoid auto-enabling a plugin that will produce an error, this moved Hadolint to only be auto-enabled if a Hadolint configuration file is already in the repository.

#1201