### PR TITLE
Hide `auth` subcommand family from help output

### DIFF
--- a/qlty-cli/src/arguments.rs
+++ b/qlty-cli/src/arguments.rs
@@ -24,6 +24,7 @@ pub struct Arguments {
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Manage authentication
+    #[command(hide = true)]
     Auth(auth::Arguments),
 
     /// Run analysis build


### PR DESCRIPTION
These are not yet ready for prime time. h/t@ robbyrussell