### PR TITLE
Fix init test

### DIFF
--- a/qlty-cli/tests/cmd/init/network/basic.stdout
+++ b/qlty-cli/tests/cmd/init/network/basic.stdout
@@ -79,7 +79,6 @@ drivers = [
   [..],
   [..],
 ]
-version = "0.53.0"
 
 [[plugin]]
 name = "trufflehog"


### PR DESCRIPTION
Seems like we missed a test somehow in https://github.com/qltysh/qlty/pull/1236, even though tests passed there.