### PR TITLE
Add secret and dependency alert categories

### DIFF
--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -255,6 +255,12 @@ pub enum OutputCategory {
 
     #[serde(rename = "lint")]
     Lint,
+
+    #[serde(rename = "secret")]
+    Secret,
+
+    #[serde(rename = "dependency_alert")]
+    DependencyAlert,
 }
 
 impl Into<Category> for OutputCategory {
@@ -273,6 +279,8 @@ impl Into<Category> for OutputCategory {
             OutputCategory::Duplication => Category::Duplication,
             OutputCategory::DeadCode => Category::DeadCode,
             OutputCategory::Lint => Category::Lint,
+            OutputCategory::Secret => Category::Secret,
+            OutputCategory::DependencyAlert => Category::DependencyAlert,
         }
     }
 }

--- a/qlty-types/src/protos/qlty.analysis.v1.rs
+++ b/qlty-types/src/protos/qlty.analysis.v1.rs
@@ -509,6 +509,8 @@ pub enum Category {
     Accessibility = 11,
     DeadCode = 12,
     Lint = 13,
+    Secret = 14,
+    DependencyAlert = 15,
 }
 impl Category {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -531,6 +533,8 @@ impl Category {
             Category::Accessibility => "CATEGORY_ACCESSIBILITY",
             Category::DeadCode => "CATEGORY_DEAD_CODE",
             Category::Lint => "CATEGORY_LINT",
+            Category::Secret => "CATEGORY_SECRET",
+            Category::DependencyAlert => "CATEGORY_DEPENDENCY_ALERT",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -550,6 +554,8 @@ impl Category {
             "CATEGORY_ACCESSIBILITY" => Some(Self::Accessibility),
             "CATEGORY_DEAD_CODE" => Some(Self::DeadCode),
             "CATEGORY_LINT" => Some(Self::Lint),
+            "CATEGORY_SECRET" => Some(Self::Secret),
+            "CATEGORY_DEPENDENCY_ALERT" => Some(Self::DependencyAlert),
             _ => None,
         }
     }

--- a/qlty-types/src/protos/qlty.analysis.v1.serde.rs
+++ b/qlty-types/src/protos/qlty.analysis.v1.serde.rs
@@ -94,6 +94,8 @@ impl serde::Serialize for Category {
             Self::Accessibility => "CATEGORY_ACCESSIBILITY",
             Self::DeadCode => "CATEGORY_DEAD_CODE",
             Self::Lint => "CATEGORY_LINT",
+            Self::Secret => "CATEGORY_SECRET",
+            Self::DependencyAlert => "CATEGORY_DEPENDENCY_ALERT",
         };
         serializer.serialize_str(variant)
     }
@@ -119,6 +121,8 @@ impl<'de> serde::Deserialize<'de> for Category {
             "CATEGORY_ACCESSIBILITY",
             "CATEGORY_DEAD_CODE",
             "CATEGORY_LINT",
+            "CATEGORY_SECRET",
+            "CATEGORY_DEPENDENCY_ALERT",
         ];
 
         struct GeneratedVisitor;
@@ -173,6 +177,8 @@ impl<'de> serde::Deserialize<'de> for Category {
                     "CATEGORY_ACCESSIBILITY" => Ok(Category::Accessibility),
                     "CATEGORY_DEAD_CODE" => Ok(Category::DeadCode),
                     "CATEGORY_LINT" => Ok(Category::Lint),
+                    "CATEGORY_SECRET" => Ok(Category::Secret),
+                    "CATEGORY_DEPENDENCY_ALERT" => Ok(Category::DependencyAlert),
                     _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
                 }
             }


### PR DESCRIPTION
Part 1.

These need to merged in sequence to prevent tests breakage or worse user issues.