### PR TITLE
Ignore unsafe rules from check --fix

### DIFF
--- a/qlty-check/src/patch_builder.rs
+++ b/qlty-check/src/patch_builder.rs
@@ -166,7 +166,9 @@ fn replace_in_range(
     }
 
     if start < mdata.len() && end < mdata.len() {
-        mdata.replace_range(start..end, replacement);
+        let start_index = mdata.char_indices().nth(start).unwrap().0;
+        let end_index = mdata.char_indices().nth(end).unwrap().0;
+        mdata.replace_range(start_index..end_index, replacement);
         true
     } else {
         warn!(

--- a/qlty-check/src/patch_builder.rs
+++ b/qlty-check/src/patch_builder.rs
@@ -166,9 +166,7 @@ fn replace_in_range(
     }
 
     if start < mdata.len() && end < mdata.len() {
-        let start_index = mdata.char_indices().nth(start).unwrap().0;
-        let end_index = mdata.char_indices().nth(end).unwrap().0;
-        mdata.replace_range(start_index..end_index, replacement);
+        mdata.replace_range(start..end, replacement);
         true
     } else {
         warn!(

--- a/qlty-check/src/patcher.rs
+++ b/qlty-check/src/patcher.rs
@@ -7,7 +7,10 @@ use qlty_types::analysis::v1::Issue;
 use std::{borrow::BorrowMut, collections::HashSet, path::PathBuf};
 use tracing::{debug, error, trace, warn};
 
-const UNSAFE_RULES: [&str; 1] = ["eslint:@typescript-eslint/no-explicit-any"];
+const UNSAFE_RULES: [&str; 2] = [
+    "eslint:@typescript-eslint/no-explicit-any",
+    "eslint:@typescript-eslint/no-empty-interface",
+];
 
 #[derive(Debug, Clone)]
 pub struct Patcher {

--- a/qlty-check/src/patcher.rs
+++ b/qlty-check/src/patcher.rs
@@ -81,7 +81,7 @@ impl Patcher {
         let mut modified_source = original_source.clone();
 
         for issue in issues.iter() {
-            if !Patcher::is_patchable(&issue, allow_unsafe) {
+            if !Patcher::is_patchable(issue, allow_unsafe) {
                 // guard to avoid issues with no suggestions. this does not guard against unsafe rules
                 continue;
             }

--- a/qlty-check/src/patcher.rs
+++ b/qlty-check/src/patcher.rs
@@ -4,12 +4,13 @@ use crate::{
 use anyhow::Result;
 use itertools::Itertools;
 use qlty_types::analysis::v1::Issue;
-use std::{borrow::BorrowMut, collections::HashSet, path::PathBuf};
+use std::{borrow::BorrowMut, collections::HashSet, ops::RangeInclusive, path::PathBuf};
 use tracing::{debug, error, trace, warn};
 
-const UNSAFE_RULES: [&str; 2] = [
+const UNSAFE_RULES: [&str; 3] = [
     "eslint:@typescript-eslint/no-explicit-any",
     "eslint:@typescript-eslint/no-empty-interface",
+    "eslint:@typescript-eslint/no-non-null-assertion",
 ];
 
 #[derive(Debug, Clone)]
@@ -18,30 +19,24 @@ pub struct Patcher {
 }
 
 impl Patcher {
-    pub fn is_patchable(issue: &Issue) -> bool {
+    pub fn filter_issues(issues: &[Issue], allow_unsafe: bool) -> Vec<Issue> {
+        issues
+            .iter()
+            .filter(|issue| Patcher::is_patchable(issue, allow_unsafe))
+            .cloned()
+            .collect()
+    }
+
+    pub fn is_patchable(issue: &Issue, allow_unsafe: bool) -> bool {
         !issue.suggestions.is_empty()
             && !issue.suggestions[0].patch.is_empty()
             && issue.location.is_some()
-            && !Patcher::is_unsafe(issue, true)
+            && (allow_unsafe || Patcher::issue_is_safe(issue))
     }
 
-    fn is_unsafe(issue: &Issue, log: bool) -> bool {
+    fn issue_is_safe(issue: &Issue) -> bool {
         let full_rule_key = format!("{}:{}", issue.tool, issue.rule_key);
-        if UNSAFE_RULES.contains(&full_rule_key.as_str()) {
-            if log {
-                let path = issue.path().map(PathBuf::from).unwrap_or_default();
-                let display_location =
-                    format!("{}:{}", path.display(), issue.line_range().unwrap().start());
-                trace!(
-                    "Ignoring issue for {} ({})",
-                    display_location,
-                    full_rule_key
-                );
-            }
-            true
-        } else {
-            false
-        }
+        !UNSAFE_RULES.contains(&full_rule_key.as_str())
     }
 
     pub fn new(staging_area: &StagingArea) -> Self {
@@ -50,7 +45,7 @@ impl Patcher {
         }
     }
 
-    pub fn try_apply(&self, issues: &[Issue]) -> HashSet<FixedResult> {
+    pub fn try_apply(&self, issues: &[Issue], allow_unsafe: bool) -> HashSet<FixedResult> {
         let mut fixed: HashSet<FixedResult> = HashSet::new();
 
         let issues_by_path = issues
@@ -65,7 +60,9 @@ impl Patcher {
             let path = path.unwrap();
             let path_buf = PathBuf::from(&path);
 
-            if let Err(err) = self.apply_to_file(path_buf, &issues, fixed.borrow_mut()) {
+            if let Err(err) =
+                self.apply_to_file(path_buf, &issues, allow_unsafe, fixed.borrow_mut())
+            {
                 warn!("Failed to apply patch to {:?}: {}", path, err);
             }
         }
@@ -77,19 +74,28 @@ impl Patcher {
         &self,
         path: PathBuf,
         issues: &[&Issue],
+        allow_unsafe: bool,
         fixed: &mut HashSet<FixedResult>,
     ) -> Result<()> {
         let original_source = self.staging_area.read(path.clone())?;
         let mut modified_source = original_source.clone();
 
         for issue in issues.iter() {
-            if !Patcher::is_patchable(issue) {
+            if !Patcher::is_patchable(&issue, allow_unsafe) {
+                // guard to avoid issues with no suggestions. this does not guard against unsafe rules
                 continue;
             }
+
             let patch_string = issue.suggestions[0].patch.clone();
             let full_rule_key = format!("{}:{}", issue.tool, issue.rule_key);
-            let display_location =
-                format!("{}:{}", path.display(), issue.line_range().unwrap().start());
+            let display_location = format!(
+                "{}:{}",
+                path.display(),
+                issue
+                    .line_range()
+                    .unwrap_or(RangeInclusive::new(1, 1))
+                    .start()
+            );
             trace!(
                 "Applying patch for {} ({}):\n{}",
                 display_location,
@@ -195,6 +201,20 @@ mod test {
                 ..Default::default()
             },
             Issue {
+                tool: "eslint".to_string(),
+                rule_key: "@typescript-eslint/no-empty-interface".to_string(),
+                location: Some(Location {
+                    path: file.to_str().unwrap().to_string(),
+                    ..Default::default()
+                }),
+                suggestions: vec![Suggestion {
+                    patch: diffy::create_patch("A\nB\nC\n\nD\nE\nF", "A\nB\nX\n\nD\nE\nF")
+                        .to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            Issue {
                 rule_key: "unfixable".to_string(),
                 location: Some(Location {
                     path: file.to_str().unwrap().to_string(),
@@ -213,7 +233,7 @@ mod test {
         ];
 
         let patcher = Patcher::new(&staging_area);
-        let fixed = patcher.try_apply(&issues);
+        let fixed = patcher.try_apply(&issues, false);
 
         assert_eq!(
             staging_area.read(file.clone()).unwrap(),
@@ -224,5 +244,174 @@ mod test {
             rule_key: "fixable".to_string(),
             location: issues.first().unwrap().location().unwrap().clone()
         }));
+    }
+
+    #[test]
+    fn test_try_apply_unsafe() {
+        let temp_dir = tempdir().unwrap();
+        let temp_source = temp_dir.path().to_path_buf();
+        let staging_area = StagingArea::generate(Mode::Source, temp_source.clone(), None);
+        let file = &temp_source.join("main.rs");
+
+        std::fs::write(file, "A\nB\nC\n\nD\nE\nF").ok();
+
+        let issues = [Issue {
+            tool: "eslint".to_string(),
+            rule_key: "@typescript-eslint/no-empty-interface".to_string(),
+            location: Some(Location {
+                path: file.to_str().unwrap().to_string(),
+                ..Default::default()
+            }),
+            suggestions: vec![Suggestion {
+                patch: diffy::create_patch("A\nB\nC\n\nD\nE\nF", "A\nB\nX\n\nD\nE\nF").to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+
+        let patcher = Patcher::new(&staging_area);
+        let fixed = patcher.try_apply(&issues, false);
+        assert_eq!(
+            staging_area.read(file.clone()).unwrap(),
+            "A\nB\nC\n\nD\nE\nF"
+        );
+        assert_eq!(fixed.len(), 0);
+
+        let fixed = patcher.try_apply(&issues, true);
+        assert_eq!(
+            staging_area.read(file.clone()).unwrap(),
+            "A\nB\nX\n\nD\nE\nF"
+        );
+        assert_eq!(fixed.len(), 1);
+    }
+
+    #[test]
+    fn test_is_patchable() {
+        struct TestData {
+            issue: Issue,
+            allow_unsafe: bool,
+            expected: bool,
+        }
+
+        let tests = vec![
+            TestData {
+                issue: Issue {
+                    tool: "tool".to_string(),
+                    rule_key: "no_suggestions".to_string(),
+                    location: Some(Location::default()),
+                    suggestions: vec![],
+                    ..Default::default()
+                },
+                allow_unsafe: false,
+                expected: false,
+            },
+            TestData {
+                issue: Issue {
+                    tool: "tool".to_string(),
+                    rule_key: "no_location".to_string(),
+                    location: None,
+                    suggestions: vec![Suggestion {
+                        patch: diffy::create_patch("A\nB\nC\n\nD\nE\nF", "X\nB\nC\n\nD\nE\nF")
+                            .to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                allow_unsafe: false,
+                expected: false,
+            },
+            TestData {
+                issue: Issue {
+                    tool: "tool".to_string(),
+                    rule_key: "fixable".to_string(),
+                    location: Some(Location::default()),
+                    suggestions: vec![Suggestion {
+                        patch: "PATCH".to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                allow_unsafe: true,
+                expected: true,
+            },
+            TestData {
+                issue: Issue {
+                    tool: "eslint".to_string(),
+                    rule_key: "@typescript-eslint/no-empty-interface".to_string(),
+                    location: Some(Location::default()),
+                    suggestions: vec![Suggestion {
+                        patch: "PATCH".to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                allow_unsafe: false,
+                expected: false,
+            },
+            TestData {
+                issue: Issue {
+                    tool: "eslint".to_string(),
+                    rule_key: "@typescript-eslint/no-empty-interface".to_string(),
+                    location: Some(Location::default()),
+                    suggestions: vec![Suggestion {
+                        patch: "PATCH".to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                allow_unsafe: true,
+                expected: true,
+            },
+        ];
+        for test in tests.iter() {
+            assert_eq!(
+                Patcher::is_patchable(&test.issue, test.allow_unsafe),
+                test.expected,
+                "rule_key: {}",
+                test.issue.rule_key
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_issues() {
+        let issues = vec![
+            Issue {
+                rule_key: "fixable".to_string(),
+                location: Some(Location::default()),
+                suggestions: vec![Suggestion {
+                    patch: "PATCH".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            Issue {
+                rule_key: "other_fixable".to_string(),
+                location: Some(Location::default()),
+                suggestions: vec![Suggestion {
+                    patch: "PATCH".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            Issue {
+                tool: "eslint".to_string(),
+                rule_key: "@typescript-eslint/no-empty-interface".to_string(),
+                location: Some(Location::default()),
+                suggestions: vec![Suggestion {
+                    patch: "PATCH".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        ];
+
+        let filtered = Patcher::filter_issues(&issues, false);
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[0].rule_key, "fixable");
+        assert_eq!(filtered[1].rule_key, "other_fixable");
+
+        let filtered = Patcher::filter_issues(&issues, true);
+        assert_eq!(filtered.len(), 3);
     }
 }

--- a/qlty-check/src/processor.rs
+++ b/qlty-check/src/processor.rs
@@ -90,7 +90,8 @@ impl Processor {
 
     fn compute_fixes(&mut self) {
         if self.plan.verb == ExecutionVerb::Check && self.plan.settings.fix {
-            self.fixed = Patcher::new(&self.plan.staging_area).try_apply(&self.fixable_issues());
+            self.fixed = Patcher::new(&self.plan.staging_area)
+                .try_apply(&self.fixable_issues(), self.plan.settings.r#unsafe);
         }
     }
 
@@ -106,11 +107,7 @@ impl Processor {
     }
 
     fn fixable_issues(&self) -> Vec<Issue> {
-        self.issues
-            .iter()
-            .filter(|issue| Patcher::is_patchable(issue))
-            .cloned()
-            .collect()
+        Patcher::filter_issues(&self.issues, self.plan.settings.r#unsafe)
     }
 
     fn transform_issue(&self, issue: &Issue) -> Option<Issue> {

--- a/qlty-check/src/processor.rs
+++ b/qlty-check/src/processor.rs
@@ -90,12 +90,12 @@ impl Processor {
 
     fn compute_fixes(&mut self) {
         if self.plan.verb == ExecutionVerb::Check && self.plan.settings.fix {
-            self.fixed = Patcher::new(&self.plan.staging_area).try_apply(&self.issues);
+            self.fixed = Patcher::new(&self.plan.staging_area).try_apply(&self.fixable_issues());
         }
     }
 
     fn compute_fixable(&mut self) {
-        for issue in self.issues.iter() {
+        for issue in self.fixable_issues().iter() {
             if !issue.suggestions.is_empty() && issue.location.is_some() {
                 self.fixable.insert(FixedResult {
                     rule_key: issue.rule_key.clone(),
@@ -103,6 +103,14 @@ impl Processor {
                 });
             }
         }
+    }
+
+    fn fixable_issues(&self) -> Vec<Issue> {
+        self.issues
+            .iter()
+            .filter(|issue| Patcher::is_patchable(issue))
+            .cloned()
+            .collect()
     }
 
     fn transform_issue(&self, issue: &Issue) -> Option<Issue> {

--- a/qlty-cli/src/commands/patch.rs
+++ b/qlty-cli/src/commands/patch.rs
@@ -11,7 +11,11 @@ use qlty_types::analysis::v1::Issue;
 
 #[derive(Args, Debug)]
 pub struct Patch {
+    /// Path to patch
     path: String,
+    /// Allow unsafe fixes
+    #[arg(long)]
+    r#unsafe: bool,
 }
 
 impl Patch {
@@ -22,7 +26,7 @@ impl Patch {
         let workspace = Workspace::new()?;
         let staging_area = StagingArea::generate(Mode::Source, workspace.root.clone(), None);
 
-        let fixed = Patcher::new(&staging_area).try_apply(&issues);
+        let fixed = Patcher::new(&staging_area).try_apply(&issues, self.r#unsafe);
 
         eprintln!(
             "{}",


### PR DESCRIPTION
Seed with some rules we do not "trust" to work reliably. Respects `--unsafe` flag.

Also fixes an eslint issue in converting char ranges to bytes for replacements.