### PR TITLE
Support initializing running StandardRB run via Rubocop

### DIFF
--- a/plugins/linters/rubocop/plugin.toml
+++ b/plugins/linters/rubocop/plugin.toml
@@ -11,7 +11,7 @@ config_files = [".rubocop.yml", ".rubocop_*.yml"]
 description = "Ruby linter and code formatter"
 suggested = "targets"
 package_file_candidate = "Gemfile"
-package_file_candidate_filters = ["rubocop"]
+package_file_candidate_filters = ["rubocop", "standard"]
 
 [plugins.definitions.rubocop.drivers.lint]
 script = "rubocop --format json ${target}"


### PR DESCRIPTION
When initializing Qlty, if the `standard` Gem is found in the `Gemfile`, install it when installing Rubocop.