### PR TITLE
Fix up JavaScript file types

### DIFF
--- a/qlty-analysis/src/workspace_entries/workspace_entry_finder_builder.rs
+++ b/qlty-analysis/src/workspace_entries/workspace_entry_finder_builder.rs
@@ -103,20 +103,22 @@ impl WorkspaceEntryFinderBuilder {
         let mut interpreters = HashMap::new();
 
         for language_name in self.config.language.keys() {
-            let file_type = self.config.file_types.get(language_name).unwrap();
+            let language = self.config.language.get(language_name).unwrap();
+
             debug!(
                 "Matching {} with globs: {:?}",
-                language_name, file_type.globs
+                language_name, &language.globs
             );
-            let matcher = LanguageGlobsMatcher::new(language_name, &file_type.globs)?;
+            let matcher = LanguageGlobsMatcher::new(language_name, &language.globs)?;
+
             languages.push(Box::new(matcher));
 
-            if !file_type.interpreters.is_empty() {
+            if !language.interpreters.is_empty() {
                 debug!(
                     "Matching {} with interpretters: {:?}",
-                    language_name, file_type.interpreters
+                    language_name, language.interpreters
                 );
-                interpreters.insert(language_name.to_string(), file_type.interpreters.to_owned());
+                interpreters.insert(language_name.to_string(), language.interpreters.to_owned());
             }
         }
 

--- a/qlty-config/default.toml
+++ b/qlty-config/default.toml
@@ -136,7 +136,6 @@ interpreters = ["jruby", "rbx", "rake", "macruby", "ruby"]
 
 [file_types.rust]
 globs = ["*.rs"]
-interpreters = []
 
 [file_types.shell]
 globs = [
@@ -307,15 +306,44 @@ globs = ["*.swift"]
 globs = ["openapi.yaml", "openapi.*.yaml"]
 
 [language.kotlin]
+globs = ["*.kt"]
 
 [language.php]
+globs = [
+  "*.php",
+  "*.ctp",
+  "*.fcgi",
+  "*.inc",
+  "*.php3",
+  "*.php4",
+  "*.php5",
+  "*.phps",
+  "*.phpt",
+  "*.phtml",
+  "**/.php_cs",
+  "**/.php_cs.dist",
+  "**/Phakefile",
+]
 
 [language.go]
+globs = ["*.go"]
 
 [language.python]
+globs = [
+  "*.py",
+  "*.pyw",
+  "**/DEPS",
+  "**/Snakefile",
+  "**/SConscript",
+  "**/wscript",
+  "**/SConstruct",
+  "**/.gclient",
+]
+interpreters = ["python", "python3", "python2", "pypy"]
 duplication.filter_patterns = ["(import_statement _)"]
 
 [language.rust]
+globs = ["*.rs"]
 test_syntax_patterns = ["""
     (
       (mod_item
@@ -335,8 +363,21 @@ duplication.filter_patterns = ["(use_declaration _)"]
 duplication.nodes_threshold = 50
 
 [language.java]
+globs = ["*.java"]
 
 [language.javascript]
+globs = ["*.js", "*.mjs", "*.cjs", "*.jsx", "**/Jakefile"]
+interpreters = [
+  "rhino",
+  "gjs",
+  "qjs",
+  "js",
+  "chakra",
+  "v8-shell",
+  "v8",
+  "node",
+  "d8",
+]
 duplication.filter_patterns = [
   "(import_statement _)",
   #  JavaScript requires: const name = require("name");
@@ -356,11 +397,40 @@ duplication.filter_patterns = [
 ]
 
 [language.ruby]
+globs = [
+  "*.rb",
+  "*.rake",
+  "**/.irbrc",
+  "**/.pryrc",
+  "**/Appraisals",
+  "**/Berksfile",
+  "**/Brewfile",
+  "**/buildfile",
+  "**/Buildfile",
+  "**/Capfile",
+  "**/Dangerfile",
+  "**/Deliverfile",
+  "**/Fastfile",
+  "**/Gemfile",
+  "**/Guardfile",
+  "**/Jarfile",
+  "**/Mavenfile",
+  "**/Podfile",
+  "**/Puppetfile",
+  "**/Rakefile",
+  "**/Snapfile",
+  "**/Thorfile",
+  "**/Vagrantfile",
+]
+interpreters = ["jruby", "rbx", "rake", "macruby", "ruby"]
 
 [language.typescript]
+globs = ["*.ts", "*.mts", "*.cts"]
+interpreters = ["ts-node", "deno"]
 duplication.filter_patterns = ["(import_statement _)"]
 
 [language.tsx]
+globs = ["*.tsx", "*.mtsx", "*.ctsx"]
 
 [smells.boolean_logic]
 threshold = 4

--- a/qlty-config/default.toml
+++ b/qlty-config/default.toml
@@ -53,7 +53,7 @@ globs = ["*.html"]
 globs = ["*.java"]
 
 [file_types.javascript]
-globs = ["*.js", "*.mjs", "*.jsx", "**/Jakefile"]
+globs = ["*.js", "*.mjs", "*.cjs", "**/Jakefile"]
 interpreters = [
   "rhino",
   "gjs",
@@ -65,6 +65,9 @@ interpreters = [
   "node",
   "d8",
 ]
+
+[file_types.jsx]
+globs = ["*.jsx", "*.mjsx", "*.cjsx"]
 
 [file_types.json]
 globs = [
@@ -190,11 +193,11 @@ globs = ["*.sass", "*.scss"]
 globs = ["*.toml", "**/Cargo.lock", "**/Gopkg.lock"]
 
 [file_types.typescript]
-globs = ["*.ts"]
+globs = ["*.ts", "*.mts", "*.cts"]
 interpreters = ["ts-node", "deno"]
 
 [file_types.tsx]
-globs = ["*.tsx"]
+globs = ["*.tsx", "*.mtsx", "*.ctsx"]
 
 [file_types.yaml]
 globs = ["*.yml", "*.yaml", "**/.clang-tidy", "**/glide.lock", "**/.gemrc"]

--- a/qlty-config/src/config/language.rs
+++ b/qlty-config/src/config/language.rs
@@ -11,6 +11,12 @@ pub struct Language {
     pub test_syntax_patterns: Vec<String>,
 
     pub smells: Option<Smells>,
+
+    #[serde(default)]
+    pub globs: Vec<String>,
+
+    #[serde(default)]
+    pub interpreters: Vec<String>,
 }
 
 const fn _default_true() -> bool {

--- a/qlty-plugins/plugins/linters/biome/plugin.toml
+++ b/qlty-plugins/plugins/linters/biome/plugin.toml
@@ -3,7 +3,7 @@ config_version = "0"
 [plugins.definitions.biome]
 runtime = "node"
 package = "@biomejs/biome"
-file_types = ["typescript", "javascript", "tsx", "json", "css"]
+file_types = ["typescript", "javascript", "jsx", "tsx", "json", "css"]
 config_files = ["biome.json"]
 affects_cache = ["package.json", ".editorconfig"]
 latest_version = "1.9.4"

--- a/qlty-plugins/plugins/linters/eslint/plugin.toml
+++ b/qlty-plugins/plugins/linters/eslint/plugin.toml
@@ -3,7 +3,7 @@ config_version = "0"
 [plugins.definitions.eslint]
 runtime = "node"
 package = "eslint"
-file_types = ["javascript", "typescript", "tsx"]
+file_types = ["javascript", "typescript", "jsx", "tsx"]
 affects_cache = [".eslintignore", "package.json", "tsconfig.json"]
 latest_version = "9.13.0"
 known_good_version = "9.7.0"

--- a/qlty-plugins/plugins/linters/knip/plugin.toml
+++ b/qlty-plugins/plugins/linters/knip/plugin.toml
@@ -3,7 +3,7 @@ config_version = "0"
 [plugins.definitions.knip]
 runtime = "node"
 package = "knip"
-file_types = ["javascript", "typescript", "tsx"]
+file_types = ["javascript", "typescript", "jsx", "tsx"]
 config_files = [
   "knip.json",
   "knip.jsonc",

--- a/qlty-plugins/plugins/linters/oxc/plugin.toml
+++ b/qlty-plugins/plugins/linters/oxc/plugin.toml
@@ -3,7 +3,7 @@ config_version = "0"
 [plugins.definitions.oxc]
 runtime = "node"
 package = "oxlint"
-file_types = ["javascript", "typescript", "tsx"]
+file_types = ["javascript", "typescript", "jsx", "tsx"]
 affects_cache = ["package.json", "tsconfig.json"]
 latest_version = "0.11.1"
 known_good_version = "0.11.1"


### PR DESCRIPTION
- Split `jsx` file type from `javascript`
- Add some missing extensions for CommonJS and ESM variants
- Behavior neutral: Maintain glob and interpreters for maintainability analysis independent of the file_types data.

I explored a few alternatives to the duplication and they all introduced subtle, confusing semantics so I just went with giving us full control for targeting maintainability independent from the file_types. This gives us the ability to tweak our targets without inadvertently affecting plugins and vice versa.