### PR TITLE
Set plugin `mode=disabled`(instead of removing whole plugin) when running `qlty plugins disable PLUGIN`

### DIFF
--- a/qlty-cli/src/commands/plugins/disable.rs
+++ b/qlty-cli/src/commands/plugins/disable.rs
@@ -29,11 +29,11 @@ impl ConfigDocument {
 
     pub fn disable_plugin(&mut self, name: &str) -> Result<()> {
         if let Some(plugins) = self.document["plugin"].as_array_of_tables_mut() {
-            plugins.retain(|plugin| {
+            plugins.iter_mut().for_each(|plugin| {
                 if let Some(plugin_name) = plugin.get("name").and_then(Item::as_str) {
-                    plugin_name != name
-                } else {
-                    true // Do not modify unknown data
+                    if plugin_name == name {
+                        plugin["mode"] = "disabled".into();
+                    }
                 }
             });
         }
@@ -109,6 +109,11 @@ config_version = "0"
 [[plugin]]
 name = "stays"
 version = "1.0.0"
+
+[[plugin]]
+name = "to_disable"
+version = "1.0.0"
+mode = "disabled"
 
 [[plugin]]
 name = "also_stays"

--- a/qlty-cli/src/commands/plugins/disable.rs
+++ b/qlty-cli/src/commands/plugins/disable.rs
@@ -28,10 +28,6 @@ impl ConfigDocument {
     }
 
     pub fn disable_plugin(&mut self, name: &str) -> Result<()> {
-        if self.document.get("plugin").is_none() {
-            bail!("No plugins found in qlty.toml");
-        }
-
         let mut updated = false;
 
         if let Some(plugin_tables) = self.document["plugin"].as_array_of_tables_mut() {

--- a/qlty-cli/src/commands/plugins/disable.rs
+++ b/qlty-cli/src/commands/plugins/disable.rs
@@ -131,4 +131,30 @@ version = "1.0.0"
 
         assert_eq!(config.document.to_string().trim(), expected.trim());
     }
+
+    #[test]
+    fn test_disable_plugin_wrong_name() {
+        let (temp_dir, _) = sample_repo();
+        let temp_path = temp_dir.path().to_path_buf();
+
+        let workspace = Workspace {
+            root: temp_path.clone(),
+        };
+        fs::create_dir_all(&temp_path.join(path_to_native_string(".qlty"))).ok();
+
+        fs::write(
+            &temp_path.join(path_to_native_string(".qlty/qlty.toml")),
+            r#"
+config_version = "0"
+
+[[plugin]]
+name = "disableme"
+version = "1.0.0"
+            "#,
+        )
+        .ok();
+        let mut config = ConfigDocument::new(&workspace).unwrap();
+
+        assert!(config.disable_plugin("typo-command").is_err());
+    }
 }

--- a/qlty-cli/src/commands/plugins/disable.rs
+++ b/qlty-cli/src/commands/plugins/disable.rs
@@ -44,7 +44,7 @@ impl ConfigDocument {
         }
 
         if !updated {
-            bail!("Plugin not found in qlty.toml");
+            bail!("Plugin '{}' not found in qlty.toml", name);
         }
 
         Ok(())

--- a/qlty-cli/src/commands/plugins/disable.rs
+++ b/qlty-cli/src/commands/plugins/disable.rs
@@ -1,7 +1,7 @@
 use crate::{Arguments, CommandError, CommandSuccess};
 use anyhow::{bail, Result};
 use clap::Args;
-use qlty_config::Workspace;
+use qlty_config::{config::IssueMode, Workspace};
 use std::fs;
 use toml_edit::{DocumentMut, value};
 
@@ -38,7 +38,7 @@ impl ConfigDocument {
             for plugin_table in plugin_tables.iter_mut() {
                 if plugin_table["name"].as_str() == Some(name) {
                     updated = true;
-                    plugin_table["mode"] = value("disabled");
+                    plugin_table["mode"] = value(IssueMode::Disabled.to_string());
                 }
             }
         }

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -468,27 +468,27 @@ pub enum OutputFormat {
     #[serde(rename = "sarif")]
     Sarif,
     #[serde(rename = "actionlint")]
-    Actionlint,    
+    Actionlint,
     #[serde(rename = "bandit")]
     Bandit,
     #[serde(rename = "biome")]
-    Biome,    
+    Biome,
     #[serde(rename = "clippy")]
-    Clippy,    
+    Clippy,
     #[serde(rename = "coffeelint")]
-    Coffeelint,    
+    Coffeelint,
     #[serde(rename = "eslint")]
     Eslint,
     #[serde(rename = "golangci_lint")]
-    GolangciLint,    
+    GolangciLint,
     #[serde(rename = "hadolint")]
     Hadolint,
     #[serde(rename = "knip")]
-    Knip,    
+    Knip,
     #[serde(rename = "markdownlint")]
     Markdownlint,
     #[serde(rename = "mypy")]
-    Mypy,    
+    Mypy,
     #[serde(rename = "pylint")]
     Pylint,
     #[serde(rename = "php_codesniffer")]
@@ -506,7 +506,7 @@ pub enum OutputFormat {
     #[serde(rename = "rubocop")]
     Rubocop,
     #[serde(rename = "ruff")]
-    Ruff,    
+    Ruff,
     #[serde(rename = "shellcheck")]
     Shellcheck,
     #[serde(rename = "sqlfluff")]
@@ -715,12 +715,13 @@ pub enum IssueMode {
     Disabled = 4,
 }
 
-impl IssueMode {pub fn to_string(&self) -> String {
-    match self {
-        IssueMode::Block => "block".to_string(),
-        IssueMode::Comment => "comment".to_string(),
-        IssueMode::Monitor => "monitor".to_string(),
-        IssueMode::Disabled => "disabled".to_string(),
+impl IssueMode {
+    pub fn to_string(&self) -> String {
+        match self {
+            IssueMode::Block => "block".to_string(),
+            IssueMode::Comment => "comment".to_string(),
+            IssueMode::Monitor => "monitor".to_string(),
+            IssueMode::Disabled => "disabled".to_string(),
         }
     }
 

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -715,7 +715,15 @@ pub enum IssueMode {
     Disabled = 4,
 }
 
-impl IssueMode {
+impl IssueMode {pub fn to_string(&self) -> String {
+    match self {
+        IssueMode::Block => "block".to_string(),
+        IssueMode::Comment => "comment".to_string(),
+        IssueMode::Monitor => "monitor".to_string(),
+        IssueMode::Disabled => "disabled".to_string(),
+        }
+    }
+
     pub fn extract_issue_mode_from_smells(
         language: &Language,
         qlty_config: &QltyConfig,


### PR DESCRIPTION
- Changes behavior of the `qlty plugins disable PLUGIN` to set the plugin mode to `disabled` (instead of removing it from the qlty.toml)
- Adds a couple error checks: errors if no plugins in qlty.toml or if the plugin referenced in the command is not found in their qlty.toml (used `upgrade` command as reference)

Couple notes:

1. The conversion of `IssueMode` to a string duplicates the serialization macro strings (`#[serde(rename = "block")]` e.g.) defined in the struct itself. From what I could tell, if we want to avoid this duplication, we could either a) use `serde_json` to translate the IssueMode value to JSON, and then extract the string out of the JSON (yuck). Or, instead, remove these macros and define our own serialization, using the new `to_string` method defined. I'm less sure where the serialization is actually happening, so not confident I could do this.
2. I looked/tested how `qlty plugins enable PLUGIN` behaves. If a plugin is disabled (with the `disable` command or by hand), you get an error message "plugin PLUGIN already enabled". So we'll have to change this behavior to just remove the disabled mode line (I'm guessing).