### PR TITLE
enhance `qlty plugins enable PLUGIN` to support enabling disabled plugins

### DIFF
--- a/qlty-cli/src/commands/plugins/disable.rs
+++ b/qlty-cli/src/commands/plugins/disable.rs
@@ -34,7 +34,7 @@ impl ConfigDocument {
             for plugin_table in plugin_tables.iter_mut() {
                 if plugin_table["name"].as_str() == Some(name) {
                     updated = true;
-                    plugin_table["mode"] = value(IssueMode::Disabled.to_string());
+                    plugin_table["mode"] = value(IssueMode::Disabled.to_str());
                 }
             }
         }

--- a/qlty-cli/src/commands/plugins/enable.rs
+++ b/qlty-cli/src/commands/plugins/enable.rs
@@ -50,23 +50,18 @@ impl ConfigDocument {
         if let Some(plugin_tables) = self.document["plugin"].as_array_of_tables_mut() {
             for plugin_table in plugin_tables.iter_mut() {
                 if plugin_table["name"].as_str() == Some(name) {
-                    if plugin_table.get("mode").is_none() {
-                        eprintln!("{} Plugin {} is already enabled", style("⚠").yellow(), name);
-                        return Ok(());
-                    } else {
-                        match plugin_table["mode"].as_str() {
-                            Some(value) if value == IssueMode::Disabled.to_string() => {
-                                plugin_table.remove("mode");
-                                return Ok(());
-                            }
-                            Some(_) | None => {
-                                eprintln!(
-                                    "{} Plugin {} is already enabled",
-                                    style("⚠").yellow(),
-                                    name
-                                );
-                                return Ok(());
-                            }
+                    match plugin_table.get("mode") {
+                        Some(value) if value.as_str() == Some(IssueMode::Disabled.to_str()) => {
+                            plugin_table.remove("mode");
+                            return Ok(());
+                        }
+                        Some(_) | None => {
+                            eprintln!(
+                                "{} Plugin {} is already enabled",
+                                style("⚠").yellow(),
+                                name
+                            );
+                            return Ok(());
                         }
                     }
                 }

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -716,12 +716,12 @@ pub enum IssueMode {
 }
 
 impl IssueMode {
-    pub fn to_string(&self) -> String {
+    pub fn to_str(&self) -> &'static str {
         match self {
-            IssueMode::Block => "block".to_string(),
-            IssueMode::Comment => "comment".to_string(),
-            IssueMode::Monitor => "monitor".to_string(),
-            IssueMode::Disabled => "disabled".to_string(),
+            IssueMode::Block => "block",
+            IssueMode::Comment => "comment",
+            IssueMode::Monitor => "monitor",
+            IssueMode::Disabled => "disabled",
         }
     }
 


### PR DESCRIPTION
Previously `qlty plugins disable PLUGIN` disabled a plugin by entirely removing the plugin definition from the `qlty.toml` file. In this world `qlty plugins enable PLUGIN` worked regardless of whether the plugin was never configured to begin with or was configured but removed with `qlty plugins disable PLUGIN`. 

This changed in #1315 when we changed the behavior of `qlty plugins disable PLUGIN` to instead mark the plugin as disabled (`mode = "disabled"`). Now, a `disabled` plugin differs from one never configured to begin with.  Because the `enable` subcommand was not "mode-aware" -- it assumed if the plugin was defined in the `qlty.toml`, regardless of its "mode", that it was enabled. This had the unfortunate user experience of informing a user that their plugin was already enabled when in fact it was explicitly disabled.

This PR makes the `enable` subcommand mode-aware: if a plugin is explicitly disabled with `mode = "disabled"` this PR removes that line from their configuration, effectively re-enabling that plugin.

This does mean that if at one point the plugin was configured with a mode other than the default (currently `block`), this would need to be put back into place.

