### PR TITLE
Adjust markdownlint output

### DIFF
--- a/qlty-plugins/plugins/linters/markdownlint/fixtures/__snapshots__/basic_v0.41.0.shot
+++ b/qlty-plugins/plugins/linters/markdownlint/fixtures/__snapshots__/basic_v0.41.0.shot
@@ -6,16 +6,16 @@ exports[`linter=markdownlint fixture=basic version=0.41.0 1`] = `
     {
       "category": "CATEGORY_STYLE",
       "documentationUrl": "https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#MD001",
-      "level": "LEVEL_FMT",
+      "level": "LEVEL_MEDIUM",
       "location": {
         "path": "basic.in.md",
         "range": {
           "startLine": 5,
         },
       },
-      "message": "Heading levels should only increment by one level at a time (https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md001.md)",
+      "message": "Heading levels should only increment by one level at a time",
       "mode": "MODE_BLOCK",
-      "ruleKey": "MD001 - heading-increment",
+      "ruleKey": "MD001",
       "snippet": "#### Here",
       "snippetWithContext": "## Crazy
 
@@ -27,16 +27,16 @@ exports[`linter=markdownlint fixture=basic version=0.41.0 1`] = `
     {
       "category": "CATEGORY_STYLE",
       "documentationUrl": "https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#MD041",
-      "level": "LEVEL_FMT",
+      "level": "LEVEL_MEDIUM",
       "location": {
         "path": "basic.in.md",
         "range": {
           "startLine": 1,
         },
       },
-      "message": "First line in a file should be a top-level heading (https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md041.md)",
+      "message": "First line in a file should be a top-level heading",
       "mode": "MODE_BLOCK",
-      "ruleKey": "MD041 - first-line-heading - first-line-h1",
+      "ruleKey": "MD041",
       "snippet": "## Crazy",
       "snippetWithContext": "## Crazy
 


### PR DESCRIPTION
- Cleanup rule keys
- Cleanup messages
- Emit at `medium` level not `fmt` -- Medium should be the default unless we have a reason to go up to high or down to low. Fmt should be for auto-formatter issues only