### PR TITLE
Move invocation files directly into out/ dir

### DIFF
--- a/qlty-check/src/executor/invocation_result.rs
+++ b/qlty-check/src/executor/invocation_result.rs
@@ -456,12 +456,7 @@ impl InvocationResult {
     }
 
     fn outfile_directory(&self) -> PathBuf {
-        self.plan
-            .workspace
-            .root
-            .join(".qlty")
-            .join("out")
-            .join("invocations")
+        self.plan.workspace.root.join(".qlty").join("out")
     }
 
     pub fn status(&self) -> InvocationStatus {

--- a/qlty-cli/tests/cmd/check/missing_output_as_error.stdout
+++ b/qlty-cli/tests/cmd/check/missing_output_as_error.stdout
@@ -1,3 +1,3 @@
-Lint error exists: Exited with code 0 .qlty/out/invocations/invoke-[..].yaml
+Lint error exists: Exited with code 0 .qlty/out/invoke-[..].yaml
 [..]The plugin crashed for some reason[..]
 

--- a/qlty-cli/tests/cmd/check/skip_errored_plugins.stdout
+++ b/qlty-cli/tests/cmd/check/skip_errored_plugins.stdout
@@ -1,2 +1,2 @@
-Lint error always_error: Exited with code 1 .qlty/out/invocations/invoke-[..].yaml
+Lint error always_error: Exited with code 1 .qlty/out/invoke-[..].yaml
 

--- a/qlty-cli/tests/cmd/check/skip_errored_plugins_reports_other_failures.stdout
+++ b/qlty-cli/tests/cmd/check/skip_errored_plugins_reports_other_failures.stdout
@@ -4,5 +4,5 @@
 :0:0
     0:0  high    always_fail failed  always_fail:fail
 
-Lint error always_error: Exited with code 1 .qlty/out/invocations/invoke-[..].yaml
+Lint error always_error: Exited with code 1 .qlty/out/invoke-[..].yaml
 


### PR DESCRIPTION
Shortens up paths we need to print to the terminal, creating more space