### PR TITLE
Ignore node_modules from plugin source embedding

### DIFF
--- a/qlty-plugins/src/lib.rs
+++ b/qlty-plugins/src/lib.rs
@@ -5,6 +5,7 @@ use rust_embed::Embed;
 #[include = "*.toml"]
 #[exclude = ".qlty/qlty.toml"]
 #[exclude = "*/fixtures/*"]
+#[exclude = "node_modules/*"]
 pub struct Plugins;
 
 #[cfg(test)]
@@ -15,5 +16,11 @@ mod test {
     fn get_definitions() {
         let eslint = Plugins::get("linters/eslint/plugin.toml").unwrap();
         assert!(eslint.data.len() > 0);
+    }
+
+    #[test]
+    fn ignore_node_modules() {
+        let has_node_modules = Plugins::iter().any(|path| path.contains("node_modules"));
+        assert!(has_node_modules == false);
     }
 }


### PR DESCRIPTION
Embedded sources was picking up toml files from node_modules directory when present.