### PR TITLE
Shorten printing of ThreadId into log

### DIFF
--- a/qlty-check/src/executor/driver.rs
+++ b/qlty-check/src/executor/driver.rs
@@ -242,8 +242,6 @@ impl Driver {
                     .map(|issue| self.fix_issue_path(issue, plan, &path_prefix))
                     .into_group_map_by(|issue| issue.path().map(PathBuf::from));
 
-                debug!("Issues by path: {:?}", issues_by_path);
-
                 let mut file_results = vec![];
 
                 let parent_with_file_results =

--- a/qlty-cli/src/logging.rs
+++ b/qlty-cli/src/logging.rs
@@ -54,11 +54,18 @@ where
             tracing::Level::ERROR => styled_level.red(),
         };
         let styled_time = ansi(&writer, time).dim();
+
+        // ThreadIdsare formatted as ThreadId(1) in current Rust, which is verbose
+        let thread_id = format!("{:?}", thread::current().id());
+        let tid = thread_id
+            .trim_start_matches("ThreadId(")
+            .trim_end_matches(')');
+
         let styled_info = ansi(
             &writer,
             format!(
-                "[{:?}]::{} ({}):",
-                thread::current().id(),
+                "[T{}] {} ({}):",
+                tid,
                 metadata.module_path().unwrap_or_default(),
                 ByteSize(ALLOCATOR.allocated() as u64),
             ),


### PR DESCRIPTION
Before:

```
2024-12-19T17:20:19Z INFO [ThreadId(1)]::qlty_check::processor (6.7 MB): Processed results from 1 invocations in 0.17s
```
Now:

```
2024-12-19T17:20:19Z INFO [T1] qlty_check::processor (6.7 MB): Processed results from 1 invocations in 0.17s
```

Also remove some super verbose printing to debug level.