### PR TITLE
Remove support for HashMap version of 'sources' key in qlty.toml

### DIFF
--- a/qlty-config/src/config.rs
+++ b/qlty-config/src/config.rs
@@ -30,10 +30,10 @@ pub use source::SourceDef;
 
 use crate::config::plugin::EnabledRuntimes;
 pub use crate::config::plugin::PluginsConfig;
-use crate::sources::{Source, SourcesList};
+use crate::sources::SourcesList;
 use crate::version::QLTY_VERSION;
 use crate::Library;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -67,9 +67,6 @@ pub struct QltyConfig {
 
     #[serde(default)]
     pub plugins: PluginsConfig,
-
-    #[serde(default)]
-    pub sources: HashMap<String, SourceDef>,
 
     #[serde(default)]
     pub language: HashMap<String, Language>,
@@ -123,33 +120,10 @@ impl QltyConfig {
         true
     }
 
-    pub fn default_source(&self, library: &Library) -> Result<Box<dyn Source>> {
-        if let Some(source) = self
-            .source
-            .iter()
-            .find(|source_def| source_def.name.as_deref() == Some("default"))
-        {
-            return source.source(library);
-        }
-
-        let source_def = self.sources.get("default").ok_or_else(|| {
-            anyhow!(
-                "Could not find `sources.default` key in project config: {:#?}",
-                self
-            )
-        })?;
-
-        source_def.source(library)
-    }
-
     pub fn sources_list(&self, library: &Library) -> Result<SourcesList> {
         let mut sources_list = SourcesList::new();
 
         for source_def in self.source.iter() {
-            sources_list.sources.push(source_def.source(library)?);
-        }
-
-        for source_def in self.sources.values() {
             sources_list.sources.push(source_def.source(library)?);
         }
 

--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, bail, Context as _, Result};
 use config::{Config, File, FileFormat};
 use console::style;
 use toml::Value;
-use tracing::{trace, warn};
+use tracing::trace;
 
 const EXPECTED_CONFIG_VERSION: &str = "0";
 

--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -86,8 +86,7 @@ impl Builder {
             }
         }
 
-        // Check if neither sources nor source were found
-        if new_toml.get("sources").is_none() && new_toml.get("source").is_none() {
+        if new_toml.get("source").is_none() {
             bail!("No sources found");
         }
 

--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -67,21 +67,6 @@ impl Builder {
     fn extract_sources(mut toml: Value) -> Result<Value> {
         let mut new_toml = Value::Table(Default::default());
 
-        // Extract and process the "sources" section
-        {
-            let sources = toml.get_mut("sources");
-            if let Some(sources) = sources {
-                if let Some(table) = sources.as_table_mut() {
-                    warn!("The `sources` field in qlty.toml is deprecated. Please use `source` instead.");
-
-                    // should be a safe unwrap()
-                    let new_table = new_toml.as_table_mut().unwrap();
-                    new_table.insert("sources".to_string(), Value::Table(table.clone()));
-                }
-            }
-        }
-
-        // Extract and process the "source" section
         {
             let source = toml.get_mut("source");
             if let Some(source) = source {

--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -287,50 +287,6 @@ mod test {
     use toml::{toml, Value::Table};
 
     #[test]
-    fn test_extract_sources_with_sources_and_source() {
-        let input = toml! {
-            random_key = "random value to be filtered out"
-
-            [sources.default]
-            key1 = "value1"
-
-            [[source]]
-            key2 = "value2"
-            key3 = "value3"
-        };
-
-        let expected_output = toml! {
-            [sources.default]
-            key1 = "value1"
-
-            [[source]]
-            key2 = "value2"
-            key3 = "value3"
-        };
-
-        let result = Builder::extract_sources(Table(input)).unwrap();
-        assert_eq!(result, Table(expected_output));
-    }
-
-    #[test]
-    fn test_extract_sources_with_only_sources() {
-        let input = toml! {
-            random_key = "random value to be filtered out"
-
-            [sources.default]
-            key1 = "value1"
-        };
-
-        let expected_output = toml! {
-            [sources.default]
-            key1 = "value1"
-        };
-
-        let result = Builder::extract_sources(Table(input)).unwrap();
-        assert_eq!(result, Table(expected_output));
-    }
-
-    #[test]
     fn test_extract_sources_with_only_source() {
         let input = toml! {
             random_key = "random value to be filtered out"


### PR DESCRIPTION
We have been supporting 2 different ways of defining sources in the `qlty.toml` configuration file:

### As a Vector
```toml
[[source]]
name = "default"
default = true
```

### As a HashMap
```toml
[sources.default]
default = true
```

The HashMap version is considered legacy, and as we look to reference sources more, it will make our lives easier if we only support a single way of defining sources.

NB: The `default_source` method was unused and removed

By removing the hashmap sources definition, we may find a small number of customers who will no longer have a correctly defined source in their qlty.tom. In these scenarios, this is the error I see:

```
❌ Plugin definition not found for name: actionlint
```

Would be preferable, probably, to either:

1. Print an error saying that a source is not defined in the qlty.toml file
2. Default to the default = true behavior in cases where not source is defined.

What do you think?