### PR TITLE
Don't use Formatter trait for TextFormatter

### DIFF
--- a/qlty-cli/src/commands/check.rs
+++ b/qlty-cli/src/commands/check.rs
@@ -313,13 +313,14 @@ impl Check {
     }
 
     fn write_stdout(&self, report: &Report, plan: &Plan, settings: &Settings) -> Result<()> {
-        let formatter = if self.json {
-            JsonFormatter::new(report.issues.clone())
+        if self.json {
+            let formatter = JsonFormatter::new(report.issues.clone());
+            formatter.write_to(&mut std::io::stdout())
         } else {
-            TextFormatter::new(report, &plan.workspace, settings.verbose, self.summary)
-        };
-
-        formatter.write_to(&mut std::io::stdout())
+            let formatter =
+                TextFormatter::new(report, &plan.workspace, settings.verbose, self.summary);
+            formatter.write_to(&mut std::io::stdout())
+        }
     }
 
     fn write_stderr(&self, report: &Report) -> Result<()> {

--- a/qlty-cli/src/ui/format/errors.rs
+++ b/qlty-cli/src/ui/format/errors.rs
@@ -1,23 +1,22 @@
 use anyhow::Result;
 use console::style;
 use qlty_check::Report;
-use qlty_cloud::format::Formatter;
 
 #[derive(Debug)]
 pub struct ErrorsFormatter {
     report: Report,
 }
 
-impl<'a> ErrorsFormatter {
-    pub fn new(report: &Report) -> Box<dyn Formatter> {
-        Box::new(Self {
+impl ErrorsFormatter {
+    pub fn new(report: &Report) -> Self {
+        Self {
             report: report.clone(),
-        })
+        }
     }
 }
 
-impl Formatter for ErrorsFormatter {
-    fn write_to(&self, writer: &mut dyn std::io::Write) -> Result<()> {
+impl ErrorsFormatter {
+    pub fn write_to(&self, writer: &mut dyn std::io::Write) -> Result<()> {
         let cwd = std::env::current_dir().expect("Unable to identify current directory");
 
         for invocation in &self.report.invocations {

--- a/qlty-cli/src/ui/format/text.rs
+++ b/qlty-cli/src/ui/format/text.rs
@@ -7,7 +7,6 @@ use num_format::{Locale, ToFormattedString as _};
 use qlty_analysis::utils::fs::path_to_string;
 use qlty_check::Report;
 use qlty_check::{executor::InvocationStatus, results::FixedResult};
-use qlty_cloud::format::Formatter;
 use qlty_config::Workspace;
 use qlty_types::analysis::v1::{ExecutionVerb, Issue, Level, SuggestionSource};
 use similar::{ChangeTag, TextDiff};
@@ -25,20 +24,14 @@ pub struct TextFormatter {
     summary: bool,
 }
 
-impl<'a> TextFormatter {
-    // qlty-ignore: clippy:new_ret_no_self
-    pub fn new(
-        report: &Report,
-        workspace: &Workspace,
-        verbose: usize,
-        summary: bool,
-    ) -> Box<dyn Formatter> {
-        Box::new(Self {
+impl TextFormatter {
+    pub fn new(report: &Report, workspace: &Workspace, verbose: usize, summary: bool) -> Self {
+        Self {
             report: report.clone(),
             workspace: workspace.clone(),
             verbose,
             summary,
-        })
+        }
     }
 }
 
@@ -53,8 +46,8 @@ impl fmt::Display for Line {
     }
 }
 
-impl Formatter for TextFormatter {
-    fn write_to(&self, writer: &mut dyn std::io::Write) -> anyhow::Result<()> {
+impl TextFormatter {
+    pub fn write_to(&self, writer: &mut dyn std::io::Write) -> anyhow::Result<()> {
         if !self.summary {
             self.print_unformatted(writer)?;
             self.print_fixes(writer)?;


### PR DESCRIPTION
The Formatter trait is most useful for programatic output like JSON, NDJSON, Gzip, and Protos.

The usage for TextFormatter and ErrorsFormatter was buying us very little, and binding those concepts to confusing semantics now that the text "formatter" is interactive.

Now that we have disconnected TextFormatter and ErrorsFormatter from `trait Formatter`, I will look at renaming and re-organizing them.