### PR TITLE
Fix duplicate issues bug on partial cache hit

### DIFF
--- a/qlty-check/src/planner/driver.rs
+++ b/qlty-check/src/planner/driver.rs
@@ -218,7 +218,7 @@ impl DriverPlanner {
             workspace_root: self.workspace.root.clone(),
         };
 
-        for driver_target_batch in target_batcher.compute(&self.targets)? {
+        for driver_target_batch in target_batcher.compute(&targets)? {
             let plugin_configs = if driver_target_batch.config_file.is_some() {
                 vec![driver_target_batch.config_file.unwrap().clone()]
             } else {


### PR DESCRIPTION
In the case where one or more files was a cache hit, and one or more files were a cache miss, the Planner would plan an invocation for all files not just the uncached file. The result was duplicate issues for the cache hit files.