### PR TITLE
Attempt to fix Windows snapshot test

### DIFF
--- a/qlty-cli/tests/cmd/check/missing_output_as_error.stdout
+++ b/qlty-cli/tests/cmd/check/missing_output_as_error.stdout
@@ -1,4 +1,4 @@
  ERRORS: 1 
 
 exists  Error  Exited with code 0 in [..].[..]s  .qlty/out/invoke-[..].yaml
-        The plugin crashed for some reason
+        [..]The plugin crashed for some reason[..]


### PR DESCRIPTION
On Windows, the output string is quoted. On Mac and Linux, it is not. This snapshot hopefully works for both.