### PR TITLE
Categorize various flavors of `if` in Ruby as `if` nodes

### DIFF
--- a/qlty-analysis/src/lang/ruby.rs
+++ b/qlty-analysis/src/lang/ruby.rs
@@ -149,7 +149,12 @@ impl Language for Ruby {
     }
 
     fn if_nodes(&self) -> Vec<&str> {
-        vec![Self::IF, Self::UNLESS, Self::IF_MODIFIER, Self::UNLESS_MODIFIER]
+        vec![
+            Self::IF,
+            Self::UNLESS,
+            Self::IF_MODIFIER,
+            Self::UNLESS_MODIFIER,
+        ]
     }
 
     fn elsif_nodes(&self) -> Vec<&str> {

--- a/qlty-analysis/src/lang/ruby.rs
+++ b/qlty-analysis/src/lang/ruby.rs
@@ -82,6 +82,9 @@ impl Ruby {
     pub const GLOBAL_VARIABLE: &'static str = "global_variable";
     pub const IDENTIFIER: &'static str = "identifier";
     pub const IF: &'static str = "if";
+    pub const UNLESS: &'static str = "unless";
+    pub const IF_MODIFIER: &'static str = "if_modifier"; // statement _modifier_ aka trailing if
+    pub const UNLESS_MODIFIER: &'static str = "unless_modifier"; // statement _modifier_ aka trailing unless
     pub const INITIALIZE: &'static str = "initialize";
     pub const INSTANCE_VARIABLE: &'static str = "instance_variable";
     pub const METHOD_CALL: &'static str = "method_call";
@@ -146,7 +149,7 @@ impl Language for Ruby {
     }
 
     fn if_nodes(&self) -> Vec<&str> {
-        vec![Self::IF]
+        vec![Self::IF, Self::UNLESS, Self::IF_MODIFIER, Self::UNLESS_MODIFIER]
     }
 
     fn elsif_nodes(&self) -> Vec<&str> {

--- a/qlty-smells/src/metrics/metrics/cognitive.rs
+++ b/qlty-smells/src/metrics/metrics/cognitive.rs
@@ -270,6 +270,33 @@ mod test {
         }
 
         #[test]
+        fn count_statement_modifiers() {
+            let source_file = File::from_string(
+                "ruby",
+                r#"
+                def foo(bar)
+                    return 1 unless bar # +1
+                    return 2 if bar # +1
+                    if bar # +1
+                        return 3
+                    end
+                    unless bar # +1
+                        return 4
+                    end
+                end
+                "#,
+            );
+            assert_eq!(
+                4,
+                count(
+                    &source_file,
+                    &source_file.parse().root_node(),
+                    &NodeFilter::empty()
+                )
+            );
+        }
+
+        #[test]
         fn count_else_if() {
             let source_file = File::from_string(
                 "java",


### PR DESCRIPTION
In https://github.com/orgs/qltysh/discussions/1313 @nk-ty noted that `qlty` and `codeclimate` CLIs calculate the cognitive complexity of a method with trailing unless statements differently. After some investigation, I determined that both were incorrectly calculating cognitive complexity. This PR is concerned with the cognitive complexity calculation in qlty.

The following are equivalent ways of expressing an `if` conditional in Ruby:

```ruby
if !foo
    puts "hi"
end
```

```ruby
unless foo
    puts "foo"
end
```

```ruby
puts "hi" if !foo
```

```ruby
puts "hi" unless foo
```

The first was correctly being calculated. The second was an obvious oversight. And the 3rd and 4th ones were less obvious oversights (the parser calls them `if_modifier` / `unless_modifier` nodes not `if` / `unless` nodes.

This PR categorizes all 4 as `if_nodes` which the cognitive complexity calculator uses, and correctly penalizes all 4 as 1 point.