### PR TITLE
Remove macos14 from CI builds

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          [ubuntu-latest-16-cores, macos-latest-xlarge, windows-latest-16-cores]
+          [ubuntu-latest-16-cores, macos-15-xlarge, windows-latest-16-cores]
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     concurrency:
@@ -51,7 +51,7 @@ jobs:
 
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2
-        if: matrix.os == 'macos-latest-xlarge'
+        if: matrix.os == 'macos-15-xlarge'
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -30,15 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-latest-xlarge currently points to MacOS 14 Sonoma
-        # macos-15-xlarge points to MacOS 15 Sequoia
-        os:
-          [
-            macos-latest-xlarge,
-            macos-15-xlarge,
-            ubuntu-latest-16-cores,
-            windows-latest-16-cores,
-          ]
+        os: [macos-15-xlarge, ubuntu-latest-16-cores, windows-latest-16-cores]
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     concurrency:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,9 +159,9 @@ install-updater = true
 allow-dirty = ["ci"]
 
 [workspace.metadata.dist.github-custom-runners]
-aarch64-apple-darwin = "macos-latest-xlarge"
+aarch64-apple-darwin = "macos-15-xlarge"
 aarch64-unknown-linux-gnu = "ubuntu-2204-32-cores-arm64"
-x86_64-apple-darwin = "macos-latest-xlarge"
+x86_64-apple-darwin = "macos-15-xlarge"
 x86_64-pc-windows-msvc = "windows-latest-32-cores-x64"
 x86_64-unknown-linux-gnu = "ubuntu-2204-32-cores-x64"
 x86_64-unknown-linux-musl = "ubuntu-2204-32-cores-x64"


### PR DESCRIPTION
Use `macos-15-xlarge` builder instead.