### PR TITLE
Update CI runners for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,12 +167,12 @@ install-updater = true
 allow-dirty = ["ci"]
 
 [workspace.metadata.dist.github-custom-runners]
-aarch64-apple-darwin = "macos-15-xlarge"
-aarch64-unknown-linux-gnu = "ubuntu-2204-32-cores-arm64"
-x86_64-apple-darwin = "macos-15-xlarge"
-x86_64-pc-windows-msvc = "windows-latest-32-cores-x64"
-x86_64-unknown-linux-gnu = "ubuntu-2204-32-cores-x64"
-x86_64-unknown-linux-musl = "ubuntu-2204-32-cores-x64"
+aarch64-apple-darwin = "macos-15"
+aarch64-unknown-linux-gnu = "ubuntu-22.04"
+x86_64-apple-darwin = "macos-15"
+x86_64-pc-windows-msvc = "windows-latest"
+x86_64-unknown-linux-gnu = "ubuntu-22.04"
+x86_64-unknown-linux-musl = "ubuntu-22.04"
 
 [workspace.metadata.release]
 publish = false


### PR DESCRIPTION
Related to #1386

Not sure if we explicitly need an arm64 host to build an arm64 linux  builds since Rust should be able to cross-compile across architectures (we explicitly already do this on macOS). I think it's worth validating this via a release with standard runners and have high confidence it would work.