### PR TITLE
WIP: Log completions to disk

### DIFF
--- a/qlty-check/src/llm/completion.rs
+++ b/qlty-check/src/llm/completion.rs
@@ -1,0 +1,32 @@
+enum CompletionResult {
+    Unspecified = 0,
+    Success = 1,
+    Error = 2,
+}
+
+struct Completion {
+    // Metadata
+    id: String,
+    timestamp: Timestamp,
+    qlty_cli_version: String,
+
+    // Issue data
+    plugin_name: String,
+    driver_name: String,
+    plugin_version: String,
+    rule_key: String,
+    level: Level,
+    category: Category,
+    language: Language,
+    message: String,
+    path: String,
+    range: Range,
+    documentation_url: String,
+    fingerprint: String,
+
+    // Results
+    duration_secs: f32,
+    result: CompletionResult,
+    patch: Option<String>,
+    error_message: Option<String>,
+}


### PR DESCRIPTION
This is WIP from a flight today...

The goal is to write out YAML files for auto-fix attempts like we do for Invocations on the client side. This is not a substitute for increasing visibility on the server-side, however it is a convenience that is better than trying to eyeball log files.

(Eventually, if we decide the completion YAML files are not useful, we might remove this feature)