### PR TITLE
Add `cache prune` subcommand

### DIFF
--- a/.qlty/.gitignore
+++ b/.qlty/.gitignore
@@ -1,4 +1,5 @@
-results
 logs
 out
+plugin_cachedir
+results
 sources

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -633,7 +633,7 @@ pub trait Tool: Debug + Sync + Send {
                 &path_to_native_string(join_path_string!(
                     std::env::current_dir().unwrap(),
                     ".qlty",
-                    "results"
+                    "plugin_cache"
                 )),
             );
         if let Some(runtime) = self.runtime() {
@@ -954,7 +954,7 @@ mod test {
                 path_to_native_string(path_to_string(join_path_string!(
                     std::env::current_dir().unwrap(),
                     ".qlty",
-                    "results"
+                    "plugin_cache"
                 ))),
                 var("PATH").unwrap()
             )

--- a/qlty-cli/src/commands/cache.rs
+++ b/qlty-cli/src/commands/cache.rs
@@ -4,10 +4,12 @@ use clap::{Args, Subcommand};
 
 mod clean;
 mod dir;
+mod prune;
 mod status;
 
 pub use clean::Clean;
 pub use dir::Dir;
+pub use prune::Prune;
 pub use status::Status;
 
 #[derive(Debug, Args)]
@@ -19,6 +21,9 @@ pub struct Arguments {
 #[derive(Subcommand, Debug)]
 
 pub enum Commands {
+    /// Prune the cache
+    Prune(Prune),
+
     /// Delete the entire cache
     Clean(Clean),
 
@@ -34,6 +39,7 @@ impl Arguments {
         match &self.command {
             Commands::Clean(command) => command.execute(args),
             Commands::Dir(command) => command.execute(args),
+            Commands::Prune(command) => command.execute(args),
             Commands::Status(command) => command.execute(args),
         }
     }

--- a/qlty-cli/src/commands/cache/prune.rs
+++ b/qlty-cli/src/commands/cache/prune.rs
@@ -1,0 +1,12 @@
+use crate::{Arguments, CommandError, CommandSuccess};
+use anyhow::Result;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct Prune {}
+
+impl Prune {
+    pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
+        CommandSuccess::ok()
+    }
+}

--- a/qlty-cli/src/commands/cache/prune.rs
+++ b/qlty-cli/src/commands/cache/prune.rs
@@ -1,12 +1,16 @@
 use crate::{Arguments, CommandError, CommandSuccess};
 use anyhow::Result;
 use clap::Args;
+use qlty_config::Workspace;
 
 #[derive(Args, Debug)]
 pub struct Prune {}
 
 impl Prune {
     pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
+        let workspace = Workspace::new()?;
+        let library = workspace.library()?;
+        library.prune()?;
         CommandSuccess::ok()
     }
 }

--- a/qlty-cli/src/commands/cache/prune.rs
+++ b/qlty-cli/src/commands/cache/prune.rs
@@ -1,6 +1,11 @@
 use crate::{Arguments, CommandError, CommandSuccess};
 use anyhow::Result;
+use bytesize::ByteSize;
 use clap::Args;
+use cli_table::{
+    format::{Border, HorizontalLine, Justify, Separator, VerticalLine},
+    print_stdout, Cell as _, Table as _,
+};
 use qlty_config::Workspace;
 
 #[derive(Args, Debug)]
@@ -10,7 +15,65 @@ impl Prune {
     pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
         let workspace = Workspace::new()?;
         let library = workspace.library()?;
+
+        let before_statuses = library.status()?;
         library.prune()?;
+        let after_statuses = library.status()?;
+
+        let rows = after_statuses
+            .iter()
+            .filter_map(|after| {
+                let before = before_statuses.iter().find(|s| s.dir == after.dir);
+
+                match before {
+                    Some(before) => {
+                        let files_removed = before.files_count - after.files_count;
+                        let bytes_removed = before.files_bytes - after.files_bytes;
+
+                        Some(vec![
+                            after
+                                .dir
+                                .to_string_lossy()
+                                .to_string()
+                                .cell()
+                                .justify(Justify::Left),
+                            format!("{}", files_removed).cell().justify(Justify::Right),
+                            ByteSize(bytes_removed)
+                                .to_string_as(true)
+                                .cell()
+                                .justify(Justify::Right),
+                            format!("{}", after.files_count)
+                                .cell()
+                                .justify(Justify::Right),
+                            ByteSize(after.files_bytes)
+                                .to_string_as(true)
+                                .cell()
+                                .justify(Justify::Right),
+                        ])
+                    }
+                    None => None,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let table = rows
+            .table()
+            .title(vec![
+                "Path".cell(),
+                "Files Removed".cell().justify(Justify::Right),
+                "Bytes Removed".cell().justify(Justify::Right),
+                "Files Remaining".cell().justify(Justify::Right),
+                "Bytes Remaining".cell().justify(Justify::Right),
+            ])
+            .border(Border::builder().build())
+            .separator(
+                Separator::builder()
+                    .title(Some(HorizontalLine::default()))
+                    .column(Some(VerticalLine::default()))
+                    .build(),
+            );
+        print_stdout(table)?;
+
         CommandSuccess::ok()
     }
 }

--- a/qlty-cli/src/initializer/templates/gitignore.txt
+++ b/qlty-cli/src/initializer/templates/gitignore.txt
@@ -1,4 +1,5 @@
-results
 logs
 out
+plugin_cachedir
+results
 sources

--- a/qlty-config/src/library.rs
+++ b/qlty-config/src/library.rs
@@ -154,6 +154,25 @@ impl Library {
             .join(self.local_fingerprint()))
     }
 
+    pub fn prune(&self) -> Result<()> {
+        for dir in self.status_dirs()? {
+            if dir.exists() {
+                for entry in fs::read_dir(dir)? {
+                    // let entry = entry?;
+                    // let path = entry.path();
+
+                    // if path.is_file() {
+                    //     fs::remove_file(&path)?;
+                    // } else {
+                    //     fs::remove_dir_all(&path)?;
+                    // }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn clean(&self) -> Result<()> {
         for dir in self.status_dirs()? {
             if dir.exists() {
@@ -170,11 +189,6 @@ impl Library {
             }
         }
 
-        Ok(())
-    }
-
-    pub fn prune(&self) -> Result<()> {
-        // TODO
         Ok(())
     }
 

--- a/qlty-config/src/library.rs
+++ b/qlty-config/src/library.rs
@@ -57,6 +57,10 @@ impl Library {
         self.local_root.join("results")
     }
 
+    pub fn plugin_cachedir_dir(&self) -> PathBuf {
+        self.local_root.join("plugin_cachedir")
+    }
+
     pub fn configs_dir(&self) -> PathBuf {
         self.local_root.join("configs")
     }
@@ -132,6 +136,12 @@ impl Library {
                 .join(self.local_fingerprint())
                 .join("results"),
         )?;
+        fs::create_dir_all(
+            global_cache_root
+                .join("repos")
+                .join(self.local_fingerprint())
+                .join("plugin_cachedir"),
+        )?;
         Ok(())
     }
 
@@ -144,6 +154,10 @@ impl Library {
         self.try_symlink_if_missing(&global_repo_path.join("out"), &self.out_dir())?;
         self.try_symlink_if_missing(&global_repo_path.join("logs"), &self.logs_dir())?;
         self.try_symlink_if_missing(&global_repo_path.join("results"), &self.results_dir())?;
+        self.try_symlink_if_missing(
+            &global_repo_path.join("plugin_cachedir"),
+            &self.plugin_cachedir_dir(),
+        )?;
 
         Ok(())
     }
@@ -155,17 +169,47 @@ impl Library {
     }
 
     pub fn prune(&self) -> Result<()> {
-        for dir in self.status_dirs()? {
-            if dir.exists() {
-                for entry in fs::read_dir(dir)? {
-                    // let entry = entry?;
-                    // let path = entry.path();
+        let cache_directory = self.cache_directory()?;
 
-                    // if path.is_file() {
-                    //     fs::remove_file(&path)?;
-                    // } else {
-                    //     fs::remove_dir_all(&path)?;
-                    // }
+        if cache_directory.join("logs").exists() {
+            self.prune_dir(&cache_directory.join("logs"), 7)?;
+        }
+
+        if cache_directory.join("out").exists() {
+            self.prune_dir(&cache_directory.join("out"), 3)?;
+        }
+
+        if cache_directory.join("results").join("issues").exists() {
+            self.prune_dir(&cache_directory.join("results").join("issues"), 1)?;
+        }
+
+        if cache_directory.join("plugin_cachedir").exists() {
+            for entry in fs::read_dir(cache_directory.join("plugin_cachedir"))? {
+                let entry = entry?;
+                let path = entry.path();
+
+                if path.is_file() {
+                    fs::remove_file(&path)?;
+                } else {
+                    fs::remove_dir_all(&path)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn prune_dir(&self, dir: &Path, days: u32) -> Result<()> {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.is_file() {
+                let metadata = fs::metadata(&path)?;
+                let usage_time = std::cmp::max(metadata.accessed()?, metadata.modified()?);
+
+                if usage_time.elapsed()?.as_secs() > days as u64 * 24 * 60 * 60 {
+                    fs::remove_file(&path)?;
                 }
             }
         }
@@ -227,10 +271,21 @@ impl Library {
 
     fn status_dirs(&self) -> Result<Vec<PathBuf>> {
         let global_repo_path = self.cache_directory()?;
-        Ok(vec![
+        let candidates = vec![
             global_repo_path.join("out"),
             global_repo_path.join("logs"),
             global_repo_path.join("results"),
-        ])
+            global_repo_path.join("plugin_cachedir"),
+        ];
+
+        let mut existing_dirs = vec![];
+
+        for candidate in candidates {
+            if candidate.exists() {
+                existing_dirs.push(candidate);
+            }
+        }
+
+        Ok(existing_dirs)
     }
 }


### PR DESCRIPTION
Uses the file MAC times to prune the results cache, logs, and outfiles. This is a fast-and-dumb approach rather than trying to analyze everything and figure out which results cache files are truly no longer needed.

Some filesystems may not track access times (`atime`) which provides visibility into cache reads, in which case it will fallback to modified time (`mtime`).

Also, adds a `plugin_cachedir` to the Library, to keep data cached by the plugins isolated from data that we cache. (In our cache, the Clippy plugin ends up with ~2 GB of "cache" which is really compilation artifacts.) Since we can't be sure of the impact of deleting some-but-not-all of a plugin's cached data, we delete it all.

### Future improvements

- Enhance `cache prune` to have an argument for whether to clear the plugin caches or not, since that data is likely to be large but also slow to re-generate
- Automatically run `cache prune` logic regularly _without_ clearing the plugin caches.