### PR TITLE
Fix incorrect reference to `plugin_cache` directory

### DIFF
--- a/.qlty/.gitignore
+++ b/.qlty/.gitignore
@@ -1,5 +1,5 @@
 logs
 out
-plugin_cachedir
+plugin_cache*
 results
 sources

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -633,7 +633,7 @@ pub trait Tool: Debug + Sync + Send {
                 &path_to_native_string(join_path_string!(
                     std::env::current_dir().unwrap(),
                     ".qlty",
-                    "plugin_cache"
+                    "plugin_cachedir"
                 )),
             );
         if let Some(runtime) = self.runtime() {
@@ -954,7 +954,7 @@ mod test {
                 path_to_native_string(path_to_string(join_path_string!(
                     std::env::current_dir().unwrap(),
                     ".qlty",
-                    "plugin_cache"
+                    "plugin_cachedir"
                 ))),
                 var("PATH").unwrap()
             )

--- a/qlty-cli/src/initializer/templates/gitignore.txt
+++ b/qlty-cli/src/initializer/templates/gitignore.txt
@@ -1,5 +1,5 @@
 logs
 out
-plugin_cachedir
+plugin_cache*
 results
 sources


### PR DESCRIPTION
Use `plugin_cachedir` instead.

Fixes a configuration issue from #1408