### PR TITLE
Allow raw coverage files with same name

### DIFF
--- a/qlty-cloud/src/export/coverage.rs
+++ b/qlty-cloud/src/export/coverage.rs
@@ -21,8 +21,8 @@ fn compress_files(files: Vec<String>, output_file: &Path) -> Result<()> {
 
         if path.is_file() {
             // Add the file to the archive
-            let file_name = path.file_name().unwrap().to_string_lossy();
-            zip.start_file(file_name, options)?;
+            // Use path as filename in case multiple files with same name
+            zip.start_file(path.to_string_lossy(), options)?;
 
             // Write the file content to the archive
             let mut file = File::open(path)?;


### PR DESCRIPTION
Right now if someone has two coverage files with same name in different directories it throws the error: `invalid Zip archive: Duplicate filename`

Adding dir path to zip should prevent that while maintaining uniqueness in identifying files.

Reference: https://discord.com/channels/1256822430505373696/1308114848403685406/1328180907554766910