### PR TITLE
Fix panic when path for `qlty check <path>` is outside qlty directory

### DIFF
--- a/qlty-analysis/src/workspace_entries/args_source.rs
+++ b/qlty-analysis/src/workspace_entries/args_source.rs
@@ -50,7 +50,7 @@ impl ArgsSource {
                     .unwrap()
                     .strip_prefix(root)
                     .ok()
-                    .unwrap()
+                    .unwrap_or(path)
                     .to_path_buf();
                 let metadata = entry.metadata().ok().unwrap();
 


### PR DESCRIPTION
The walker attempts to strip the "root qlty directory" off of each path when iterating over args, but if the prefix does not match, the offending line unwraps a None option and panics.

This fixes the panic, although in general, the behavior for this situation is undefined (qlty does not support calling `check <path>` on paths that are not in the root qlty directory).

Ideally all path arguments should be validated and an error should be printed when an invalid path is found, but let's start by removing panics.