### PR TITLE
Fix off-by-1 offset in ripgrep column info

### DIFF
--- a/qlty-check/src/parser/ripgrep.rs
+++ b/qlty-check/src/parser/ripgrep.rs
@@ -100,9 +100,9 @@ impl Parser for Ripgrep {
                             path: path.text.clone(),
                             range: Some(Range {
                                 start_line: line_number,
-                                start_column: submatch.start + 1,
+                                start_column: submatch.start + 1, // submatch uses 1-based indexing
                                 end_line: line_number,
-                                end_column: submatch.end + 1,
+                                end_column: submatch.end + 1, // submatch uses 1-based indexing
                                 ..Default::default()
                             }),
                         }),

--- a/qlty-check/src/parser/ripgrep.rs
+++ b/qlty-check/src/parser/ripgrep.rs
@@ -100,9 +100,9 @@ impl Parser for Ripgrep {
                             path: path.text.clone(),
                             range: Some(Range {
                                 start_line: line_number,
-                                start_column: submatch.start,
+                                start_column: submatch.start + 1,
                                 end_line: line_number,
-                                end_column: submatch.end,
+                                end_column: submatch.end + 1,
                                 ..Default::default()
                             }),
                         }),
@@ -137,7 +137,7 @@ mod test {
         "###;
 
         let issues = Ripgrep::default().parse("ripgrep", input);
-        insta::assert_yaml_snapshot!(issues.unwrap(), @r###"
+        insta::assert_yaml_snapshot!(issues.unwrap(), @r"
         - tool: ripgrep
           ruleKey: FIXME
           message: // FIXME TODO
@@ -147,9 +147,9 @@ mod test {
             path: basic_e.in.rs
             range:
               startLine: 2
-              startColumn: 7
+              startColumn: 8
               endLine: 2
-              endColumn: 12
+              endColumn: 13
         - tool: ripgrep
           ruleKey: TODO
           message: // FIXME TODO
@@ -159,9 +159,9 @@ mod test {
             path: basic_e.in.rs
             range:
               startLine: 2
-              startColumn: 13
+              startColumn: 14
               endLine: 2
-              endColumn: 17
+              endColumn: 18
         - tool: ripgrep
           ruleKey: NOTE
           message: // NOTE
@@ -171,9 +171,9 @@ mod test {
             path: basic.in.rs
             range:
               startLine: 2
-              startColumn: 7
+              startColumn: 8
               endLine: 2
-              endColumn: 11
+              endColumn: 12
         - tool: ripgrep
           ruleKey: FIXME
           message: // FIXME TODO
@@ -183,9 +183,9 @@ mod test {
             path: basic.in.rs
             range:
               startLine: 3
-              startColumn: 7
+              startColumn: 8
               endLine: 3
-              endColumn: 12
+              endColumn: 13
         - tool: ripgrep
           ruleKey: TODO
           message: // FIXME TODO
@@ -195,9 +195,9 @@ mod test {
             path: basic.in.rs
             range:
               startLine: 3
-              startColumn: 13
+              startColumn: 14
               endLine: 3
-              endColumn: 17
+              endColumn: 18
         - tool: ripgrep
           ruleKey: HACK
           message: // HACK
@@ -207,10 +207,10 @@ mod test {
             path: basic.in.rs
             range:
               startLine: 4
-              startColumn: 7
+              startColumn: 8
               endLine: 4
-              endColumn: 11
-        "###);
+              endColumn: 12
+        ");
     }
 
     #[test]
@@ -231,7 +231,7 @@ mod test {
         assert!(logs_contain("Failed to parse line number"));
         assert!(logs_contain("Failed to parse path"));
 
-        insta::assert_yaml_snapshot!(issues.unwrap(), @r###"
+        insta::assert_yaml_snapshot!(issues.unwrap(), @r"
         - tool: ripgrep
           ruleKey: NOTE
           message: // NOTE
@@ -241,7 +241,9 @@ mod test {
             path: basic.in.rs
             range:
               startLine: 2
+              startColumn: 1
               endLine: 2
-        "###);
+              endColumn: 1
+        ");
     }
 }

--- a/qlty-plugins/plugins/linters/ripgrep/fixtures/__snapshots__/basic_v14.1.0.shot
+++ b/qlty-plugins/plugins/linters/ripgrep/fixtures/__snapshots__/basic_v14.1.0.shot
@@ -9,9 +9,9 @@ exports[`linter=ripgrep fixture=basic version=14.1.0 1`] = `
       "location": {
         "path": "basic.in.rs",
         "range": {
-          "endColumn": 12,
+          "endColumn": 13,
           "endLine": 3,
-          "startColumn": 7,
+          "startColumn": 8,
           "startLine": 3,
         },
       },
@@ -36,9 +36,9 @@ exports[`linter=ripgrep fixture=basic version=14.1.0 1`] = `
       "location": {
         "path": "basic.in.rs",
         "range": {
-          "endColumn": 12,
+          "endColumn": 13,
           "endLine": 7,
-          "startColumn": 7,
+          "startColumn": 8,
           "startLine": 7,
         },
       },
@@ -63,9 +63,9 @@ exports[`linter=ripgrep fixture=basic version=14.1.0 1`] = `
       "location": {
         "path": "basic.in.rs",
         "range": {
-          "endColumn": 11,
+          "endColumn": 12,
           "endLine": 4,
-          "startColumn": 7,
+          "startColumn": 8,
           "startLine": 4,
         },
       },
@@ -90,9 +90,9 @@ exports[`linter=ripgrep fixture=basic version=14.1.0 1`] = `
       "location": {
         "path": "basic.in.rs",
         "range": {
-          "endColumn": 11,
+          "endColumn": 12,
           "endLine": 2,
-          "startColumn": 7,
+          "startColumn": 8,
           "startLine": 2,
         },
       },
@@ -117,9 +117,9 @@ exports[`linter=ripgrep fixture=basic version=14.1.0 1`] = `
       "location": {
         "path": "basic.in.rs",
         "range": {
-          "endColumn": 17,
+          "endColumn": 18,
           "endLine": 3,
-          "startColumn": 13,
+          "startColumn": 14,
           "startLine": 3,
         },
       },

--- a/qlty-plugins/plugins/linters/ripgrep/fixtures/__snapshots__/basic_v14.1.1.shot
+++ b/qlty-plugins/plugins/linters/ripgrep/fixtures/__snapshots__/basic_v14.1.1.shot
@@ -9,9 +9,9 @@ exports[`linter=ripgrep fixture=basic version=14.1.1 1`] = `
       "location": {
         "path": "basic.in.rs",
         "range": {
-          "endColumn": 12,
+          "endColumn": 13,
           "endLine": 3,
-          "startColumn": 7,
+          "startColumn": 8,
           "startLine": 3,
         },
       },
@@ -36,9 +36,9 @@ exports[`linter=ripgrep fixture=basic version=14.1.1 1`] = `
       "location": {
         "path": "basic.in.rs",
         "range": {
-          "endColumn": 12,
+          "endColumn": 13,
           "endLine": 7,
-          "startColumn": 7,
+          "startColumn": 8,
           "startLine": 7,
         },
       },
@@ -63,9 +63,9 @@ exports[`linter=ripgrep fixture=basic version=14.1.1 1`] = `
       "location": {
         "path": "basic.in.rs",
         "range": {
-          "endColumn": 11,
+          "endColumn": 12,
           "endLine": 4,
-          "startColumn": 7,
+          "startColumn": 8,
           "startLine": 4,
         },
       },
@@ -90,9 +90,9 @@ exports[`linter=ripgrep fixture=basic version=14.1.1 1`] = `
       "location": {
         "path": "basic.in.rs",
         "range": {
-          "endColumn": 11,
+          "endColumn": 12,
           "endLine": 2,
-          "startColumn": 7,
+          "startColumn": 8,
           "startLine": 2,
         },
       },
@@ -117,9 +117,9 @@ exports[`linter=ripgrep fixture=basic version=14.1.1 1`] = `
       "location": {
         "path": "basic.in.rs",
         "range": {
-          "endColumn": 17,
+          "endColumn": 18,
           "endLine": 3,
-          "startColumn": 13,
+          "startColumn": 14,
           "startLine": 3,
         },
       },

--- a/qlty-plugins/plugins/scripts/updateLinterVersions.ts
+++ b/qlty-plugins/plugins/scripts/updateLinterVersions.ts
@@ -42,12 +42,17 @@ const getLintersList = async (): Promise<string[]> => {
   try {
     const dirContents = await fs.promises.readdir(LINTERS_PATH);
     const folders = await Promise.all(
-      dirContents.filter(async (dirContent) => {
-        const linterPath = path.join(LINTERS_PATH, dirContent);
-        return (await fs.promises.stat(linterPath)).isDirectory();
+      dirContents.map((dirContent) => {
+        return (async () => {
+          const linterPath = path.join(LINTERS_PATH, dirContent);
+          const stat = await fs.promises.stat(linterPath);
+          if (stat.isDirectory()) {
+            return linterPath;
+          }
+        })();
       }),
     );
-    return folders;
+    return folders.filter((folder) => folder !== undefined);
   } catch (err) {
     throw new Error(`Failed to read linters directory: ${err}`);
   }

--- a/qlty-plugins/plugins/tests/runLinterTest.ts
+++ b/qlty-plugins/plugins/tests/runLinterTest.ts
@@ -40,7 +40,7 @@ export const getVersionsForTarget = (
     .map((file) => {
       const fileMatch = file.match(getSnapshotRegex(prefix));
 
-      if (fileMatch) {
+      if (fileMatch?.groups?.version) {
         matchExists = true;
         return fileMatch.groups?.version;
       }
@@ -85,7 +85,8 @@ export const getKnownGoodVersion = (dirname: string, linterName: string) => {
   );
 
   const plugin_toml = toml.parse(plugin_file);
-  return plugin_toml.plugins.definitions[linterName].known_good_version;
+  return plugin_toml.plugins.definitions[linterName]
+    .known_good_version as string;
 };
 
 const getSnapshotRegex = (prefix: string) =>

--- a/qlty-plugins/plugins/tests/utils.ts
+++ b/qlty-plugins/plugins/tests/utils.ts
@@ -32,7 +32,7 @@ export const OPTIONS: EnvOptions = {
   ),
 };
 
-const extractStructure = (obj: any): Record<string, unknown> => {
+const extractStructure = (obj: object): Record<string, unknown> => {
   const structure: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
     if (typeof value === "object" && value !== null) {
@@ -48,7 +48,7 @@ const extractStructure = (obj: any): Record<string, unknown> => {
   return structure;
 };
 
-export const serializeStructure = (obj: any) => {
+export const serializeStructure = (obj: object) => {
   const structure = extractStructure(obj);
   return JSON.stringify(structure, undefined, 2);
 };


### PR DESCRIPTION
Ripgrep uses 0-indexed column values which is not used by other linter output