### PR TITLE
Improvements to kube-linter plugin

### DIFF
--- a/qlty-plugins/plugins/linters/kube-linter/plugin.toml
+++ b/qlty-plugins/plugins/linters/kube-linter/plugin.toml
@@ -46,3 +46,4 @@ output = "stdout"
 output_format = "sarif"
 output_category = "vulnerability"
 output_level = "medium"
+missing_output_as_error = true

--- a/qlty-plugins/plugins/linters/kube-linter/plugin.toml
+++ b/qlty-plugins/plugins/linters/kube-linter/plugin.toml
@@ -47,3 +47,4 @@ output_format = "sarif"
 output_category = "vulnerability"
 output_level = "medium"
 missing_output_as_error = true
+target = { type = "literal", path = "." }


### PR DESCRIPTION
- Lint the entire directory all at once
- If kube-linter exits with a "success" exit code but no stdout, treat it as a Lint Error rather than invoking the parser (which would crash due to trying to parse a blank string)