### PR TITLE
Support workspace tokens by inferring and appending project name to token

### DIFF
--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -218,6 +218,9 @@ impl Publish {
     /// Appends repository name to token if it is a workspace token
     fn expand_token(&self, token: String) -> Result<String> {
         if token.starts_with(COVERAGE_TOKEN_WORKSPACE_PREFIX) {
+            if token.contains("/") {
+                return Ok(token);
+            }
             let project_name = if let Some(project_name) = &self.project_name {
                 project_name.clone()
             } else if let Some(repository) = self.find_repository_name_from_env() {
@@ -333,6 +336,13 @@ mod tests {
         let token = publish(None).expand_token("qltcw_123".to_string())?;
         assert_eq!(token, "qltcw_123/b");
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_expand_token_already_expanded() -> Result<()> {
+        let token = publish(Some("test")).expand_token("qltcw_123/abc".to_string())?;
+        assert_eq!(token, "qltcw_123/abc");
         Ok(())
     }
 }

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -259,7 +259,7 @@ impl Publish {
         value
             .split('/')
             .last()
-            .map(|s| s.to_string())
+            .map(|s| s.strip_suffix(".git").unwrap_or(s).to_string())
             .take_if(|v| !v.is_empty())
     }
 
@@ -326,9 +326,13 @@ mod tests {
         let token = publish(None).expand_token("qltcw_123".to_string())?;
         assert_eq!(token, "qltcw_123/qlty");
 
-        std::env::set_var("GITHUB_REPOSITORY", "a/b");
+        std::env::set_var("GITHUB_REPOSITORY", "a/b.git");
         let token = publish(None).expand_token("qltcw_123".to_string())?;
         assert_eq!(token, "qltcw_123/b");
+
+        std::env::set_var("GITHUB_REPOSITORY", "b/c");
+        let token = publish(None).expand_token("qltcw_123".to_string())?;
+        assert_eq!(token, "qltcw_123/c");
 
         Ok(())
     }

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -272,15 +272,9 @@ impl Publish {
     }
 
     fn load_config() -> QltyConfig {
-        if let Ok(workspace) = Workspace::new() {
-            if let Ok(cfg) = workspace.config() {
-                cfg
-            } else {
-                QltyConfig::default()
-            }
-        } else {
-            QltyConfig::default()
-        }
+        Workspace::new()
+            .and_then(|workspace| workspace.config())
+            .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
Also support `--project-name` when it cannot be inferred by env/repo.

Lookup for project name is:

1. GITHUB_REPOSITORY
2. The last path component of the origin remote url in the active git repository

Note that workspace tokens can currently be specified by providing `--token qltcw_SOME_TOKEN/project_name` manually and this will continue to work, we just add `--project-name` for a more discoverable approach since the token format might be obfuscated (and not well documented).
