### PR TITLE
Upgrade version of ruby from 3.3.0 => 3.3.7 (Do not merge)

### DIFF
--- a/.github/workflows/cli_integration.yml
+++ b/.github/workflows/cli_integration.yml
@@ -62,9 +62,9 @@ jobs:
       matrix:
         container: [
             "ubuntu:24.04",
-            "redhat/ubi9",
+            #"redhat/ubi9",
             "debian:trixie-slim",
-            "debian:bookworm-slim",
+            #"debian:bookworm-slim",
             # unsupported:
             # "ubuntu:20.04",
             # "redhat/ubi8",
@@ -74,10 +74,10 @@ jobs:
             package_install: apt-get update && apt-get install -y git curl libyaml-dev libgmp-dev build-essential
           - container: debian:trixie-slim
             package_install: apt-get update && apt-get install -y git curl libyaml-dev libgmp-dev build-essential
-          - container: debian:bookworm-slim
-            package_install: apt-get update && apt-get install -y git curl libyaml-dev libgmp-dev build-essential
-          - container: redhat/ubi9
-            package_install: yum install -y git gcc make libyaml-devel gmp-devel
+          #- container: debian:bookworm-slim
+          #  package_install: apt-get update && apt-get install -y git curl libyaml-dev libgmp-dev build-essential
+          #- container: redhat/ubi9
+          #  package_install: yum install -y git gcc make libyaml-devel gmp-devel
           # unsupported:
           # - container: ubuntu:20.04
           #   package_install: apt-get update && apt-get install -y git curl libyaml-dev libgmp-dev build-essential

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.0
+          ruby-version: 3.3.7
         if: contains(matrix.os, 'windows')
 
       - name: Install Rust toolchain

--- a/qlty-check/src/tool/ruby/sys/macos.rs
+++ b/qlty-check/src/tool/ruby/sys/macos.rs
@@ -200,7 +200,7 @@ mod test {
                 "install_name_tool",
                 "-change",
                 format!(
-                    "/Users/runner/hostedtoolcache/Ruby/128.128.0/{}/lib/libruby.128.128.dylib",
+                    "/Users/runner/hostedtoolcache/Ruby/128.128.128/{}/lib/libruby.128.128.dylib",
                     ARCH
                 )
                 .as_str(),

--- a/qlty-check/src/tool/ruby/sys/macos.rs
+++ b/qlty-check/src/tool/ruby/sys/macos.rs
@@ -37,8 +37,10 @@ impl PlatformRuby for RubyMacos {
                 vec![
                     "-change",
                     format!(
-                        "/Users/runner/hostedtoolcache/Ruby/{}.0/{}/lib/libruby.{}.dylib",
-                        major_version, ARCH, major_version
+                        "/Users/runner/hostedtoolcache/Ruby/{}/{}/lib/libruby.{}.dylib",
+                        tool.version().unwrap_or_default(),
+                        ARCH,
+                        major_version
                     )
                     .as_str(),
                     join_path_string!(

--- a/qlty-check/src/tool/tool_builder.rs
+++ b/qlty-check/src/tool/tool_builder.rs
@@ -147,7 +147,7 @@ impl ToolBuilder<'_> {
             Runtime::Go => Some("1.22.0".to_owned()),
             Runtime::Node => Some("21.7.3".to_owned()),
             Runtime::Python => Some("3.11.7".to_owned()),
-            Runtime::Ruby => Some("3.3.0".to_owned()),
+            Runtime::Ruby => Some("3.3.7".to_owned()),
             Runtime::Rust => Some("1.77.2".to_owned()),
             Runtime::Java => Some("22.0.1+8".to_owned()),
             Runtime::Php => Some("8.3.7".to_owned()),


### PR DESCRIPTION
Currently the `reek` plugin is failing for customers. The stack trace for these customers looks like this:

```
2025-01-22T18:03:07Z INFO [T13] qlty_check::tool (47.8 MB): Setting up tool reek@Some("6.3.0"). Logging to /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3-install.log
2025-01-22T18:03:20Z ERROR [T13] qlty_check::tool (47.8 MB): Failed to get version for package "reek": Output { status: ExitStatus(unix_wait_status(256)), stdout: "", stderr: "<internal:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require': \n/home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/dry-types-1.8.1/lib/dry/types/sum.rb:33: anonymous block parameter is also used within block (SyntaxError)\n\tfrom <internal:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/zeitwerk-2.7.1/lib/zeitwerk/core_ext/kernel.rb:26:in `require'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/dry-types-1.8.1/lib/dry/types/builder.rb:28:in `|'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/dry-types-1.8.1/lib/dry/types/builder.rb:53:in `optional'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/dry-types-1.8.1/lib/dry/types/core.rb:79:in `block in <module:Types>'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/dry-types-1.8.1/lib/dry/types/core.rb:78:in `each_key'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/dry-types-1.8.1/lib/dry/types/core.rb:78:in `<module:Types>'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/dry-types-1.8.1/lib/dry/types/core.rb:4:in `<module:Dry>'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/dry-types-1.8.1/lib/dry/types/core.rb:3:in `<top (required)>'\n\tfrom <internal:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'\n\tfrom <internal:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/zeitwerk-2.7.1/lib/zeitwerk/core_ext/kernel.rb:34:in `require'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/dry-types-1.8.1/lib/dry/types.rb:258:in `<top (required)>'\n\tfrom <internal:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'\n\tfrom <internal:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/zeitwerk-2.7.1/lib/zeitwerk/core_ext/kernel.rb:34:in `require'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/dry-schema-1.13.4/lib/dry/schema.rb:8:in `<top (required)>'\n\tfrom <internal:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'\n\tfrom <internal:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek/configuration/schema.rb:3:in `<top (required)>'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek/configuration/schema_validator.rb:4:in `require_relative'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek/configuration/schema_validator.rb:4:in `<top (required)>'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek/configuration/configuration_file_finder.rb:5:in `require_relative'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek/configuration/configuration_file_finder.rb:5:in `<top (required)>'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek/configuration/app_configuration.rb:4:in `require_relative'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek/configuration/app_configuration.rb:4:in `<top (required)>'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek/detector_repository.rb:5:in `require_relative'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek/detector_repository.rb:5:in `<top (required)>'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek/examiner.rb:4:in `require_relative'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek/examiner.rb:4:in `<top (required)>'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek.rb:7:in `require_relative'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/lib/reek.rb:7:in `<top (required)>'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/bin/reek:9:in `require_relative'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/gems/reek-6.3.0/bin/reek:9:in `<top (required)>'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/bin/reek:25:in `load'\n\tfrom /home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/bin/reek:25:in `<main>'\n" } {"LD_LIBRARY_PATH": "/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib", "PKG_CONFIG_PATH": "/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/pkgconfig", "GEM_HOME": "/home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3", "HOME": "/home/runner", "PATH": "/home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3/bin:/home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin", "GEM_PATH": "/home/runner/.qlty/cache/tools/reek/6.3.0-fb49277b68e3", "RUBYLIB": "/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/site_ruby/3.3.0:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/site_ruby/3.3.0/x86_64-linux:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/site_ruby:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/vendor_ruby/3.3.0:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/vendor_ruby/3.3.0/x86_64-linux:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/vendor_ruby:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/3.3.0:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/3.3.0/x86_64-linux:/home/runner/.qlty/cache/tools/ruby/3.3.0-bbe397d161fc/lib/ruby/"}
2025-01-22T18:03:20Z ERROR [T13] qlty_check::tool (47.8 MB): Failed to set up reek@Some("6.3.0"): Failed to get version for package "reek": (command sh -c "reek --version" exited with code 1)
2025-01-22T18:03:20Z ERROR [T1] qlty (8.7 MB): Command failed: qlty build
❌ Error installing reek@6.3.0.
```

Initially this was very confusing since there were no CLI upgrades between when it was working and when it suddenly stopped working ...

In digging into it, we discovered that:

- the reek gem [depends on dry-schema](https://github.com/troessner/reek/blob/master/reek.gemspec#L35)
- dry-schema [depends on dry-types](https://github.com/dry-rb/dry-schema/blob/main/dry-schema.gemspec#L44) version `~1.8`
- dry-types recently [upgraded to 1.8.1 from 1.8.0](https://github.com/dry-rb/dry-types/releases/tag/v1.8.1)

Because of the dependency chain, this upgrade was picked up and changed the behavior of the plugin.

The upgrade apparently [exposed a bug](https://bugs.ruby-lang.org/issues/20090) in Ruby 3.3.0 that it previously hadn't run into. (h/t https://github.com/dry-rb/dry-system/issues/284#issuecomment-2596526150).

This PR bumps the version of ruby to the latest on the 3.3.x line (`3.3.7`). 

However, I'm currently unable to install this locally via qlty and cannot verify that it does indeed fix the bug. `Reek` runs tests on 3.3.6, so that is also a fairly safe alternative (bug also does not install locally for me).