### PR TITLE
Fix path target mode when used in subdirectory 

### DIFF
--- a/qlty-analysis/src/workspace_entries/workspace_entry_finder_builder.rs
+++ b/qlty-analysis/src/workspace_entries/workspace_entry_finder_builder.rs
@@ -55,7 +55,8 @@ impl WorkspaceEntryFinderBuilder {
             TargetMode::All => Ok(Arc::new(AllSource::new(self.root.clone()))),
             TargetMode::Paths(_) => Ok(Arc::new(ArgsSource::new(
                 self.root.clone(),
-                self.paths.clone(),
+                // Use absolute paths, so when running in a subdirectory, the paths are still correct
+                self.paths.iter().map(|p| self.root.join(p)).collect(),
             ))),
             TargetMode::UpstreamDiff(_) => Ok(Arc::new(DiffSource::new(
                 self.git_diff()?.changed_files,

--- a/qlty-check/src/planner/plugin_workspace_entry_finder_builder.rs
+++ b/qlty-check/src/planner/plugin_workspace_entry_finder_builder.rs
@@ -47,9 +47,11 @@ impl PluginWorkspaceEntryFinderBuilder {
                 TargetMode::All | TargetMode::Sample(_) => {
                     Arc::new(AllSource::new(self.root.clone()))
                 }
-                TargetMode::Paths(_) => {
-                    Arc::new(ArgsSource::new(self.root.clone(), self.paths.clone()))
-                }
+                TargetMode::Paths(_) => Arc::new(ArgsSource::new(
+                    self.root.clone(),
+                    // Use absolute paths, so when running in a subdirectory, the paths are still correct
+                    self.paths.iter().map(|p| self.root.join(p)).collect(),
+                )),
                 TargetMode::UpstreamDiff(_) => {
                     Arc::new(DiffSource::new(self.git_diff()?.changed_files, &self.root))
                 }


### PR DESCRIPTION
Right now if you apply a formatting change bubbled up from `qlty check` command while in a sub directory, the application fails with an `Result::unwrap() on an Err value`.

The root of that issue lies in the fact that when you apply the format this way, formatter is run with only selected file paths (which are project root relative and not relative to cwd) and TargetMode is set to Path when that happens. Instead of normalizing relative paths based on cwd I think just using absoluete paths is a better approach and less likely to cause any issues.
