### PR TITLE
Support SemaphoreCI environment variables for auto-detection of coverage upload metadata

### DIFF
--- a/qlty-coverage/src/ci.rs
+++ b/qlty-coverage/src/ci.rs
@@ -2,11 +2,13 @@ mod circleci;
 mod codefresh;
 mod github;
 mod gitlab;
+mod semaphore;
 
 pub use circleci::CircleCI;
 pub use codefresh::Codefresh;
 pub use github::GitHub;
 pub use gitlab::GitLab;
+pub use semaphore::Semaphore;
 use qlty_types::tests::v1::CoverageMetadata;
 
 pub trait CI {
@@ -63,5 +65,6 @@ pub fn all() -> Vec<Box<dyn CI>> {
         Box::<GitLab>::default(),
         Box::<CircleCI>::default(),
         Box::<Codefresh>::default(),
+        Box::<Semaphore>::default(),
     ]
 }

--- a/qlty-coverage/src/ci.rs
+++ b/qlty-coverage/src/ci.rs
@@ -8,8 +8,8 @@ pub use circleci::CircleCI;
 pub use codefresh::Codefresh;
 pub use github::GitHub;
 pub use gitlab::GitLab;
-pub use semaphore::Semaphore;
 use qlty_types::tests::v1::CoverageMetadata;
+pub use semaphore::Semaphore;
 
 pub trait CI {
     fn detect(&self) -> bool;

--- a/qlty-coverage/src/ci/semaphore.rs
+++ b/qlty-coverage/src/ci/semaphore.rs
@@ -1,0 +1,227 @@
+use crate::{
+  ci::CI,
+  env::{EnvSource, SystemEnv},
+};
+
+#[derive(Debug)]
+pub struct Semaphore {
+  env: Box<dyn EnvSource>,
+}
+
+impl Default for Semaphore {
+  fn default() -> Self {
+      Self {
+          env: Box::<SystemEnv>::default(),
+      }
+  }
+}
+
+impl CI for Semaphore {
+  fn detect(&self) -> bool {
+      self.env.var("SEMAPHORE").unwrap_or_default() == "true"
+  }
+
+  fn ci_name(&self) -> String {
+      "Semaphore".to_string()
+  }
+
+  fn ci_url(&self) -> String {
+      self.env.var("SEMAPHORE_ORGANIZATION_URL").unwrap_or_default()
+  }
+
+  fn branch(&self) -> String {
+      self.env.var("SEMAPHORE_GIT_BRANCH").unwrap_or_default()
+  }
+
+  fn workflow(&self) -> String {
+      self.env.var("SEMAPHORE_WORKFLOW_ID").unwrap_or_default()
+  }
+
+  fn job(&self) -> String {
+      self.env.var("SEMAPHORE_JOB_NAME").unwrap_or_default()
+  }
+
+  fn build_id(&self) -> String {
+      self.env.var("SEMAPHORE_JOB_ID").unwrap_or_default()
+  }
+
+  fn build_url(&self) -> String {
+      format!("{}/jobs/{}", self.ci_url().to_string(), self.build_id().to_string())
+  }
+
+  fn pull_number(&self) -> String {
+    self.env.var("SEMAPHORE_GIT_PR_NUMBER").unwrap_or_default()
+  }
+
+  fn repository_name(&self) -> String {
+      self.env.var("SEMAPHORE_GIT_REPO_NAME").unwrap_or_default()
+  }
+
+  fn repository_url(&self) -> String {
+      self.env.var("SEMAPHORE_GIT_URL").unwrap_or_default()
+  }
+
+  fn pull_url(&self) -> String {
+      // Semaphore doesn't expose a pull url
+      "".to_string()
+  }
+
+  fn commit_sha(&self) -> String {
+      self.env.var("SEMAPHORE_GIT_SHA").unwrap_or_default()
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use std::collections::HashMap;
+
+  #[derive(Debug, Clone, Default)]
+  pub struct HashMapEnv {
+      inner: HashMap<String, String>,
+  }
+
+  impl HashMapEnv {
+      pub fn new(env: HashMap<String, String>) -> Self {
+          Self { inner: env }
+      }
+  }
+
+  impl EnvSource for HashMapEnv {
+      fn var(&self, name: &str) -> Option<String> {
+          self.inner.get(name).cloned()
+      }
+  }
+
+  #[test]
+  fn detect_ci() {
+      let ci: Semaphore = Semaphore {
+          env: Box::new(HashMapEnv::default()),
+      };
+      assert_eq!(ci.detect(), false);
+
+      let mut env: HashMap<String, String> = HashMap::default();
+      env.insert("SEMAPHORE".to_string(), "true".to_string());
+      let ci = Semaphore {
+          env: Box::new(HashMapEnv::new(env)),
+      };
+      assert_eq!(ci.detect(), true);
+      assert_eq!(&ci.ci_name(), "Semaphore");
+      assert_eq!(&ci.ci_url(), "");
+  }
+
+  #[test]
+  fn branch() {
+      let mut env: HashMap<String, String> = HashMap::default();
+      env.insert("SEMAPHORE_GIT_BRANCH".to_string(), "main".to_string());
+
+      let ci = Semaphore {
+          env: Box::new(HashMapEnv::new(env)),
+      };
+      assert_eq!(&ci.branch(), "main");
+  }
+
+  #[test]
+  fn workflow() {
+      let mut env: HashMap<String, String> = HashMap::default();
+      env.insert("SEMAPHORE_WORKFLOW_ID".to_string(), "workflow_id".to_string());
+
+      let ci = Semaphore {
+          env: Box::new(HashMapEnv::new(env)),
+      };
+      assert_eq!(&ci.workflow(), "workflow_id");
+  }
+
+  #[test]
+  fn job() {
+      let mut env: HashMap<String, String> = HashMap::default();
+      env.insert("SEMAPHORE_JOB_NAME".to_string(), "job_name".to_string());
+
+      let ci = Semaphore {
+          env: Box::new(HashMapEnv::new(env)),
+      };
+      assert_eq!(&ci.job(), "job_name");
+  }
+
+  #[test]
+  fn build_id() {
+      let mut env: HashMap<String, String> = HashMap::default();
+      env.insert("SEMAPHORE_JOB_ID".to_string(), "1234".to_string());
+
+      let ci = Semaphore {
+          env: Box::new(HashMapEnv::new(env)),
+      };
+      assert_eq!(&ci.build_id(), "1234");
+  }
+
+  #[test]
+  fn build_url() {
+      let mut env: HashMap<String, String> = HashMap::default();
+      env.insert(
+          "SEMAPHORE_JOB_ID".to_string(),
+          "1234".to_string(),
+      );
+      env.insert(
+          "SEMAPHORE_ORGANIZATION_URL".to_string(),
+          "http://example.semaphoreci.com".to_string(),
+      );
+
+      let ci = Semaphore {
+          env: Box::new(HashMapEnv::new(env)),
+      };
+      assert_eq!(&ci.build_url(), "http://example.semaphoreci.com/jobs/1234");
+  }
+
+  #[test]
+  fn pull_number() {
+      let mut env: HashMap<String, String> = HashMap::default();
+      env.insert(
+          "SEMAPHORE_GIT_PR_NUMBER".to_string(),
+          "42".to_string(),
+      );
+
+      let ci = Semaphore {
+          env: Box::new(HashMapEnv::new(env)),
+      };
+      assert_eq!(&ci.pull_number(), "42");
+  }
+
+  #[test]
+  fn repository_name() {
+      let mut env: HashMap<String, String> = HashMap::default();
+      env.insert(
+          "SEMAPHORE_GIT_REPO_NAME".to_string(),
+          "repo_name".to_string(),
+      );
+
+      let ci = Semaphore {
+          env: Box::new(HashMapEnv::new(env)),
+      };
+      assert_eq!(&ci.repository_name(), "repo_name");
+  }
+
+  #[test]
+  fn repository_url() {
+      let mut env: HashMap<String, String> = HashMap::default();
+      env.insert(
+          "SEMAPHORE_GIT_URL".to_string(),
+          "https://github.com/user/repo".to_string(),
+      );
+
+      let ci = Semaphore {
+          env: Box::new(HashMapEnv::new(env)),
+      };
+      assert_eq!(&ci.repository_url(), "https://github.com/user/repo");
+  }
+
+  #[test]
+  fn commit_sha() {
+      let mut env: HashMap<String, String> = HashMap::default();
+      env.insert("SEMAPHORE_GIT_SHA".to_string(), "abc123".to_string());
+
+      let ci = Semaphore {
+          env: Box::new(HashMapEnv::new(env)),
+      };
+      assert_eq!(&ci.commit_sha(), "abc123");
+  }
+}

--- a/qlty-coverage/src/ci/semaphore.rs
+++ b/qlty-coverage/src/ci/semaphore.rs
@@ -48,11 +48,7 @@ impl CI for Semaphore {
     }
 
     fn build_url(&self) -> String {
-        format!(
-            "{}/jobs/{}",
-            self.ci_url(),
-            self.build_id()
-        )
+        format!("{}/jobs/{}", self.ci_url(), self.build_id())
     }
 
     fn pull_number(&self) -> String {

--- a/qlty-coverage/src/ci/semaphore.rs
+++ b/qlty-coverage/src/ci/semaphore.rs
@@ -50,8 +50,8 @@ impl CI for Semaphore {
     fn build_url(&self) -> String {
         format!(
             "{}/jobs/{}",
-            self.ci_url().to_string(),
-            self.build_id().to_string()
+            self.ci_url(),
+            self.build_id()
         )
     }
 

--- a/qlty-coverage/src/ci/semaphore.rs
+++ b/qlty-coverage/src/ci/semaphore.rs
@@ -1,227 +1,230 @@
 use crate::{
-  ci::CI,
-  env::{EnvSource, SystemEnv},
+    ci::CI,
+    env::{EnvSource, SystemEnv},
 };
 
 #[derive(Debug)]
 pub struct Semaphore {
-  env: Box<dyn EnvSource>,
+    env: Box<dyn EnvSource>,
 }
 
 impl Default for Semaphore {
-  fn default() -> Self {
-      Self {
-          env: Box::<SystemEnv>::default(),
-      }
-  }
+    fn default() -> Self {
+        Self {
+            env: Box::<SystemEnv>::default(),
+        }
+    }
 }
 
 impl CI for Semaphore {
-  fn detect(&self) -> bool {
-      self.env.var("SEMAPHORE").unwrap_or_default() == "true"
-  }
+    fn detect(&self) -> bool {
+        self.env.var("SEMAPHORE").unwrap_or_default() == "true"
+    }
 
-  fn ci_name(&self) -> String {
-      "Semaphore".to_string()
-  }
+    fn ci_name(&self) -> String {
+        "Semaphore".to_string()
+    }
 
-  fn ci_url(&self) -> String {
-      self.env.var("SEMAPHORE_ORGANIZATION_URL").unwrap_or_default()
-  }
+    fn ci_url(&self) -> String {
+        self.env
+            .var("SEMAPHORE_ORGANIZATION_URL")
+            .unwrap_or_default()
+    }
 
-  fn branch(&self) -> String {
-      self.env.var("SEMAPHORE_GIT_BRANCH").unwrap_or_default()
-  }
+    fn branch(&self) -> String {
+        self.env.var("SEMAPHORE_GIT_BRANCH").unwrap_or_default()
+    }
 
-  fn workflow(&self) -> String {
-      self.env.var("SEMAPHORE_WORKFLOW_ID").unwrap_or_default()
-  }
+    fn workflow(&self) -> String {
+        self.env.var("SEMAPHORE_WORKFLOW_ID").unwrap_or_default()
+    }
 
-  fn job(&self) -> String {
-      self.env.var("SEMAPHORE_JOB_NAME").unwrap_or_default()
-  }
+    fn job(&self) -> String {
+        self.env.var("SEMAPHORE_JOB_NAME").unwrap_or_default()
+    }
 
-  fn build_id(&self) -> String {
-      self.env.var("SEMAPHORE_JOB_ID").unwrap_or_default()
-  }
+    fn build_id(&self) -> String {
+        self.env.var("SEMAPHORE_JOB_ID").unwrap_or_default()
+    }
 
-  fn build_url(&self) -> String {
-      format!("{}/jobs/{}", self.ci_url().to_string(), self.build_id().to_string())
-  }
+    fn build_url(&self) -> String {
+        format!(
+            "{}/jobs/{}",
+            self.ci_url().to_string(),
+            self.build_id().to_string()
+        )
+    }
 
-  fn pull_number(&self) -> String {
-    self.env.var("SEMAPHORE_GIT_PR_NUMBER").unwrap_or_default()
-  }
+    fn pull_number(&self) -> String {
+        self.env.var("SEMAPHORE_GIT_PR_NUMBER").unwrap_or_default()
+    }
 
-  fn repository_name(&self) -> String {
-      self.env.var("SEMAPHORE_GIT_REPO_NAME").unwrap_or_default()
-  }
+    fn repository_name(&self) -> String {
+        self.env.var("SEMAPHORE_GIT_REPO_NAME").unwrap_or_default()
+    }
 
-  fn repository_url(&self) -> String {
-      self.env.var("SEMAPHORE_GIT_URL").unwrap_or_default()
-  }
+    fn repository_url(&self) -> String {
+        self.env.var("SEMAPHORE_GIT_URL").unwrap_or_default()
+    }
 
-  fn pull_url(&self) -> String {
-      // Semaphore doesn't expose a pull url
-      "".to_string()
-  }
+    fn pull_url(&self) -> String {
+        // Semaphore doesn't expose a pull url
+        "".to_string()
+    }
 
-  fn commit_sha(&self) -> String {
-      self.env.var("SEMAPHORE_GIT_SHA").unwrap_or_default()
-  }
+    fn commit_sha(&self) -> String {
+        self.env.var("SEMAPHORE_GIT_SHA").unwrap_or_default()
+    }
 }
 
 #[cfg(test)]
 mod test {
-  use super::*;
-  use std::collections::HashMap;
+    use super::*;
+    use std::collections::HashMap;
 
-  #[derive(Debug, Clone, Default)]
-  pub struct HashMapEnv {
-      inner: HashMap<String, String>,
-  }
+    #[derive(Debug, Clone, Default)]
+    pub struct HashMapEnv {
+        inner: HashMap<String, String>,
+    }
 
-  impl HashMapEnv {
-      pub fn new(env: HashMap<String, String>) -> Self {
-          Self { inner: env }
-      }
-  }
+    impl HashMapEnv {
+        pub fn new(env: HashMap<String, String>) -> Self {
+            Self { inner: env }
+        }
+    }
 
-  impl EnvSource for HashMapEnv {
-      fn var(&self, name: &str) -> Option<String> {
-          self.inner.get(name).cloned()
-      }
-  }
+    impl EnvSource for HashMapEnv {
+        fn var(&self, name: &str) -> Option<String> {
+            self.inner.get(name).cloned()
+        }
+    }
 
-  #[test]
-  fn detect_ci() {
-      let ci: Semaphore = Semaphore {
-          env: Box::new(HashMapEnv::default()),
-      };
-      assert_eq!(ci.detect(), false);
+    #[test]
+    fn detect_ci() {
+        let ci: Semaphore = Semaphore {
+            env: Box::new(HashMapEnv::default()),
+        };
+        assert_eq!(ci.detect(), false);
 
-      let mut env: HashMap<String, String> = HashMap::default();
-      env.insert("SEMAPHORE".to_string(), "true".to_string());
-      let ci = Semaphore {
-          env: Box::new(HashMapEnv::new(env)),
-      };
-      assert_eq!(ci.detect(), true);
-      assert_eq!(&ci.ci_name(), "Semaphore");
-      assert_eq!(&ci.ci_url(), "");
-  }
+        let mut env: HashMap<String, String> = HashMap::default();
+        env.insert("SEMAPHORE".to_string(), "true".to_string());
+        let ci = Semaphore {
+            env: Box::new(HashMapEnv::new(env)),
+        };
+        assert_eq!(ci.detect(), true);
+        assert_eq!(&ci.ci_name(), "Semaphore");
+        assert_eq!(&ci.ci_url(), "");
+    }
 
-  #[test]
-  fn branch() {
-      let mut env: HashMap<String, String> = HashMap::default();
-      env.insert("SEMAPHORE_GIT_BRANCH".to_string(), "main".to_string());
+    #[test]
+    fn branch() {
+        let mut env: HashMap<String, String> = HashMap::default();
+        env.insert("SEMAPHORE_GIT_BRANCH".to_string(), "main".to_string());
 
-      let ci = Semaphore {
-          env: Box::new(HashMapEnv::new(env)),
-      };
-      assert_eq!(&ci.branch(), "main");
-  }
+        let ci = Semaphore {
+            env: Box::new(HashMapEnv::new(env)),
+        };
+        assert_eq!(&ci.branch(), "main");
+    }
 
-  #[test]
-  fn workflow() {
-      let mut env: HashMap<String, String> = HashMap::default();
-      env.insert("SEMAPHORE_WORKFLOW_ID".to_string(), "workflow_id".to_string());
+    #[test]
+    fn workflow() {
+        let mut env: HashMap<String, String> = HashMap::default();
+        env.insert(
+            "SEMAPHORE_WORKFLOW_ID".to_string(),
+            "workflow_id".to_string(),
+        );
 
-      let ci = Semaphore {
-          env: Box::new(HashMapEnv::new(env)),
-      };
-      assert_eq!(&ci.workflow(), "workflow_id");
-  }
+        let ci = Semaphore {
+            env: Box::new(HashMapEnv::new(env)),
+        };
+        assert_eq!(&ci.workflow(), "workflow_id");
+    }
 
-  #[test]
-  fn job() {
-      let mut env: HashMap<String, String> = HashMap::default();
-      env.insert("SEMAPHORE_JOB_NAME".to_string(), "job_name".to_string());
+    #[test]
+    fn job() {
+        let mut env: HashMap<String, String> = HashMap::default();
+        env.insert("SEMAPHORE_JOB_NAME".to_string(), "job_name".to_string());
 
-      let ci = Semaphore {
-          env: Box::new(HashMapEnv::new(env)),
-      };
-      assert_eq!(&ci.job(), "job_name");
-  }
+        let ci = Semaphore {
+            env: Box::new(HashMapEnv::new(env)),
+        };
+        assert_eq!(&ci.job(), "job_name");
+    }
 
-  #[test]
-  fn build_id() {
-      let mut env: HashMap<String, String> = HashMap::default();
-      env.insert("SEMAPHORE_JOB_ID".to_string(), "1234".to_string());
+    #[test]
+    fn build_id() {
+        let mut env: HashMap<String, String> = HashMap::default();
+        env.insert("SEMAPHORE_JOB_ID".to_string(), "1234".to_string());
 
-      let ci = Semaphore {
-          env: Box::new(HashMapEnv::new(env)),
-      };
-      assert_eq!(&ci.build_id(), "1234");
-  }
+        let ci = Semaphore {
+            env: Box::new(HashMapEnv::new(env)),
+        };
+        assert_eq!(&ci.build_id(), "1234");
+    }
 
-  #[test]
-  fn build_url() {
-      let mut env: HashMap<String, String> = HashMap::default();
-      env.insert(
-          "SEMAPHORE_JOB_ID".to_string(),
-          "1234".to_string(),
-      );
-      env.insert(
-          "SEMAPHORE_ORGANIZATION_URL".to_string(),
-          "http://example.semaphoreci.com".to_string(),
-      );
+    #[test]
+    fn build_url() {
+        let mut env: HashMap<String, String> = HashMap::default();
+        env.insert("SEMAPHORE_JOB_ID".to_string(), "1234".to_string());
+        env.insert(
+            "SEMAPHORE_ORGANIZATION_URL".to_string(),
+            "http://example.semaphoreci.com".to_string(),
+        );
 
-      let ci = Semaphore {
-          env: Box::new(HashMapEnv::new(env)),
-      };
-      assert_eq!(&ci.build_url(), "http://example.semaphoreci.com/jobs/1234");
-  }
+        let ci = Semaphore {
+            env: Box::new(HashMapEnv::new(env)),
+        };
+        assert_eq!(&ci.build_url(), "http://example.semaphoreci.com/jobs/1234");
+    }
 
-  #[test]
-  fn pull_number() {
-      let mut env: HashMap<String, String> = HashMap::default();
-      env.insert(
-          "SEMAPHORE_GIT_PR_NUMBER".to_string(),
-          "42".to_string(),
-      );
+    #[test]
+    fn pull_number() {
+        let mut env: HashMap<String, String> = HashMap::default();
+        env.insert("SEMAPHORE_GIT_PR_NUMBER".to_string(), "42".to_string());
 
-      let ci = Semaphore {
-          env: Box::new(HashMapEnv::new(env)),
-      };
-      assert_eq!(&ci.pull_number(), "42");
-  }
+        let ci = Semaphore {
+            env: Box::new(HashMapEnv::new(env)),
+        };
+        assert_eq!(&ci.pull_number(), "42");
+    }
 
-  #[test]
-  fn repository_name() {
-      let mut env: HashMap<String, String> = HashMap::default();
-      env.insert(
-          "SEMAPHORE_GIT_REPO_NAME".to_string(),
-          "repo_name".to_string(),
-      );
+    #[test]
+    fn repository_name() {
+        let mut env: HashMap<String, String> = HashMap::default();
+        env.insert(
+            "SEMAPHORE_GIT_REPO_NAME".to_string(),
+            "repo_name".to_string(),
+        );
 
-      let ci = Semaphore {
-          env: Box::new(HashMapEnv::new(env)),
-      };
-      assert_eq!(&ci.repository_name(), "repo_name");
-  }
+        let ci = Semaphore {
+            env: Box::new(HashMapEnv::new(env)),
+        };
+        assert_eq!(&ci.repository_name(), "repo_name");
+    }
 
-  #[test]
-  fn repository_url() {
-      let mut env: HashMap<String, String> = HashMap::default();
-      env.insert(
-          "SEMAPHORE_GIT_URL".to_string(),
-          "https://github.com/user/repo".to_string(),
-      );
+    #[test]
+    fn repository_url() {
+        let mut env: HashMap<String, String> = HashMap::default();
+        env.insert(
+            "SEMAPHORE_GIT_URL".to_string(),
+            "https://github.com/user/repo".to_string(),
+        );
 
-      let ci = Semaphore {
-          env: Box::new(HashMapEnv::new(env)),
-      };
-      assert_eq!(&ci.repository_url(), "https://github.com/user/repo");
-  }
+        let ci = Semaphore {
+            env: Box::new(HashMapEnv::new(env)),
+        };
+        assert_eq!(&ci.repository_url(), "https://github.com/user/repo");
+    }
 
-  #[test]
-  fn commit_sha() {
-      let mut env: HashMap<String, String> = HashMap::default();
-      env.insert("SEMAPHORE_GIT_SHA".to_string(), "abc123".to_string());
+    #[test]
+    fn commit_sha() {
+        let mut env: HashMap<String, String> = HashMap::default();
+        env.insert("SEMAPHORE_GIT_SHA".to_string(), "abc123".to_string());
 
-      let ci = Semaphore {
-          env: Box::new(HashMapEnv::new(env)),
-      };
-      assert_eq!(&ci.commit_sha(), "abc123");
-  }
+        let ci = Semaphore {
+            env: Box::new(HashMapEnv::new(env)),
+        };
+        assert_eq!(&ci.commit_sha(), "abc123");
+    }
 }


### PR DESCRIPTION
Adds recognition of Semaphore environment variables so that when running `qlty coverage publish` from within a Semaphore environment, users do not have to specify `--override-*` command line arguments (instead those values are taken from the detected environment variables).