### PR TITLE
Copy phpstan config into tool dir

### DIFF
--- a/qlty-check/src/executor/invocation_script.rs
+++ b/qlty-check/src/executor/invocation_script.rs
@@ -17,6 +17,7 @@ pub fn compute_invocation_script(plan: &InvocationPlan) -> Result<String> {
 
     // Autoload script first in case it has variables that need to be interpolated
     base_script = replace_autoload_script(plan, base_script);
+    base_script = replace_config_script(plan, base_script);
     base_script = plan.tool.interpolate_variables(&base_script);
     base_script = replace_target_variable(plan, base_script);
     base_script = replace_tmpfile_variable(plan, base_script);
@@ -33,6 +34,19 @@ fn replace_autoload_script(plan: &InvocationPlan, script: String) -> String {
             script.replace("${autoload_script}", autoload_script)
         } else {
             script.replace("${autoload_script}", "")
+        }
+    } else {
+        script
+    }
+}
+
+fn replace_config_script(plan: &InvocationPlan, script: String) -> String {
+    if script.contains("${config_script}") {
+        if plan.plugin_configs.len() > 0 {
+            let config_script = plan.driver.config_script.as_deref().unwrap_or("");
+            script.replace("${config_script}", config_script)
+        } else {
+            script.replace("${config_script}", "")
         }
     } else {
         script

--- a/qlty-check/src/executor/invocation_script.rs
+++ b/qlty-check/src/executor/invocation_script.rs
@@ -42,7 +42,7 @@ fn replace_autoload_script(plan: &InvocationPlan, script: String) -> String {
 
 fn replace_config_script(plan: &InvocationPlan, script: String) -> String {
     if script.contains("${config_script}") {
-        if plan.plugin_configs.len() > 0 {
+        if !plan.plugin_configs.is_empty() {
             let config_script = plan.driver.config_script.as_deref().unwrap_or("");
             script.replace("${config_script}", config_script)
         } else {

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -115,6 +115,9 @@ pub struct DriverDef {
 
     #[serde(default)]
     pub autoload_script: Option<String>,
+
+    #[serde(default)]
+    pub config_script: Option<String>,
 }
 
 fn default_driver_timeout() -> u64 {

--- a/qlty-plugins/plugins/linters/phpstan/plugin.toml
+++ b/qlty-plugins/plugins/linters/phpstan/plugin.toml
@@ -12,8 +12,9 @@ description = "PHP code linter"
 suggested = "targets"
 
 [plugins.definitions.phpstan.drivers.lint]
-script = "php -d memory_limit=-1 ${linter}/phpstan analyze ${target} --error-format=json --level=9 ${autoload_script} --configuration=${config_file}"
+script = "php -d memory_limit=-1 ${linter}/phpstan analyze ${target} --error-format=json --level=9 ${autoload_script} ${config_script}"
 autoload_script = "--autoload-file=${linter}/vendor/autoload.php"
+config_script = "--configuration=${config_file}"
 success_codes = [0, 1]
 output = "stdout"
 output_format = "phpstan"

--- a/qlty-plugins/plugins/linters/phpstan/plugin.toml
+++ b/qlty-plugins/plugins/linters/phpstan/plugin.toml
@@ -12,7 +12,7 @@ description = "PHP code linter"
 suggested = "targets"
 
 [plugins.definitions.phpstan.drivers.lint]
-script = "php -d memory_limit=-1 ${linter}/phpstan analyze ${target} --error-format=json --level=9 ${autoload_script}"
+script = "php -d memory_limit=-1 ${linter}/phpstan analyze ${target} --error-format=json --level=9 ${autoload_script} --configuration=${config_file}"
 autoload_script = "--autoload-file=${linter}/vendor/autoload.php"
 success_codes = [0, 1]
 output = "stdout"
@@ -21,3 +21,4 @@ cache_results = true
 batch = true
 suggested = "targets"
 output_missing = "parse"
+copy_configs_into_tool_install = true


### PR DESCRIPTION
Similar to eslint, phpstan config files also load dependencies relative to config file path, so we should copy the phpstan configs into tool directory where we install the packages.