### PR TITLE
Fix behavior of ignores

### DIFF
--- a/qlty-check/src/planner/plugin_workspace_entry_finder_builder.rs
+++ b/qlty-check/src/planner/plugin_workspace_entry_finder_builder.rs
@@ -105,8 +105,13 @@ impl PluginWorkspaceEntryFinderBuilder {
             )));
         }
 
-        let ignores = self
+        let ignores_without_metadata = self
             .ignores
+            .iter()
+            .filter(|i| i.plugins.is_empty() && i.rules.is_empty() && i.levels.is_empty())
+            .collect::<Vec<_>>();
+
+        let ignores = ignores_without_metadata
             .iter()
             .flat_map(|i| i.file_patterns.clone())
             .collect::<Vec<_>>();


### PR DESCRIPTION
The `Ignore` struct is being used for two entirely different purposes. First, it is used for `exclude_patterns` which filter files out of analysis. Also, it is used for post-processing, to suppress specific issues based on plugin/rule/level filtering.

These two usages have come together in an emergent behavior with a pretty bad bug -- If you have an `[[ignore]]` block without a `file_patterns` specifier, it will exclude all files from all analysis.

To fix this properly, this will require some data re-architecture and more tests, but want to get a hotfix out right away.