### PR TITLE
tool(ruby): fix macos identification of arch with non-standard version numbering

### DIFF
--- a/qlty-check/src/tool/ruby.rs
+++ b/qlty-check/src/tool/ruby.rs
@@ -53,7 +53,7 @@ pub trait PlatformRuby {
                         let mut major_version = major_version.clone();
                         let entries_path = join_path_string!(&lib_prefix, dir);
                         if let Ok(entries) = read_dir(entries_path) {
-                            for entry in entries.flatten() {
+                            for entry in entries.flatten().filter(|entry| entry.path().is_dir()) {
                                 if path_to_string(entry.file_name()).starts_with(&major_version) {
                                     major_version = path_to_string(entry.file_name());
                                     break;


### PR DESCRIPTION
Small fix to ensure that arch is correctly extracted when version number path is parsed differently from version string (#1497)