### PR TITLE
Treat missing phpstan output as error

### DIFF
--- a/qlty-plugins/plugins/linters/phpstan/plugin.toml
+++ b/qlty-plugins/plugins/linters/phpstan/plugin.toml
@@ -21,5 +21,5 @@ output_format = "phpstan"
 cache_results = true
 batch = true
 suggested = "targets"
-output_missing = "parse"
+output_missing = "error"
 copy_configs_into_tool_install = true


### PR DESCRIPTION
In some cases, phpstan will exit with code 1. From the docs, it is a bit unclear, but I believe that phpstan uses exit code 1 also to mean "issues found".

The problem is that if phpstan crashes, it exits with code 1, but does not produce any output on stdout. Prior to this PR, we would consider this to be a _successful_ lint invocation and then hand an empty string to the parser which would raise an EOF error. After this PR, if phpstan produces no stdout, we consider that to be a _lint_ phase error and we will not move to the parser.

In terms of outcome, it is the same -- Either behavior results in an error. However, in the case of a Lint Error, we will print the warnings and errors from stderr to the terminal, whereas in the case of a Parse Error we do not. So specifying the `output_missing = "error"` behavior in this case increases that clarity of phpstan errors for customers.