### PR TITLE
Disable logging from log crate as it only applies to external libs

### DIFF
--- a/qlty-cli/src/logging.rs
+++ b/qlty-cli/src/logging.rs
@@ -138,7 +138,7 @@ pub fn init_logs(repository_path: Option<PathBuf>) -> Vec<WorkerGuard> {
         .expect("Could not set global default logger");
 
     if std::env::var("QLTY_LOG").unwrap_or_default().to_lowercase() != "trace" {
-        // disable all log crate logging below trace (external libs)
+        // disable all log crate logging (external libs)
         log::set_max_level(::log::LevelFilter::Off);
     }
 

--- a/qlty-cli/src/logging.rs
+++ b/qlty-cli/src/logging.rs
@@ -136,6 +136,12 @@ pub fn init_logs(repository_path: Option<PathBuf>) -> Vec<WorkerGuard> {
         .with(layers)
         .try_init()
         .expect("Could not set global default logger");
+
+    if std::env::var("QLTY_LOG").unwrap_or_default().to_lowercase() != "trace" {
+        // disable all log crate logging below trace (external libs)
+        log::set_max_level(::log::LevelFilter::Off);
+    }
+
     guards
 }
 


### PR DESCRIPTION
This PR is designed to clean up globset logging which is very noisy.

Notes:

1. This does not disable logs in `trace` mode, however these libraries will still log at their original level (not necessarily trace).
2. You can disable ext lib logging in trace mode by using setting `QLTY_LOG` to `qlty=trace` which will focus trace messages on qlty only.