### PR TITLE
Use composer to install php plugins

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -53,18 +53,17 @@ jobs:
           cache-dependency-path: plugins/package-lock.json
 
       - name: Generate cache key
-        run: echo "CACHE_MONTH=$(date +'blowup-cache')" >> $GITHUB_ENV
+        run: echo "CACHE_MONTH=$(date +'%Y-%m')" >> $GITHUB_ENV
 
       - name: Cache qlty tools
         uses: actions/cache@v4
         with:
           path: ~/.qlty
-          key: ${{ runner.os }}-qlty-${{ env.CACHE_MONTH }}
+          key: ${{ runner.os }}-qlty-${{ env.CACHE_MONTH }}-v1
 
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2
-        with:
-          extensions: xmlwriter  # Install xmlwriter extension
+        if: contains(matrix.os, 'macos')
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -53,7 +53,7 @@ jobs:
           cache-dependency-path: plugins/package-lock.json
 
       - name: Generate cache key
-        run: echo "CACHE_MONTH=$(date +'%Y-%m')" >> $GITHUB_ENV
+        run: echo "CACHE_MONTH=$(date +'blowup-cache')" >> $GITHUB_ENV
 
       - name: Cache qlty tools
         uses: actions/cache@v4

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -63,7 +63,8 @@ jobs:
 
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2
-        if: contains(matrix.os, 'macos')
+        with:
+          extensions: xmlwriter  # Install xmlwriter extension
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/qlty-check/src/tool/php.rs
+++ b/qlty-check/src/tool/php.rs
@@ -153,7 +153,6 @@ impl Tool for PhpPackage {
                 &path_to_native_string(composer_phar.to_str().unwrap()),
                 "require",
                 "--no-interaction",
-                "--ignore-platform-reqs",
                 format!("{}:{}", name, version).as_str(),
             ],
         ))

--- a/qlty-check/src/tool/php.rs
+++ b/qlty-check/src/tool/php.rs
@@ -46,6 +46,12 @@ impl Tool for Php {
         task.set_message("Verifying Php installation");
         Php::verify_installation(self.env())?;
 
+        task.set_message("Installing composer");
+        let composer = Composer {
+            cmd: default_command_builder(),
+        };
+        composer.setup(task)?;
+
         Ok(())
     }
 
@@ -133,11 +139,17 @@ impl Tool for PhpPackage {
         self.plugin.version_regex.clone()
     }
 
-    fn install(&self, task: &ProgressTask) -> Result<()> {
-        self.download().install(self.directory(), self.name())?;
-        self.package_file_install(task)?;
+    fn package_install(&self, task: &ProgressTask, name: &str, version: &str) -> Result<()> {
+        task.set_dim_message(&format!("Installing {}", name));
 
-        Ok(())
+        self.run_command(self.cmd.build(
+            "composer",
+            vec![
+                "require",
+                "--no-interaction",
+                format!("{}:{}", name, version).as_str(),
+            ],
+        ))
     }
 
     fn package_file_install(&self, task: &ProgressTask) -> Result<()> {

--- a/qlty-check/src/tool/php.rs
+++ b/qlty-check/src/tool/php.rs
@@ -141,12 +141,19 @@ impl Tool for PhpPackage {
 
     fn package_install(&self, task: &ProgressTask, name: &str, version: &str) -> Result<()> {
         task.set_dim_message(&format!("Installing {}", name));
+        let composer = Composer {
+            cmd: default_command_builder(),
+        };
+
+        let composer_phar = PathBuf::from(composer.directory()).join("composer.phar");
 
         self.run_command(self.cmd.build(
-            "composer",
+            "php",
             vec![
+                &path_to_native_string(composer_phar.to_str().unwrap()),
                 "require",
                 "--no-interaction",
+                "--ignore-platform-reqs",
                 format!("{}:{}", name, version).as_str(),
             ],
         ))

--- a/qlty-plugins/plugins/linters/gitleaks/plugin.toml
+++ b/qlty-plugins/plugins/linters/gitleaks/plugin.toml
@@ -1,7 +1,7 @@
 config_version = "0"
 
 [plugins.releases.gitleaks]
-github = "zricethezav/gitleaks"
+github = "gitleaks/gitleaks"
 download_type = "targz"
 strip_components = 0
 

--- a/qlty-plugins/plugins/linters/php-codesniffer/plugin.toml
+++ b/qlty-plugins/plugins/linters/php-codesniffer/plugin.toml
@@ -1,19 +1,18 @@
 config_version = "0"
 
 [plugins.definitions.php-codesniffer]
-runnable_archive_url = "https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/download/${version}/phpcs.phar"
-strip_components = 0
+package = "squizlabs/php_codesniffer"
 runtime = "php"
 file_types = ["php"]
 config_files = ["phpcs.xml"]
 latest_version = "3.10.3"
 known_good_version = "3.10.3"
-version_command = "php ${linter}/php-codesniffer --version"
+version_command = "php ${linter}/vendor/bin/phpcs --version"
 description = "PHP code linter"
 suggested = "targets"
 
 [plugins.definitions.php-codesniffer.drivers.lint]
-script = "php -d memory_limit=-1 ${linter}/php-codesniffer --report=json -q ${autoload_script} ${target}"
+script = "php -d memory_limit=-1 ${linter}/vendor/bin/phpcs --report=json -q ${autoload_script} ${target}"
 autoload_script = "--bootstrap=${linter}/vendor/autoload.php"
 success_codes = [0, 1, 2]
 output = "stdout"

--- a/qlty-plugins/plugins/linters/phpstan/plugin.toml
+++ b/qlty-plugins/plugins/linters/phpstan/plugin.toml
@@ -1,8 +1,7 @@
 config_version = "0"
 
 [plugins.definitions.phpstan]
-runnable_archive_url = "https://github.com/phpstan/phpstan/releases/download/${version}/phpstan.phar"
-strip_components = 0
+package = "phpstan/phpstan"
 runtime = "php"
 file_types = ["php"]
 latest_version = "1.12.7"
@@ -12,7 +11,7 @@ description = "PHP code linter"
 suggested = "config"
 
 [plugins.definitions.phpstan.drivers.lint]
-script = "php -d memory_limit=-1 ${linter}/phpstan analyze ${target} --error-format=json --level=9 ${autoload_script} ${config_script}"
+script = "php -d memory_limit=-1 ${linter}/vendor/bin/phpstan analyze ${target} --error-format=json --level=9 ${autoload_script} ${config_script}"
 autoload_script = "--autoload-file=${linter}/vendor/autoload.php"
 config_script = "--configuration=${config_file}"
 success_codes = [0, 1]


### PR DESCRIPTION
Instead of using phar files like we have done so far, using composer to install php plugins seems to help remove certain compatibility issues when using extra packages.

Attempts to resolve compatibility issues with php-codesniffer and its extra optional standards.