### PR TITLE
Compress files into a single coverage.zip and update upload logic accordingly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,6 +2522,7 @@ dependencies = [
  "serde",
  "serde-querystring",
  "serde_json",
+ "tempfile",
  "tiny_http",
  "tracing",
  "ureq",

--- a/qlty-cloud/Cargo.toml
+++ b/qlty-cloud/Cargo.toml
@@ -32,3 +32,6 @@ ureq.workspace = true
 uuid.workspace = true
 webbrowser.workspace = true
 zip.workspace = true
+
+[dev-dependencies]
+tempfile = "3.2"

--- a/qlty-cloud/src/export/coverage.rs
+++ b/qlty-cloud/src/export/coverage.rs
@@ -70,18 +70,23 @@ impl CoverageExport {
             .cloned()
             .collect();
 
-        compress_files(raw_file_paths, &directory.join("raw_files.zip"))
+        compress_files(raw_file_paths, &directory.join("raw_files.zip"))?;
+
+        let files_to_zip = vec![
+            "report_files.json.gz",
+            "file_coverages.json.gz",
+            "metadata.json",
+            "raw_files.zip",
+        ]
+        .iter()
+        .map(|file| directory.join(file).to_string_lossy().into_owned())
+        .collect();
+
+        compress_files(files_to_zip, &directory.join("coverage.zip"))
     }
 
     pub fn total_size_bytes(&self) -> Result<u64> {
-        let mut bytes: u64 = 0;
-
-        bytes += self.read_file("report_files.json.gz")?.len() as u64;
-        bytes += self.read_file("file_coverages.json.gz")?.len() as u64;
-        bytes += self.read_file("metadata.json")?.len() as u64;
-        bytes += self.read_file("raw_files.zip")?.len() as u64;
-
-        Ok(bytes)
+        Ok(self.read_file("coverage.zip")?.len() as u64)
     }
 
     pub fn read_file<P: AsRef<Path>>(&self, filename: P) -> Result<Vec<u8>> {

--- a/qlty-cloud/src/export/coverage.rs
+++ b/qlty-cloud/src/export/coverage.rs
@@ -54,11 +54,11 @@ impl CoverageExport {
     fn export(&self) -> Result<()> {
         let directory = self.to.as_ref().unwrap();
 
-        GzFormatter::new(JsonEachRowFormatter::new(self.report_files.clone()))
-            .write_to_file(&directory.join("report_files.json.gz"))?;
+        JsonEachRowFormatter::new(self.report_files.clone())
+            .write_to_file(&directory.join("report_files.jsonl"))?;
 
-        GzFormatter::new(JsonEachRowFormatter::new(self.file_coverages.clone()))
-            .write_to_file(&directory.join("file_coverages.json.gz"))?;
+        JsonEachRowFormatter::new(self.file_coverages.clone())
+            .write_to_file(&directory.join("file_coverages.jsonl"))?;
 
         JsonFormatter::new(self.metadata.clone())
             .write_to_file(&directory.join("metadata.json"))?;
@@ -73,8 +73,8 @@ impl CoverageExport {
         compress_files(raw_file_paths, &directory.join("raw_files.zip"))?;
 
         let files_to_zip = vec![
-            "report_files.json.gz",
-            "file_coverages.json.gz",
+            "report_files.jsonl",
+            "file_coverages.jsonl",
             "metadata.json",
             "raw_files.zip",
         ]

--- a/qlty-cloud/src/export/coverage.rs
+++ b/qlty-cloud/src/export/coverage.rs
@@ -76,10 +76,10 @@ impl CoverageExport {
         JsonFormatter::new(self.metadata.clone())
             .write_to_file(&directory.join("metadata.json"))?;
 
-        let raw_files_dir = &directory.join("raw_files");
+        let raw_files_dir = directory.join("raw_files");
         let exported_raw_files = self.export_raw_report_files(&raw_files_dir)?;
 
-        let mut files_to_zip = vec![
+        let mut files_to_zip = [
             "report_files.jsonl",
             "file_coverages.jsonl",
             "metadata.json",


### PR DESCRIPTION
Instead of uploading 4 separate files for coverage uploads, this uploads a single zip file containing the 4 files.

This cannot be merged until a server side component which knows how to read the single zip file is merged.