### PR TITLE
Fix plugin prefix during init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4001,9 +4001,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d59ca99a559661b96bf898d8fce28ed87935fd2bea9f05983c1464dd6c71b1"
+checksum = "bd8dcafa1ca14750d8d7a05aa05988c17aab20886e1f3ae33a40223c58d92ef7"
 dependencies = [
  "getrandom 0.3.1",
  "serde",


### PR DESCRIPTION
Right now if there 3 or more options for a prefix there is a chance an empty "" will be inserted as a prefix, which is undesirable, this PR fixes that.