### PR TITLE
Fix fmt path issues with prefixes

### DIFF
--- a/qlty-check/src/executor.rs
+++ b/qlty-check/src/executor.rs
@@ -533,7 +533,7 @@ impl Executor {
                 results.extend(formatted.clone());
             }
         }
-
+        results.sort();
         results
     }
 

--- a/qlty-check/src/executor/invocation_result.rs
+++ b/qlty-check/src/executor/invocation_result.rs
@@ -282,13 +282,13 @@ impl InvocationResult {
 
         for workspace_entry in self.invocation.target_paths.iter() {
             let prefixed_path = if let Some(prefix) = &self.plan.plugin.prefix {
-                PathBuf::from(prefix).join(&workspace_entry)
+                PathBuf::from(prefix).join(workspace_entry)
             } else {
                 PathBuf::from(&workspace_entry)
             };
 
             let workspace_path = self.plan.workspace.root.join(&prefixed_path);
-            let staged_path = self.plan.target_root.join(&workspace_entry);
+            let staged_path = self.plan.target_root.join(workspace_entry);
 
             info!("workspace_path file {:?}", &workspace_path);
             info!("staged_path file {:?}", &staged_path);

--- a/qlty-check/src/executor/invocation_result.rs
+++ b/qlty-check/src/executor/invocation_result.rs
@@ -16,7 +16,7 @@ use qlty_types::analysis::v1::{
 use serde::Serialize;
 use std::{collections::HashMap, path::PathBuf};
 use std::{process::Output, sync::Arc};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 #[derive(Debug, Clone)]
 pub struct InvocationResult {
@@ -290,8 +290,8 @@ impl InvocationResult {
             let workspace_path = self.plan.workspace.root.join(&prefixed_path);
             let staged_path = self.plan.target_root.join(workspace_entry);
 
-            info!("workspace_path file {:?}", &workspace_path);
-            info!("staged_path file {:?}", &staged_path);
+            trace!("workspace_path file {:?}", &workspace_path);
+            trace!("staged_path file {:?}", &staged_path);
 
             let workspace_contents = match std::fs::read_to_string(&workspace_path) {
                 Ok(content) => content,

--- a/qlty-check/src/executor/invocation_result.rs
+++ b/qlty-check/src/executor/invocation_result.rs
@@ -511,4 +511,12 @@ impl InvocationResult {
 
         file_results_by_path
     }
+
+    fn prefixed_file_path(&self, path: &str) -> PathBuf {
+        if let Some(prefix) = &self.plan.plugin.prefix {
+            PathBuf::from(prefix).join(path)
+        } else {
+            PathBuf::from(path)
+        }
+    }
 }

--- a/qlty-cli/tests/cmd/network/check/prefix.in/.gitignore
+++ b/qlty-cli/tests/cmd/network/check/prefix.in/.gitignore
@@ -1,0 +1,4 @@
+.qlty/results
+.qlty/logs
+.qlty/out
+.qlty/sources

--- a/qlty-cli/tests/cmd/network/check/prefix.in/.qlty/qlty.toml
+++ b/qlty-cli/tests/cmd/network/check/prefix.in/.qlty/qlty.toml
@@ -1,0 +1,13 @@
+config_version = "0"
+
+[[source]]
+name = "default"
+default = true
+
+[[plugin]]
+name = "prettier"
+prefix = "also_nested"
+
+[[plugin]]
+name = "prettier"
+prefix = "nested"

--- a/qlty-cli/tests/cmd/network/check/prefix.in/also_nested/needs_formatting.js
+++ b/qlty-cli/tests/cmd/network/check/prefix.in/also_nested/needs_formatting.js
@@ -1,0 +1,4 @@
+function x() {
+
+  return 1 ;
+}

--- a/qlty-cli/tests/cmd/network/check/prefix.in/nested/needs_formatting.js
+++ b/qlty-cli/tests/cmd/network/check/prefix.in/nested/needs_formatting.js
@@ -1,0 +1,5 @@
+function x() {
+  
+  return 1 ;
+  
+}

--- a/qlty-cli/tests/cmd/network/check/prefix.stderr
+++ b/qlty-cli/tests/cmd/network/check/prefix.stderr
@@ -1,2 +1,2 @@
 ✖ 2 issues
-✖ 1 unformatted file
+✖ 2 unformatted files

--- a/qlty-cli/tests/cmd/network/check/prefix.stderr
+++ b/qlty-cli/tests/cmd/network/check/prefix.stderr
@@ -1,0 +1,2 @@
+✖ 2 issues
+✖ 1 unformatted file

--- a/qlty-cli/tests/cmd/network/check/prefix.stdout
+++ b/qlty-cli/tests/cmd/network/check/prefix.stdout
@@ -1,12 +1,15 @@
 
- UNFORMATTED FILES: 1 
+ UNFORMATTED FILES: 2 
 
-✖ needs_formatting.js
+✖ also_nested/needs_formatting.js
+✖ nested/needs_formatting.js
 
 
  ISSUES: 2 
 
-needs_formatting.js:0:0
+also_nested/needs_formatting.js:0:0
     0:0  fmt     Incorrect formatting, autoformat by running `qlty fmt`.  prettier:fmt
+
+nested/needs_formatting.js:0:0
     0:0  fmt     Incorrect formatting, autoformat by running `qlty fmt`.  prettier:fmt
 

--- a/qlty-cli/tests/cmd/network/check/prefix.stdout
+++ b/qlty-cli/tests/cmd/network/check/prefix.stdout
@@ -1,0 +1,12 @@
+
+ UNFORMATTED FILES: 1 
+
+✖ needs_formatting.js
+
+
+ ISSUES: 2 
+
+needs_formatting.js:0:0
+    0:0  fmt     Incorrect formatting, autoformat by running `qlty fmt`.  prettier:fmt
+    0:0  fmt     Incorrect formatting, autoformat by running `qlty fmt`.  prettier:fmt
+

--- a/qlty-cli/tests/cmd/network/check/prefix.toml
+++ b/qlty-cli/tests/cmd/network/check/prefix.toml
@@ -1,0 +1,3 @@
+bin.name = "qlty"
+args = ["check", "--all", "--no-cache"]
+status.code = 1

--- a/qlty-cli/tests/cmd/network/fmt/prefix.in/.gitignore
+++ b/qlty-cli/tests/cmd/network/fmt/prefix.in/.gitignore
@@ -1,0 +1,4 @@
+.qlty/results
+.qlty/logs
+.qlty/out
+.qlty/sources

--- a/qlty-cli/tests/cmd/network/fmt/prefix.in/.qlty/qlty.toml
+++ b/qlty-cli/tests/cmd/network/fmt/prefix.in/.qlty/qlty.toml
@@ -1,0 +1,13 @@
+config_version = "0"
+
+[[source]]
+name = "default"
+default = true
+
+[[plugin]]
+name = "prettier"
+prefix = "also_nested"
+
+[[plugin]]
+name = "prettier"
+prefix = "nested"

--- a/qlty-cli/tests/cmd/network/fmt/prefix.in/also_nested/needs_formatting.js
+++ b/qlty-cli/tests/cmd/network/fmt/prefix.in/also_nested/needs_formatting.js
@@ -1,0 +1,4 @@
+function x() {
+
+  return 1 ;
+}

--- a/qlty-cli/tests/cmd/network/fmt/prefix.in/nested/needs_formatting.js
+++ b/qlty-cli/tests/cmd/network/fmt/prefix.in/nested/needs_formatting.js
@@ -1,0 +1,5 @@
+function x() {
+  
+  return 1 ;
+  
+}

--- a/qlty-cli/tests/cmd/network/fmt/prefix.stdout
+++ b/qlty-cli/tests/cmd/network/fmt/prefix.stdout
@@ -1,0 +1,2 @@
+✔ Formatted [..]/needs_formatting.js
+✔ Formatted [..]/needs_formatting.js

--- a/qlty-cli/tests/cmd/network/fmt/prefix.stdout
+++ b/qlty-cli/tests/cmd/network/fmt/prefix.stdout
@@ -1,2 +1,2 @@
-✔ Formatted [..]/needs_formatting.js
-✔ Formatted [..]/needs_formatting.js
+✔ Formatted also_nested/needs_formatting.js
+✔ Formatted nested/needs_formatting.js

--- a/qlty-cli/tests/cmd/network/fmt/prefix.toml
+++ b/qlty-cli/tests/cmd/network/fmt/prefix.toml
@@ -1,0 +1,4 @@
+bin.name = "qlty"
+args = ["fmt", "--all"]
+status.code = 0
+stderr = ""


### PR DESCRIPTION
Right now path for formatters when using prefixes were not matching correctly causing issues during both check and fmt. 
This PR fixes that.