### PR TITLE
Fix GitDiff calculation of repository paths

### DIFF
--- a/qlty-analysis/src/git/diff.rs
+++ b/qlty-analysis/src/git/diff.rs
@@ -81,10 +81,8 @@ impl GitDiff {
         debug!("Found {} changed files", changed_files.len());
         trace!("Changed files: {:?}", changed_files);
 
-        let line_filter = DiffLineTransformer::new(Self::plus_lines_index(
-            &diff,
-            path.parent().unwrap().to_path_buf(),
-        )?);
+        let line_filter =
+            DiffLineTransformer::new(Self::plus_lines_index(&diff, path.to_path_buf())?);
 
         Ok(Self {
             changed_files,
@@ -349,7 +347,7 @@ mod test {
         )
         .unwrap();
 
-        let git_diff = GitDiff::compute(DiffMode::HeadToWorkdir, &repo.path())?;
+        let git_diff = GitDiff::compute(DiffMode::HeadToWorkdir, &repo.path().parent().unwrap())?;
         let paths = git_diff.changed_files;
 
         let expected_paths = [


### PR DESCRIPTION
* GitDiff::compute path is passed as the root of repository, but we use the .parent() when computing diffs
* Our test `sample_repo()` returns a Repository object whose `.path()` returns the subdir `.git/` directory, meaning we are testing the function differently from how it is used.

tldr: the parent() is unnecessary. This causes matching issues when running from subdirectories (issues are filtered out because they do not match the path). To be honest, I'm not 100% sure why this works when running from root, but we have been passing the wrong path for those files too (i.e. for `/path/to/qltysh/qlty` we used `/path/to/qltysh` as the repo dir).