### PR TITLE
Update output_missing to error for stylelint

### DIFF
--- a/qlty-plugins/plugins/linters/stylelint/plugin.toml
+++ b/qlty-plugins/plugins/linters/stylelint/plugin.toml
@@ -44,7 +44,7 @@ cache_results = true
 batch = true
 max_batch = 100
 suggested = "config"
-output_missing = "parse"
+output_missing = "error"
 
 [[plugins.definitions.stylelint.drivers.lint.version]]
 version_matcher = ">=16.0.0"
@@ -57,7 +57,7 @@ cache_results = true
 batch = true
 max_batch = 100
 suggested = "config"
-output_missing = "parse"
+output_missing = "error"
 
 [plugins.definitions.stylelint.drivers.format]
 script = "stylelint --fix ${target}"


### PR DESCRIPTION
Since the stylelint output always contains a valid json output we can update the output_missing to error so it doesn't give a parser error when output is missing.