### PR TITLE
Disable batching for php-cs-fixer

### DIFF
--- a/qlty-plugins/plugins/linters/php-cs-fixer/fixtures/__snapshots__/multiple_files_v3.73.1.shot
+++ b/qlty-plugins/plugins/linters/php-cs-fixer/fixtures/__snapshots__/multiple_files_v3.73.1.shot
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`linter=php-cs-fixer fixture=multiple_files version=3.73.1 1`] = `
+{
+  "issues": [
+    {
+      "category": "CATEGORY_STYLE",
+      "level": "LEVEL_FMT",
+      "location": {
+        "path": "basic.php",
+      },
+      "message": "Incorrect formatting, autoformat by running \`qlty fmt\`.",
+      "mode": "MODE_BLOCK",
+      "onAddedLine": true,
+      "ruleKey": "fmt",
+      "tool": "php-cs-fixer",
+    },
+    {
+      "category": "CATEGORY_STYLE",
+      "level": "LEVEL_FMT",
+      "location": {
+        "path": "basic_too.php",
+      },
+      "message": "Incorrect formatting, autoformat by running \`qlty fmt\`.",
+      "mode": "MODE_BLOCK",
+      "onAddedLine": true,
+      "ruleKey": "fmt",
+      "tool": "php-cs-fixer",
+    },
+  ],
+}
+`;

--- a/qlty-plugins/plugins/linters/php-cs-fixer/fixtures/multiple_files.in/basic.php
+++ b/qlty-plugins/plugins/linters/php-cs-fixer/fixtures/multiple_files.in/basic.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+class HelloWorld
+{
+	private $b;
+
+	private $a;
+
+
+	public function sayHello(DateTimeImutable $date): void
+	{
+		$c=(ARRAY)array(1,2);
+		echo 'Hello, ' . $date->format('j. n. Y');
+	}
+}

--- a/qlty-plugins/plugins/linters/php-cs-fixer/fixtures/multiple_files.in/basic_too.php
+++ b/qlty-plugins/plugins/linters/php-cs-fixer/fixtures/multiple_files.in/basic_too.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+class HelloWorld
+{
+	private $b;
+
+	private $a;
+
+
+	public function sayHello(DateTimeImutable $date): void
+	{
+		$c=(ARRAY)array(1,2);
+		echo 'Hello, ' . $date->format('j. n. Y');
+	}
+}

--- a/qlty-plugins/plugins/linters/php-cs-fixer/plugin.toml
+++ b/qlty-plugins/plugins/linters/php-cs-fixer/plugin.toml
@@ -15,7 +15,7 @@ suggested = "targets"
 script = "php -d memory_limit=-1 ${linter}/vendor/bin/php-cs-fixer fix --using-cache=no --show-progress=none ${target}"
 success_codes = [0]
 output = "rewrite"
-batch = true
+batch = false
 cache_results = true
 driver_type = "formatter"
 suggested = "targets"

--- a/qlty-plugins/plugins/linters/php-cs-fixer/plugin.toml
+++ b/qlty-plugins/plugins/linters/php-cs-fixer/plugin.toml
@@ -15,10 +15,11 @@ suggested = "targets"
 script = "php -d memory_limit=-1 ${linter}/vendor/bin/php-cs-fixer fix --using-cache=no --show-progress=none ${target}"
 success_codes = [0]
 output = "rewrite"
-batch = false
 cache_results = true
 driver_type = "formatter"
 suggested = "targets"
+# Batching with php-cs-fixer requires a config file to be present
+batch = false
 
 # To get the local php config, since php is installed by user and not qlty
 [[plugins.definitions.php-cs-fixer.environment]]


### PR DESCRIPTION
Batching with php-cs-fixer requires a config file to be present, we can either change suggested to "config" or disable batching.

Disabling batching will make it slower, but will give more value