### PR TITLE
Fix panic-prone unwraps in plugin.rs

### DIFF
--- a/qlty-check/src/planner.rs
+++ b/qlty-check/src/planner.rs
@@ -9,7 +9,7 @@ use crate::patch_builder::PatchBuilder;
 use crate::planner::config_files::plugin_configs;
 use crate::planner::config_files::PluginConfigFile;
 use crate::Settings;
-use anyhow::{bail, Error, Result};
+use anyhow::{anyhow, bail, Error, Result};
 use check_filters::CheckFilters;
 use document_url_generator::DocumentUrlGenerator;
 use itertools::Itertools;
@@ -169,14 +169,17 @@ impl Planner {
         }
 
         for active_plugin in &self.active_plugins {
-            plugin_planners.push(PluginPlanner::new(
+            match PluginPlanner::new(
                 self,
                 active_plugin.clone(),
                 plugin_prefixes
                     .get(&active_plugin.name)
                     .cloned()
                     .unwrap_or_default(),
-            ));
+            ) {
+                Ok(planner) => plugin_planners.push(planner),
+                Err(err) => bail!("Failed to create plugin planner for {}: {}", active_plugin.name, err),
+            }
         }
 
         let results = plugin_planners
@@ -214,20 +217,28 @@ impl Planner {
     }
 
     fn compute_transformers(&mut self) {
-        if let Ok(diff_line_filter) = self
-            .workspace_entry_finder_builder
-            .as_mut()
-            .unwrap()
-            .clone()
-            .lock()
-            .unwrap()
-            .diff_line_filter()
-        {
+        let workspace_entry_finder_builder = match self.workspace_entry_finder_builder.as_mut() {
+            Some(builder) => builder,
+            None => {
+                debug!("No workspace entry finder builder available for transformers");
+                return;
+            }
+        };
+        
+        let result = workspace_entry_finder_builder.clone().lock().map_err(|_| {
+            debug!("Failed to lock workspace entry finder builder");
+        }).and_then(|mut builder| {
+            builder.diff_line_filter().map_err(|_| {
+                debug!("Failed to get diff line filter");
+            })
+        });
+        
+        if let Ok(diff_line_filter) = result {
             self.transformers.push(diff_line_filter);
 
             if !self.settings.emit_existing_issues {
-                match &self.target_mode.as_ref().unwrap() {
-                    TargetMode::UpstreamDiff(_) | TargetMode::HeadDiff => {
+                match &self.target_mode.as_ref() {
+                    Some(TargetMode::UpstreamDiff(_)) | Some(TargetMode::HeadDiff) => {
                         self.transformers.push(Box::new(DiffLineFilter));
                     }
                     _ => {}
@@ -268,9 +279,13 @@ impl Planner {
     }
 
     fn build_plan(&mut self) -> Result<Plan> {
+        let target_mode = self.target_mode.as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Target mode not computed"))?
+            .clone();
+            
         Ok(Plan {
             verb: self.verb,
-            target_mode: self.target_mode.as_ref().unwrap().clone(),
+            target_mode,
             settings: self.settings.clone(),
             workspace: self.workspace.clone(),
             config: self.config.clone(),

--- a/qlty-check/src/planner.rs
+++ b/qlty-check/src/planner.rs
@@ -9,7 +9,7 @@ use crate::patch_builder::PatchBuilder;
 use crate::planner::config_files::plugin_configs;
 use crate::planner::config_files::PluginConfigFile;
 use crate::Settings;
-use anyhow::{anyhow, bail, Error, Result};
+use anyhow::{bail, Error, Result};
 use check_filters::CheckFilters;
 use document_url_generator::DocumentUrlGenerator;
 use itertools::Itertools;
@@ -178,7 +178,11 @@ impl Planner {
                     .unwrap_or_default(),
             ) {
                 Ok(planner) => plugin_planners.push(planner),
-                Err(err) => bail!("Failed to create plugin planner for {}: {}", active_plugin.name, err),
+                Err(err) => bail!(
+                    "Failed to create plugin planner for {}: {}",
+                    active_plugin.name,
+                    err
+                ),
             }
         }
 
@@ -224,15 +228,19 @@ impl Planner {
                 return;
             }
         };
-        
-        let result = workspace_entry_finder_builder.clone().lock().map_err(|_| {
-            debug!("Failed to lock workspace entry finder builder");
-        }).and_then(|mut builder| {
-            builder.diff_line_filter().map_err(|_| {
-                debug!("Failed to get diff line filter");
+
+        let result = workspace_entry_finder_builder
+            .clone()
+            .lock()
+            .map_err(|_| {
+                debug!("Failed to lock workspace entry finder builder");
             })
-        });
-        
+            .and_then(|mut builder| {
+                builder.diff_line_filter().map_err(|_| {
+                    debug!("Failed to get diff line filter");
+                })
+            });
+
         if let Ok(diff_line_filter) = result {
             self.transformers.push(diff_line_filter);
 
@@ -279,10 +287,12 @@ impl Planner {
     }
 
     fn build_plan(&mut self) -> Result<Plan> {
-        let target_mode = self.target_mode.as_ref()
+        let target_mode = self
+            .target_mode
+            .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Target mode not computed"))?
             .clone();
-            
+
         Ok(Plan {
             verb: self.verb,
             target_mode,

--- a/qlty-check/src/planner/plugin.rs
+++ b/qlty-check/src/planner/plugin.rs
@@ -3,7 +3,7 @@ use super::{config_files::PluginConfigFile, Planner, PluginWorkspaceEntryFinderB
 use crate::planner::driver::DriverPlanner;
 use crate::tool::tool_builder::ToolBuilder;
 use crate::{cache::IssueCache, executor::staging_area::StagingArea, tool::Tool};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use qlty_analysis::{workspace_entries::TargetMode, WorkspaceEntry};
 use qlty_config::{
     config::{DriverDef, DriverType, PluginDef},
@@ -33,8 +33,57 @@ pub struct PluginPlanner {
     pub all_prefixes: Vec<String>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::staging_area::Mode;
+    use crate::tool::null_tool::NullTool;
+    use qlty_analysis::cache::NullCache;
+    use std::path::PathBuf;
+    
+    #[test]
+    fn test_compute_workspace_entries_lock_error() {
+        // Create a workspace_entry_finder_builder that will fail when locked
+        let broken_mutex = Arc::new(Mutex::new(PluginWorkspaceEntryFinderBuilder::default()));
+        // Poison the mutex by forcing a panic in a thread that holds the lock
+        let broken_mutex_clone = broken_mutex.clone();
+        let handle = std::thread::spawn(move || {
+            let _guard = broken_mutex_clone.lock().unwrap();
+            panic!("This panic is intentional for testing");
+        });
+        let _ = handle.join(); // This should be an Err because the thread panicked
+        
+        // Now create a PluginPlanner with the poisoned mutex
+        let mut planner = PluginPlanner {
+            formatters: false,
+            target_mode: TargetMode::All,
+            workspace_entry_finder_builder: broken_mutex,
+            plugin_name: "test".to_string(),
+            plugin: PluginDef::default(),
+            verb: ExecutionVerb::Check,
+            settings: Settings::default(),
+            workspace: Workspace { root: PathBuf::from("/") },
+            plugin_configs: vec![],
+            issue_cache: IssueCache::new(Box::new(NullCache::new())),
+            workspace_entries: Arc::new(vec![]),
+            staging_area: StagingArea::generate(Mode::Source, PathBuf::from("/"), None),
+            runtime_version: None,
+            tool: Box::new(NullTool {
+                plugin_name: "test".to_string(),
+                plugin: PluginDef::default(),
+            }),
+            driver_planners: vec![],
+            all_prefixes: vec![],
+        };
+        
+        // Verify that compute_workspace_entries returns an error instead of panicking
+        let result = planner.compute_workspace_entries();
+        assert!(result.is_err());
+    }
+}
+
 impl PluginPlanner {
-    pub fn new(planner: &Planner, active_plugin: ActivePlugin, all_prefixes: Vec<String>) -> Self {
+    pub fn new(planner: &Planner, active_plugin: ActivePlugin, all_prefixes: Vec<String>) -> Result<Self> {
         let plugin = active_plugin.plugin;
         let plugin_name = &active_plugin.name;
 
@@ -45,15 +94,18 @@ impl PluginPlanner {
 
         let tool = ToolBuilder::new(&planner.config, plugin_name, &plugin)
             .build_tool()
-            .unwrap();
+            .context("Failed to build tool")?;
 
         let workspace_entry_finder_builder = planner
             .workspace_entry_finder_builder
             .clone()
-            .unwrap()
+            .context("Workspace entry finder builder is missing")?
             .clone();
 
-        Self {
+        let target_mode = planner.target_mode.clone()
+            .context("Target mode is missing")?;
+
+        Ok(Self {
             plugin_name: plugin_name.to_owned(),
             plugin,
             verb: planner.verb,
@@ -61,7 +113,7 @@ impl PluginPlanner {
             tool,
             runtime_version,
             workspace: planner.workspace.clone(),
-            target_mode: planner.target_mode.clone().unwrap(),
+            target_mode,
             workspace_entry_finder_builder,
             formatters: planner.settings.formatters,
             plugin_configs: planner
@@ -74,7 +126,7 @@ impl PluginPlanner {
             workspace_entries: Arc::new(vec![]),
             driver_planners: vec![],
             all_prefixes,
-        }
+        })
     }
 
     pub fn compute(&mut self) -> Result<()> {
@@ -117,7 +169,9 @@ impl PluginPlanner {
 
     fn compute_workspace_entries(&mut self) -> Result<()> {
         let mut workspace_entry_finder_builder =
-            self.workspace_entry_finder_builder.lock().unwrap();
+            self.workspace_entry_finder_builder
+                .lock()
+                .map_err(|_| anyhow::anyhow!("Failed to acquire lock on workspace_entry_finder_builder"))?;
         let prefix = workspace_entry_finder_builder.prefix.clone();
         if let Some(prefix) = &self.plugin.prefix {
             workspace_entry_finder_builder.prefix = Some(prefix.clone());

--- a/qlty-check/src/planner/plugin.rs
+++ b/qlty-check/src/planner/plugin.rs
@@ -40,7 +40,7 @@ mod tests {
     use crate::tool::null_tool::NullTool;
     use qlty_analysis::cache::NullCache;
     use std::path::PathBuf;
-    
+
     #[test]
     fn test_compute_workspace_entries_lock_error() {
         // Create a workspace_entry_finder_builder that will fail when locked
@@ -52,7 +52,7 @@ mod tests {
             panic!("This panic is intentional for testing");
         });
         let _ = handle.join(); // This should be an Err because the thread panicked
-        
+
         // Now create a PluginPlanner with the poisoned mutex
         let mut planner = PluginPlanner {
             formatters: false,
@@ -62,7 +62,9 @@ mod tests {
             plugin: PluginDef::default(),
             verb: ExecutionVerb::Check,
             settings: Settings::default(),
-            workspace: Workspace { root: PathBuf::from("/") },
+            workspace: Workspace {
+                root: PathBuf::from("/"),
+            },
             plugin_configs: vec![],
             issue_cache: IssueCache::new(Box::new(NullCache::new())),
             workspace_entries: Arc::new(vec![]),
@@ -75,7 +77,7 @@ mod tests {
             driver_planners: vec![],
             all_prefixes: vec![],
         };
-        
+
         // Verify that compute_workspace_entries returns an error instead of panicking
         let result = planner.compute_workspace_entries();
         assert!(result.is_err());
@@ -83,7 +85,11 @@ mod tests {
 }
 
 impl PluginPlanner {
-    pub fn new(planner: &Planner, active_plugin: ActivePlugin, all_prefixes: Vec<String>) -> Result<Self> {
+    pub fn new(
+        planner: &Planner,
+        active_plugin: ActivePlugin,
+        all_prefixes: Vec<String>,
+    ) -> Result<Self> {
         let plugin = active_plugin.plugin;
         let plugin_name = &active_plugin.name;
 
@@ -102,7 +108,9 @@ impl PluginPlanner {
             .context("Workspace entry finder builder is missing")?
             .clone();
 
-        let target_mode = planner.target_mode.clone()
+        let target_mode = planner
+            .target_mode
+            .clone()
             .context("Target mode is missing")?;
 
         Ok(Self {
@@ -169,9 +177,9 @@ impl PluginPlanner {
 
     fn compute_workspace_entries(&mut self) -> Result<()> {
         let mut workspace_entry_finder_builder =
-            self.workspace_entry_finder_builder
-                .lock()
-                .map_err(|_| anyhow::anyhow!("Failed to acquire lock on workspace_entry_finder_builder"))?;
+            self.workspace_entry_finder_builder.lock().map_err(|_| {
+                anyhow::anyhow!("Failed to acquire lock on workspace_entry_finder_builder")
+            })?;
         let prefix = workspace_entry_finder_builder.prefix.clone();
         if let Some(prefix) = &self.plugin.prefix {
             workspace_entry_finder_builder.prefix = Some(prefix.clone());


### PR DESCRIPTION
## Summary
- Replace unwraps with proper error handling in plugin.rs to avoid panics seen in Sentry
- Add detailed error context to improve debugging
- Add test to verify error handling behavior
- Update caller code to handle Results properly

## Test plan
- All existing tests pass
- Added new test for error handling in PluginPlanner::compute_workspace_entries

🤖 Generated with [Claude Code](https://claude.ai/code)