### PR TITLE
Fix panic in extract_zip and install_tarxz functions

### DIFF
--- a/qlty-check/src/tool/go.rs
+++ b/qlty-check/src/tool/go.rs
@@ -28,7 +28,7 @@ impl Tool for Go {
     }
 
     fn update_hash(&self, sha: &mut sha2::Sha256) -> Result<()> {
-        self.download().update_hash(sha, &self.name());
+        self.download().update_hash(sha, &self.name())?;
         Ok(())
     }
 

--- a/qlty-check/src/tool/java.rs
+++ b/qlty-check/src/tool/java.rs
@@ -28,7 +28,7 @@ impl Tool for Java {
     }
 
     fn update_hash(&self, sha: &mut sha2::Sha256) -> Result<()> {
-        self.download().update_hash(sha, &self.name());
+        self.download().update_hash(sha, &self.name())?;
         Ok(())
     }
 

--- a/qlty-check/src/tool/node.rs
+++ b/qlty-check/src/tool/node.rs
@@ -36,7 +36,7 @@ impl Tool for NodeJS {
     }
 
     fn update_hash(&self, sha: &mut sha2::Sha256) -> Result<()> {
-        self.download().update_hash(sha, &self.name());
+        self.download().update_hash(sha, &self.name())?;
         Ok(())
     }
 

--- a/qlty-check/src/tool/python.rs
+++ b/qlty-check/src/tool/python.rs
@@ -41,7 +41,7 @@ impl Tool for Python {
     }
 
     fn update_hash(&self, sha: &mut sha2::Sha256) -> Result<()> {
-        self.download().update_hash(sha, &self.name());
+        self.download().update_hash(sha, &self.name())?;
         Ok(())
     }
 

--- a/qlty-check/src/tool/ruby.rs
+++ b/qlty-check/src/tool/ruby.rs
@@ -117,7 +117,7 @@ pub trait PlatformRuby {
         sha: &mut sha2::Sha256,
         download: Download,
     ) -> Result<()> {
-        download.update_hash(sha, &tool.name());
+        download.update_hash(sha, &tool.name())?;
         sha.update("qlty_load_path:v1".as_bytes());
         Ok(())
     }

--- a/qlty-check/src/tool/ruby_source.rs
+++ b/qlty-check/src/tool/ruby_source.rs
@@ -27,7 +27,7 @@ impl Tool for RubySource {
     }
 
     fn update_hash(&self, sha: &mut sha2::Sha256) -> Result<()> {
-        self.download().update_hash(sha, &self.name());
+        self.download().update_hash(sha, &self.name())?;
         Ok(())
     }
 

--- a/qlty-check/src/tool/rust.rs
+++ b/qlty-check/src/tool/rust.rs
@@ -25,7 +25,7 @@ impl Tool for Rust {
     }
 
     fn update_hash(&self, sha: &mut sha2::Sha256) -> Result<()> {
-        self.download().update_hash(sha, &self.name());
+        self.download().update_hash(sha, &self.name())?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Update extract_zip and install_tarxz in download.rs to return proper Errors instead of using unwrap() which can cause panics
- Fix update_hash methods to properly propagate errors using the ? operator

## Test plan
- All existing tests pass
- Error handling is now more robust with proper error messages instead of panics

🤖 Generated with [Claude Code](https://claude.ai/code)