### PR TITLE
Fix PHP tool unwrap calls

### DIFF
--- a/qlty-check/src/executor/driver.rs
+++ b/qlty-check/src/executor/driver.rs
@@ -106,7 +106,7 @@ impl Driver {
         let cmd = cmd_wrapper
             .cmd
             .dir(&plan.invocation_directory)
-            .full_env(plan.tool.env())
+            .full_env(plan.tool.env()?)
             .stderr_capture()
             .stdout_capture()
             .unchecked();
@@ -504,7 +504,7 @@ impl Driver {
         let cmd = cmd_wrapper
             .cmd
             .dir(dir)
-            .full_env(plan.tool.env())
+            .full_env(plan.tool.env()?)
             .stderr_capture()
             .stdout_capture()
             .unchecked();

--- a/qlty-check/src/executor/invocation_result.rs
+++ b/qlty-check/src/executor/invocation_result.rs
@@ -82,7 +82,7 @@ impl InvocationResult {
                     .collect(),
                 script: rerun.to_string(),
                 cwd: path_to_string(&plan.invocation_directory),
-                env: plan.tool.env().unwrap_or_default(),
+                env: plan.tool.env().with_context(|| format!("Failed to get environment for {}", plan.tool.name()))?,
                 started_at: Some(start_time.into()),
                 duration_secs: duration as f32,
                 exit_code: exec_result.exit_code,

--- a/qlty-check/src/executor/invocation_result.rs
+++ b/qlty-check/src/executor/invocation_result.rs
@@ -82,7 +82,7 @@ impl InvocationResult {
                     .collect(),
                 script: rerun.to_string(),
                 cwd: path_to_string(&plan.invocation_directory),
-                env: plan.tool.env(),
+                env: plan.tool.env().unwrap_or_default(),
                 started_at: Some(start_time.into()),
                 duration_secs: duration as f32,
                 exit_code: exec_result.exit_code,

--- a/qlty-check/src/executor/invocation_result.rs
+++ b/qlty-check/src/executor/invocation_result.rs
@@ -82,7 +82,9 @@ impl InvocationResult {
                     .collect(),
                 script: rerun.to_string(),
                 cwd: path_to_string(&plan.invocation_directory),
-                env: plan.tool.env().with_context(|| format!("Failed to get environment for {}", plan.tool.name()))?,
+                env: plan.tool.env().with_context(|| {
+                    format!("Failed to get environment for {}", plan.tool.name())
+                })?,
                 started_at: Some(start_time.into()),
                 duration_secs: duration as f32,
                 exit_code: exec_result.exit_code,

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -532,7 +532,10 @@ pub trait Tool: Debug + Sync + Send {
     }
 
     fn extra_env_paths(&self) -> Result<Vec<String>> {
-        Ok(vec![join_path_string!(self.directory(), "bin"), self.directory()])
+        Ok(vec![
+            join_path_string!(self.directory(), "bin"),
+            self.directory(),
+        ])
     }
 
     fn extra_env_vars(&self) -> HashMap<String, String> {
@@ -622,12 +625,16 @@ pub trait Tool: Debug + Sync + Send {
                 Vec::new()
             }
         };
-        
+
         if let Some(runtime) = self.runtime() {
             match runtime.extra_env_paths() {
                 Ok(runtime_paths) => paths.extend(runtime_paths),
                 Err(err) => {
-                    debug!("Failed to get runtime extra env paths for {}: {}", self.name(), err);
+                    debug!(
+                        "Failed to get runtime extra env paths for {}: {}",
+                        self.name(),
+                        err
+                    );
                 }
             }
         }
@@ -791,7 +798,10 @@ mod test {
         }
 
         fn extra_env_paths(&self) -> Result<Vec<String>> {
-            Ok(vec![join_path_string!(self.directory(), "bin"), self.directory()])
+            Ok(vec![
+                join_path_string!(self.directory(), "bin"),
+                self.directory(),
+            ])
         }
 
         fn install(&self, _task: &ProgressTask) -> Result<()> {
@@ -858,7 +868,10 @@ mod test {
         }
 
         fn extra_env_paths(&self) -> Result<Vec<String>> {
-            Ok(vec![join_path_string!(self.directory(), "bin"), self.directory()])
+            Ok(vec![
+                join_path_string!(self.directory(), "bin"),
+                self.directory(),
+            ])
         }
 
         fn install(&self, _task: &ProgressTask) -> Result<()> {

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -348,7 +348,7 @@ pub trait Tool: Debug + Sync + Send {
     where
         Self: Sized,
     {
-        let mut installation = initialize_installation(self);
+        let mut installation = initialize_installation(self)?;
 
         let cmd = cmd
             .dir(self.directory())
@@ -529,7 +529,7 @@ pub trait Tool: Debug + Sync + Send {
 
         env.insert("PATH".to_string(), full_path);
 
-        for (key, value) in self.extra_env_vars_with_plugin_env() {
+        for (key, value) in self.extra_env_vars_with_plugin_env()? {
             env.insert(key, value);
         }
 
@@ -543,8 +543,8 @@ pub trait Tool: Debug + Sync + Send {
         ])
     }
 
-    fn extra_env_vars(&self) -> HashMap<String, String> {
-        HashMap::new()
+    fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
+        Ok(HashMap::new())
     }
 
     fn install_log_file(&self) -> Result<std::fs::File> {
@@ -643,13 +643,13 @@ pub trait Tool: Debug + Sync + Send {
         Ok(paths.iter().map(path_to_native_string).collect())
     }
 
-    fn extra_env_vars_with_plugin_env(&self) -> HashMap<String, String> {
-        let mut env = self.extra_env_vars();
+    fn extra_env_vars_with_plugin_env(&self) -> Result<HashMap<String, String>> {
+        let mut env = self.extra_env_vars()?;
         if let Some(plugin) = self.plugin() {
             env.extend(self.load_environment_vars(&plugin.environment));
         }
 
-        env
+        Ok(env)
     }
 
     fn interpolate_variables(&self, value: &str) -> String {
@@ -784,8 +784,8 @@ mod test {
             self.plugin.clone()
         }
 
-        fn extra_env_vars(&self) -> HashMap<String, String> {
-            self.extra_env_vars.clone()
+        fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
+            Ok(self.extra_env_vars.clone())
         }
 
         fn extra_env_paths(&self) -> Result<Vec<String>> {
@@ -854,8 +854,8 @@ mod test {
             self.plugin.clone()
         }
 
-        fn extra_env_vars(&self) -> HashMap<String, String> {
-            self.extra_env_vars.clone()
+        fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
+            Ok(self.extra_env_vars.clone())
         }
 
         fn extra_env_paths(&self) -> Result<Vec<String>> {

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -352,7 +352,7 @@ pub trait Tool: Debug + Sync + Send {
 
         let cmd = cmd
             .dir(self.directory())
-            .full_env(self.env())
+            .full_env(self.env()?)
             .stderr_capture()
             .stdout_capture();
 
@@ -449,7 +449,7 @@ pub trait Tool: Debug + Sync + Send {
     fn installed_version(&self) -> Result<String> {
         if let Some(ref verion_cmd) = self.version_command() {
             let command = Command::new(None, self.interpolate_variables(verion_cmd));
-            let env = self.env();
+            let env = self.env()?;
             let cmd_output = command
                 .cmd
                 .full_env(&env)
@@ -511,7 +511,7 @@ pub trait Tool: Debug + Sync + Send {
         }
     }
 
-    fn env(&self) -> HashMap<String, String> {
+    fn env(&self) -> Result<HashMap<String, String>> {
         let mut env = HashMap::new();
 
         for key in SYSTEM_ENV_KEYS {
@@ -520,15 +520,12 @@ pub trait Tool: Debug + Sync + Send {
             }
         }
 
-        let env_paths = match self.env_paths() {
-            Ok(paths) => paths,
-            Err(err) => {
-                debug!("Failed to get env paths for {}: {}", self.name(), err);
-                Vec::new()
-            }
-        };
+        let env_paths = self.env_paths()?;
 
-        let full_path = path_to_native_string(join_paths(env_paths).unwrap_or_default());
+        let full_path = path_to_native_string(
+            join_paths(env_paths)
+                .with_context(|| format!("Failed to join paths for {}", self.name()))?,
+        );
 
         env.insert("PATH".to_string(), full_path);
 
@@ -536,7 +533,7 @@ pub trait Tool: Debug + Sync + Send {
             env.insert(key, value);
         }
 
-        env
+        Ok(env)
     }
 
     fn extra_env_paths(&self) -> Result<Vec<String>> {
@@ -985,7 +982,7 @@ mod test {
             extra_env_vars: [("TEST".into(), "test".into())].iter().cloned().collect(),
             ..TestTool::default()
         };
-        let env = tool.env();
+        let env = tool.env().unwrap();
 
         for key in SYSTEM_ENV_KEYS {
             assert_eq!(env.get(*key), Some(&std::env::var(key).unwrap()));

--- a/qlty-check/src/tool/download.rs
+++ b/qlty-check/src/tool/download.rs
@@ -364,8 +364,8 @@ impl Tool for DownloadTool {
         Ok(())
     }
 
-    fn extra_env_paths(&self) -> Vec<String> {
-        vec![self.directory()]
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
+        Ok(vec![self.directory()])
     }
 
     fn clone_box(&self) -> Box<dyn Tool> {

--- a/qlty-check/src/tool/download.rs
+++ b/qlty-check/src/tool/download.rs
@@ -92,7 +92,7 @@ impl Download {
     pub fn install(&self, tool: &dyn Tool) -> Result<()> {
         let directory = PathBuf::from(tool.directory());
         let tool_name = tool.name();
-        let mut installation = initialize_installation(tool);
+        let mut installation = initialize_installation(tool)?;
 
         let result = match self.file_type() {
             DownloadFileType::Executable => self.install_executable(&directory, &tool_name),

--- a/qlty-check/src/tool/github.rs
+++ b/qlty-check/src/tool/github.rs
@@ -310,8 +310,8 @@ impl Tool for GitHubReleaseTool {
         Ok(())
     }
 
-    fn extra_env_paths(&self) -> Vec<String> {
-        vec![self.directory()]
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
+        Ok(vec![self.directory()])
     }
 
     fn clone_box(&self) -> Box<dyn Tool> {

--- a/qlty-check/src/tool/github.rs
+++ b/qlty-check/src/tool/github.rs
@@ -399,7 +399,7 @@ impl GitHubReleaseTool {
             request = request.set("Authorization", &format!("Bearer {}", auth_token));
         }
 
-        let mut installation = initialize_installation(self);
+        let mut installation = initialize_installation(self)?;
         let result = request.call();
         finalize_installation_from_assets_fetch(&mut installation, &result, url);
 

--- a/qlty-check/src/tool/go.rs
+++ b/qlty-check/src/tool/go.rs
@@ -42,7 +42,7 @@ impl Tool for Go {
         Ok(())
     }
 
-    fn extra_env_vars(&self) -> HashMap<String, String> {
+    fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
         let mut env = HashMap::new();
         env.insert("GOROOT".to_string(), self.directory());
         env.insert("GO111MODULE".to_string(), "on".to_string());
@@ -51,7 +51,7 @@ impl Tool for Go {
             "LD_LIBRARY_PATH".to_string(),
             join_path_string!(self.directory(), "lib"),
         );
-        env
+        Ok(env)
     }
 
     fn version_command(&self) -> Option<String> {
@@ -167,11 +167,11 @@ impl Tool for GoPackage {
         Ok(())
     }
 
-    fn extra_env_vars(&self) -> HashMap<String, String> {
-        let mut env = self.runtime.extra_env_vars();
+    fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
+        let mut env = self.runtime.extra_env_vars()?;
         env.insert("GOPATH".to_string(), self.directory());
 
-        env
+        Ok(env)
     }
 
     fn clone_box(&self) -> Box<dyn Tool> {

--- a/qlty-check/src/tool/go.rs
+++ b/qlty-check/src/tool/go.rs
@@ -178,11 +178,11 @@ impl Tool for GoPackage {
         Box::new(self.clone())
     }
 
-    fn extra_env_paths(&self) -> Vec<String> {
-        vec![
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
+        Ok(vec![
             join_path_string!(self.directory(), "bin"),
             join_path_string!(self.runtime.directory(), "bin"),
-        ]
+        ])
     }
 
     fn plugin(&self) -> Option<PluginDef> {

--- a/qlty-check/src/tool/installations.rs
+++ b/qlty-check/src/tool/installations.rs
@@ -7,8 +7,10 @@ use qlty_types::analysis::v1::Installation;
 use std::{fs::create_dir_all, path::PathBuf};
 use tracing::{debug, error};
 
-pub fn initialize_installation(tool: &dyn Tool) -> Installation {
-    Installation {
+pub fn initialize_installation(tool: &dyn Tool) -> Result<Installation> {
+    let env = tool.env()?;
+
+    Ok(Installation {
         tool_name: tool.name(),
         version: tool.version().unwrap_or_default(),
         tool_type: format!("{:?}", tool.tool_type()),
@@ -18,9 +20,9 @@ pub fn initialize_installation(tool: &dyn Tool) -> Installation {
         qlty_cli_version: QLTY_VERSION.to_string(),
         log_file_path: tool.install_log_path(),
         started_at: Some(Utc::now().into()),
-        env: tool.env().unwrap_or_default(),
+        env,
         ..Default::default()
-    }
+    })
 }
 
 pub fn write_to_file(installation: &Installation) {

--- a/qlty-check/src/tool/installations.rs
+++ b/qlty-check/src/tool/installations.rs
@@ -18,7 +18,7 @@ pub fn initialize_installation(tool: &dyn Tool) -> Installation {
         qlty_cli_version: QLTY_VERSION.to_string(),
         log_file_path: tool.install_log_path(),
         started_at: Some(Utc::now().into()),
-        env: tool.env(),
+        env: tool.env().unwrap_or_default(),
         ..Default::default()
     }
 }

--- a/qlty-check/src/tool/java.rs
+++ b/qlty-check/src/tool/java.rs
@@ -55,11 +55,11 @@ impl Tool for Java {
     }
 
     // So Java linux and macos releases have different directory structures
-    fn extra_env_paths(&self) -> Vec<String> {
-        vec![
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
+        Ok(vec![
             join_path_string!(self.directory(), "bin"),
             join_path_string!(self.directory(), "Contents", "Home", "bin"),
-        ]
+        ])
     }
 }
 
@@ -157,11 +157,11 @@ impl Tool for JavaPackage {
         Ok(())
     }
 
-    fn extra_env_paths(&self) -> Vec<String> {
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
         let mut paths = vec![self.directory(), join_path_string!(self.directory(), "bin")];
-        paths.extend(self.runtime.extra_env_paths());
+        paths.extend(self.runtime.extra_env_paths()?);
 
-        paths
+        Ok(paths)
     }
 
     fn clone_box(&self) -> Box<dyn Tool> {

--- a/qlty-check/src/tool/node.rs
+++ b/qlty-check/src/tool/node.rs
@@ -193,13 +193,13 @@ impl Tool for NodePackage {
         )
     }
 
-    fn extra_env_paths(&self) -> Vec<String> {
-        let mut paths = self.runtime.extra_env_paths();
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
+        let mut paths = self.runtime.extra_env_paths()?;
         paths.insert(
             0,
             join_path_string!(self.directory(), "node_modules", ".bin"),
         );
-        paths
+        Ok(paths)
     }
 
     fn extra_env_vars(&self) -> HashMap<String, String> {

--- a/qlty-check/src/tool/node.rs
+++ b/qlty-check/src/tool/node.rs
@@ -202,14 +202,14 @@ impl Tool for NodePackage {
         Ok(paths)
     }
 
-    fn extra_env_vars(&self) -> HashMap<String, String> {
-        let mut env = self.runtime.extra_env_vars();
+    fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
+        let mut env = self.runtime.extra_env_vars()?;
         env.insert(
             "NODE_PATH".to_string(),
             join_path_string!(self.directory(), "node_modules"),
         );
 
-        env
+        Ok(env)
     }
 
     fn clone_box(&self) -> Box<dyn Tool> {

--- a/qlty-check/src/tool/php.rs
+++ b/qlty-check/src/tool/php.rs
@@ -45,7 +45,7 @@ impl Tool for Php {
 
     fn install(&self, task: &ProgressTask) -> Result<()> {
         task.set_message("Verifying Php installation");
-        self.verify_installation(self.env())?;
+        self.verify_installation(self.env()?)?;
 
         task.set_message("Installing composer");
         let composer = Composer {

--- a/qlty-check/src/tool/php.rs
+++ b/qlty-check/src/tool/php.rs
@@ -81,7 +81,7 @@ impl Php {
         let script = format!("{:?}", cmd);
         debug!(script);
 
-        let mut installation = initialize_installation(self);
+        let mut installation = initialize_installation(self)?;
         let result = cmd.run();
         finalize_installation_from_cmd_result(self, &result, &mut installation, script).ok();
 
@@ -191,13 +191,13 @@ impl Tool for PhpPackage {
         Some(self.plugin.clone())
     }
 
-    fn extra_env_vars(&self) -> HashMap<String, String> {
+    fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
         let mut env = HashMap::new();
         env.insert(
             "COMPOSER_VENDOR_DIR".to_string(),
             path_to_native_string(PathBuf::from(format!("{}/vendor", self.directory()))),
         );
-        env
+        Ok(env)
     }
 }
 

--- a/qlty-check/src/tool/php/composer.rs
+++ b/qlty-check/src/tool/php/composer.rs
@@ -94,7 +94,7 @@ impl Composer {
                 ],
             )
             .dir(php_package.directory())
-            .full_env(self.env())
+            .full_env(self.env()?)
             .stderr_capture()
             .stdout_capture()
             .unchecked(); // Capture output for debugging

--- a/qlty-check/src/tool/php/composer.rs
+++ b/qlty-check/src/tool/php/composer.rs
@@ -102,7 +102,7 @@ impl Composer {
         let script = format!("{:?}", cmd);
         debug!(script);
 
-        let mut installation = initialize_installation(php_package);
+        let mut installation = initialize_installation(php_package)?;
         let result = cmd.run();
         let _ =
             finalize_installation_from_cmd_result(php_package, &result, &mut installation, script);

--- a/qlty-check/src/tool/python.rs
+++ b/qlty-check/src/tool/python.rs
@@ -195,11 +195,11 @@ impl Tool for PipVenvPackage {
         Ok(vec![join_path_string!(self.directory(), BIN_DIRECTORY)])
     }
 
-    fn extra_env_vars(&self) -> HashMap<String, String> {
-        let mut env = self.runtime.extra_env_vars();
+    fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
+        let mut env = self.runtime.extra_env_vars()?;
         env.insert("VIRTUAL_ENV".to_string(), self.directory());
 
-        env
+        Ok(env)
     }
 
     fn clone_box(&self) -> Box<dyn Tool> {

--- a/qlty-check/src/tool/python.rs
+++ b/qlty-check/src/tool/python.rs
@@ -357,7 +357,7 @@ mod test {
     #[test]
     fn test_pip_venv_package_env() {
         with_pip_venv_package(|pkg, _, _| {
-            let env = pkg.env();
+            let env = pkg.env().unwrap();
             let mut paths = vec![
                 join_path_string!(pkg.directory(), BIN_DIRECTORY),
                 join_path_string!(pkg.runtime.directory(), "bin"),

--- a/qlty-check/src/tool/python.rs
+++ b/qlty-check/src/tool/python.rs
@@ -191,8 +191,8 @@ impl Tool for PipVenvPackage {
         ))
     }
 
-    fn extra_env_paths(&self) -> Vec<String> {
-        vec![join_path_string!(self.directory(), BIN_DIRECTORY)]
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
+        Ok(vec![join_path_string!(self.directory(), BIN_DIRECTORY)])
     }
 
     fn extra_env_vars(&self) -> HashMap<String, String> {

--- a/qlty-check/src/tool/ruby.rs
+++ b/qlty-check/src/tool/ruby.rs
@@ -7,7 +7,7 @@ use super::{Tool, ToolType};
 use crate::tool::download::Download;
 use crate::tool::RuntimeTool;
 use crate::ui::{ProgressBar, ProgressTask};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use itertools::Itertools;
 use qlty_analysis::join_path_string;
 use qlty_analysis::utils::fs::{path_to_native_string, path_to_string};
@@ -29,7 +29,7 @@ pub struct Ruby {
 pub trait PlatformRuby {
     fn post_install(&self, tool: &dyn Tool, task: &ProgressTask) -> Result<()>;
     fn extra_env_paths(&self, tool: &dyn Tool) -> Vec<String>;
-    fn extra_env_vars(&self, tool: &dyn Tool, env: &mut HashMap<String, String>);
+    fn extra_env_vars(&self, tool: &dyn Tool, env: &mut HashMap<String, String>) -> Result<()>;
     fn platform_directory(&self, tool: &dyn Tool) -> String;
 
     fn version(&self, version: &String) -> Option<String> {
@@ -100,15 +100,16 @@ pub trait PlatformRuby {
             .collect_vec()
     }
 
-    fn insert_rubylib_env(&self, tool: &dyn Tool, env: &mut HashMap<String, String>) {
+    fn insert_rubylib_env(&self, tool: &dyn Tool, env: &mut HashMap<String, String>) -> Result<()> {
         env.insert("RUBYOPT".to_string(), "-rqlty_load_path".to_string());
         env.insert(
             "RUBYLIB".to_string(),
             join_paths(self.rubylib_paths(tool))
-                .unwrap_or_default()
+                .context(format!("Failed to join RUBYLIB paths for {}", tool.name()))?
                 .to_string_lossy()
                 .to_string(),
         );
+        Ok(())
     }
 
     fn update_hash(
@@ -184,10 +185,10 @@ impl Tool for Ruby {
         Ok(self.platform_tool.extra_env_paths(self))
     }
 
-    fn extra_env_vars(&self) -> HashMap<String, String> {
+    fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
         let mut env = HashMap::new();
-        self.platform_tool.extra_env_vars(self, &mut env);
-        env
+        self.platform_tool.extra_env_vars(self, &mut env)?;
+        Ok(env)
     }
 
     fn version_command(&self) -> Option<String> {
@@ -359,8 +360,8 @@ impl Tool for RubygemsPackage {
         self.gemfile_install(task)
     }
 
-    fn extra_env_vars(&self) -> HashMap<String, String> {
-        let mut env = self.runtime.extra_env_vars();
+    fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
+        let mut env = self.runtime.extra_env_vars()?;
         env.insert(
             "GEM_HOME".to_string(),
             path_to_native_string(self.directory()),
@@ -370,11 +371,9 @@ impl Tool for RubygemsPackage {
             path_to_native_string(self.directory()),
         );
 
-        if let Err(err) = self.package_file_envs(&mut env) {
-            debug!("Failed to add package file env vars: {}", err);
-        }
+        self.package_file_envs(&mut env)?;
 
-        env
+        Ok(env)
     }
 
     fn extra_env_paths(&self) -> Result<Vec<String>> {

--- a/qlty-check/src/tool/ruby.rs
+++ b/qlty-check/src/tool/ruby.rs
@@ -389,7 +389,10 @@ impl Tool for RubygemsPackage {
                 }
             }
         }
-        Ok(vec![join_path_string!(self.directory(), "bin"), self.directory()])
+        Ok(vec![
+            join_path_string!(self.directory(), "bin"),
+            self.directory(),
+        ])
     }
 
     fn clone_box(&self) -> Box<dyn Tool> {

--- a/qlty-check/src/tool/ruby.rs
+++ b/qlty-check/src/tool/ruby.rs
@@ -370,7 +370,9 @@ impl Tool for RubygemsPackage {
             path_to_native_string(self.directory()),
         );
 
-        self.package_file_envs(&mut env);
+        if let Err(err) = self.package_file_envs(&mut env) {
+            debug!("Failed to add package file env vars: {}", err);
+        }
 
         env
     }
@@ -519,7 +521,7 @@ pub mod test {
     #[test]
     fn test_rubygems_package_env() {
         with_rubygems_package(|pkg, temp_path, _| {
-            let env = pkg.env();
+            let env = pkg.env().unwrap();
 
             if !cfg!(windows) {
                 assert_eq!(

--- a/qlty-check/src/tool/ruby.rs
+++ b/qlty-check/src/tool/ruby.rs
@@ -180,8 +180,8 @@ impl Tool for Ruby {
         self.platform_tool.post_install(self, task)
     }
 
-    fn extra_env_paths(&self) -> Vec<String> {
-        self.platform_tool.extra_env_paths(self)
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
+        Ok(self.platform_tool.extra_env_paths(self))
     }
 
     fn extra_env_vars(&self) -> HashMap<String, String> {
@@ -375,7 +375,7 @@ impl Tool for RubygemsPackage {
         env
     }
 
-    fn extra_env_paths(&self) -> Vec<String> {
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
         if self.plugin.package_file.is_some() {
             if let Ok(version_paths) = read_dir(join_path_string!(self.directory(), "ruby")) {
                 let paths = version_paths
@@ -385,11 +385,11 @@ impl Tool for RubygemsPackage {
                     .map(|entry| path_to_native_string(entry.path().join("bin")))
                     .collect_vec();
                 if !paths.is_empty() {
-                    return paths;
+                    return Ok(paths);
                 }
             }
         }
-        vec![join_path_string!(self.directory(), "bin"), self.directory()]
+        Ok(vec![join_path_string!(self.directory(), "bin"), self.directory()])
     }
 
     fn clone_box(&self) -> Box<dyn Tool> {

--- a/qlty-check/src/tool/ruby/gemfile.rs
+++ b/qlty-check/src/tool/ruby/gemfile.rs
@@ -24,7 +24,7 @@ impl RubyGemfile {
         let list_command = self
             .cmd
             .build("ruby", vec!["-S", "bundle", "list"])
-            .full_env(self.env())
+            .full_env(self.env()?)
             .dir(self.directory())
             .stderr_capture()
             .stdout_capture()
@@ -144,7 +144,7 @@ impl RubyGemfile {
             .cmd
             .build("ruby", vec!["-rrubygems", "-e", script.as_str()])
             .env_remove("RUBYOPT")
-            .full_env(self.env())
+            .full_env(self.env()?)
             .dir(source.parent().unwrap())
             .stdin_path(source)
             .stdout_path(dest);
@@ -153,9 +153,9 @@ impl RubyGemfile {
         cmd.run().map(|_| ()).map_err(Into::into)
     }
 
-    pub fn package_file_envs(&self, env: &mut HashMap<String, String>) {
+    pub fn package_file_envs(&self, env: &mut HashMap<String, String>) -> Result<()> {
         if self.plugin.package_file.is_none() {
-            return;
+            return Ok(());
         }
 
         env.insert(
@@ -173,7 +173,7 @@ impl RubyGemfile {
         );
 
         let rubyopt_prefix = if let Some(runtime) = self.runtime() {
-            runtime.env().get("RUBYOPT").cloned()
+            runtime.env()?.get("RUBYOPT").cloned()
         } else {
             None
         };
@@ -186,6 +186,8 @@ impl RubyGemfile {
         );
         env.insert("BUNDLE_JOBS".to_string(), "4".to_string());
         env.insert("BUNDLE_RETRY".to_string(), "3".to_string());
+
+        Ok(())
     }
 
     fn package_file_name(&self) -> String {
@@ -238,7 +240,7 @@ mod test {
             assert_eq!(pkg.version(), Some("bundled".to_string()));
             assert_eq!(pkg.version_command(), None);
 
-            let env = pkg.env();
+            let env = pkg.env().unwrap();
             assert_eq!(
                 env.get("BUNDLE_PATH").unwrap(),
                 &path_to_native_string(pkg.directory())
@@ -325,7 +327,7 @@ mod test {
             assert_eq!(pkg.version(), Some("bundled".to_string()));
             assert_eq!(pkg.version_command(), None);
 
-            let env = pkg.env();
+            let env = pkg.env().unwrap();
             assert_eq!(
                 env.get("BUNDLE_PATH").unwrap(),
                 &path_to_native_string(pkg.directory())

--- a/qlty-check/src/tool/ruby/gemfile.rs
+++ b/qlty-check/src/tool/ruby/gemfile.rs
@@ -33,7 +33,7 @@ impl RubyGemfile {
         let script = format!("{:?}", list_command);
         debug!(script);
 
-        let mut installation = initialize_installation(self);
+        let mut installation = initialize_installation(self)?;
         let result = list_command.run();
         let _ = finalize_installation_from_cmd_result(self, &result, &mut installation, script);
 

--- a/qlty-check/src/tool/ruby/sys/linux.rs
+++ b/qlty-check/src/tool/ruby/sys/linux.rs
@@ -54,8 +54,8 @@ impl PlatformRuby for RubyLinux {
         vec![join_path_string!(tool.directory(), "bin")]
     }
 
-    fn extra_env_vars(&self, tool: &dyn Tool, env: &mut HashMap<String, String>) {
-        self.insert_rubylib_env(tool, env);
+    fn extra_env_vars(&self, tool: &dyn Tool, env: &mut HashMap<String, String>) -> Result<()> {
+        self.insert_rubylib_env(tool, env)?;
         env.insert(
             "LD_LIBRARY_PATH".to_string(),
             join_path_string!(tool.directory(), "lib"),
@@ -64,6 +64,7 @@ impl PlatformRuby for RubyLinux {
             "PKG_CONFIG_PATH".to_string(),
             join_path_string!(tool.directory(), "lib", "pkgconfig"),
         );
+        Ok(())
     }
 
     fn platform_directory(&self, _tool: &dyn Tool) -> String {
@@ -265,7 +266,7 @@ mod test {
         let mut env = std::collections::HashMap::new();
         let runtime = RubyLinux::default();
         let platform_dir = runtime.platform_directory(&tool);
-        runtime.extra_env_vars(&tool, &mut env);
+        runtime.extra_env_vars(&tool, &mut env).unwrap();
         assert_eq!(
             *env.get("PKG_CONFIG_PATH").unwrap(),
             format!("{}/lib/pkgconfig", path_to_string(tempdir.path()))
@@ -305,7 +306,7 @@ mod test {
         };
         let mut env = std::collections::HashMap::new();
         let runtime = RubyLinux::default();
-        runtime.extra_env_vars(&tool, &mut env);
+        runtime.extra_env_vars(&tool, &mut env).unwrap();
         assert_eq!(
             *env.get("LD_LIBRARY_PATH").unwrap(),
             format!("{}/lib", path_to_string(tempdir.path()))

--- a/qlty-check/src/tool/ruby/sys/linux.rs
+++ b/qlty-check/src/tool/ruby/sys/linux.rs
@@ -104,7 +104,7 @@ impl RubyLinux {
             "https://ftp.debian.org/debian/pool/main/{}_{}.deb",
             package, ARCH
         );
-        let mut installation = initialize_installation(tool);
+        let mut installation = initialize_installation(tool)?;
         installation.download_url = Some(url.to_string());
         installation.download_file_type = Some(".deb".to_string());
         installation.download_binary_name = Some(package.to_string());

--- a/qlty-check/src/tool/ruby/sys/macos.rs
+++ b/qlty-check/src/tool/ruby/sys/macos.rs
@@ -56,7 +56,7 @@ impl PlatformRuby for RubyMacos {
                 ],
             )
             .dir(tool.directory())
-            .full_env(tool.env());
+            .full_env(tool.env()?);
 
         debug!("Running: {:?}", cmd);
 

--- a/qlty-check/src/tool/ruby/sys/macos.rs
+++ b/qlty-check/src/tool/ruby/sys/macos.rs
@@ -63,7 +63,7 @@ impl PlatformRuby for RubyMacos {
         let script = format!("{:?}", cmd);
         debug!(script);
 
-        let mut installation = initialize_installation(tool);
+        let mut installation = initialize_installation(tool)?;
         let result = cmd.run();
         finalize_installation_from_cmd_result(tool, &result, &mut installation, script).ok();
 
@@ -79,12 +79,13 @@ impl PlatformRuby for RubyMacos {
         ]
     }
 
-    fn extra_env_vars(&self, tool: &dyn Tool, env: &mut HashMap<String, String>) {
-        self.insert_rubylib_env(tool, env);
+    fn extra_env_vars(&self, tool: &dyn Tool, env: &mut HashMap<String, String>) -> Result<()> {
+        self.insert_rubylib_env(tool, env)?;
         env.insert(
             "PKG_CONFIG_PATH".to_string(),
             join_path_string!(tool.directory(), "lib", "pkgconfig"),
         );
+        Ok(())
     }
 
     /// On macOS this can be <arch>-darwin19 or <arch>-darwin22 depending on the
@@ -264,7 +265,7 @@ mod test {
         };
         let mut env = std::collections::HashMap::new();
         let runtime = RubyMacos::default();
-        runtime.extra_env_vars(&tool, &mut env);
+        runtime.extra_env_vars(&tool, &mut env).unwrap();
         assert_eq!(
             *env.get("PKG_CONFIG_PATH").unwrap(),
             format!("{}/lib/pkgconfig", path_to_string(tempdir.path()))
@@ -299,7 +300,7 @@ mod test {
         };
         let mut env = std::collections::HashMap::new();
         let runtime = RubyMacos::default();
-        runtime.extra_env_vars(&tool, &mut env);
+        runtime.extra_env_vars(&tool, &mut env).unwrap();
         assert_eq!(
             *env.get("PKG_CONFIG_PATH").unwrap(),
             format!("{}/lib/pkgconfig", path_to_string(tempdir.path()))

--- a/qlty-check/src/tool/ruby/sys/windows.rs
+++ b/qlty-check/src/tool/ruby/sys/windows.rs
@@ -50,8 +50,9 @@ impl PlatformRuby for RubyWindows {
         .collect_vec()
     }
 
-    fn extra_env_vars(&self, _tool: &dyn Tool, _env: &mut HashMap<String, String>) {
+    fn extra_env_vars(&self, _tool: &dyn Tool, _env: &mut HashMap<String, String>) -> Result<()> {
         // Windows does not need any extra env vars
+        Ok(())
     }
 
     fn platform_directory(&self, _tool: &dyn Tool) -> String {
@@ -70,7 +71,7 @@ impl RubyWindows {
         let script = format!("{:?}", cmd);
         debug!("Verify system Ruby: {:?}", script);
 
-        let mut installation = initialize_installation(tool);
+        let mut installation = initialize_installation(tool)?;
         let result = cmd.run();
         let _ = finalize_installation_from_cmd_result(tool, &result, &mut installation, script);
 

--- a/qlty-check/src/tool/ruby/sys/windows.rs
+++ b/qlty-check/src/tool/ruby/sys/windows.rs
@@ -63,7 +63,7 @@ impl RubyWindows {
     fn verify_system_installation(tool: &dyn Tool) -> Result<()> {
         let cmd = Command::new(None, tool.version_command().unwrap_or_default())
             .cmd
-            .full_env(tool.env())
+            .full_env(tool.env()?)
             .stderr_to_stdout()
             .stdout_capture();
 

--- a/qlty-check/src/tool/ruby_source.rs
+++ b/qlty-check/src/tool/ruby_source.rs
@@ -56,11 +56,11 @@ impl Tool for RubySource {
         Ok(())
     }
 
-    fn extra_env_paths(&self) -> Vec<String> {
-        vec![
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
+        Ok(vec![
             join_path_string!(self.directory(), "bin"),
             "/opt/homebrew/bin".to_string(),
-        ]
+        ])
     }
 
     fn extra_env_vars(&self) -> HashMap<String, String> {

--- a/qlty-check/src/tool/ruby_source.rs
+++ b/qlty-check/src/tool/ruby_source.rs
@@ -63,13 +63,13 @@ impl Tool for RubySource {
         ])
     }
 
-    fn extra_env_vars(&self) -> HashMap<String, String> {
+    fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
         let mut env = HashMap::new();
         env.insert(
             "LD_LIBRARY_PATH".to_string(),
             join_path_string!(self.directory(), "lib"),
         );
-        env
+        Ok(env)
     }
 
     fn version_command(&self) -> Option<String> {

--- a/qlty-check/src/tool/rust.rs
+++ b/qlty-check/src/tool/rust.rs
@@ -157,7 +157,7 @@ impl Tool for RustPackage {
         Ok(())
     }
 
-    fn extra_env_paths(&self) -> Vec<String> {
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
         self.runtime.extra_env_paths()
     }
 


### PR DESCRIPTION
# Error Handling Improvements

This PR improves error handling throughout the codebase by replacing unwraps with proper error handling using the Result type.

## Changes

1. ✅ Updated InvocationResult to handle env() errors by properly propagating them with context
2. ✅ Updated initialize_installation to return Result<Installation> and use the ? operator to return Err if tool.env() is an Err
3. ✅ Updated fn extra_env_vars to return Result<HashMap<String, String>>
4. ✅ Modified fn extra_env_vars in ruby.rs to treat errors from self.package_file_envs as fatal using the ? operator

The PR makes error handling more consistent throughout the codebase, ensuring that errors are properly propagated and displayed to the user with appropriate context.