### PR TITLE
Update WorkspaceEntrySource trait to return Result

### DIFF
--- a/qlty-analysis/src/workspace_entries/all_source.rs
+++ b/qlty-analysis/src/workspace_entries/all_source.rs
@@ -1,5 +1,6 @@
 use super::workspace_entry::{WorkspaceEntry, WorkspaceEntrySource};
 use crate::ArgsSource;
+use anyhow::Result;
 use core::fmt;
 use std::{path::PathBuf, sync::Arc};
 
@@ -29,7 +30,7 @@ impl AllSource {
 }
 
 impl WorkspaceEntrySource for AllSource {
-    fn entries(&self) -> Arc<Vec<WorkspaceEntry>> {
+    fn entries(&self) -> Result<Arc<Vec<WorkspaceEntry>>> {
         self.iter.entries()
     }
 }
@@ -47,7 +48,7 @@ mod test {
         let source = AllSource::new(root.path().to_path_buf());
         let mut paths = vec![];
 
-        for workspace_entry in source.entries().iter() {
+        for workspace_entry in source.entries().unwrap().iter() {
             let workspace_entry = workspace_entry.clone();
             paths.push((workspace_entry.path, workspace_entry.kind));
         }
@@ -84,7 +85,7 @@ mod test {
         let source = AllSource::new(root.path().to_path_buf());
         let mut paths = vec![];
 
-        for workspace_entry in source.entries().iter() {
+        for workspace_entry in source.entries().unwrap().iter() {
             paths.push(workspace_entry.clone().path);
         }
 

--- a/qlty-analysis/src/workspace_entries/args_source.rs
+++ b/qlty-analysis/src/workspace_entries/args_source.rs
@@ -1,4 +1,5 @@
 use crate::{walker::WalkerBuilder, WorkspaceEntry, WorkspaceEntryKind, WorkspaceEntrySource};
+use anyhow::Result;
 use core::fmt;
 use ignore::WalkState;
 use path_absolutize::Absolutize;
@@ -11,7 +12,7 @@ use std::{
 pub struct ArgsSource {
     pub root: PathBuf,
     pub paths: Vec<PathBuf>,
-    pub entries: Arc<Vec<WorkspaceEntry>>,
+    pub entries: Result<Arc<Vec<WorkspaceEntry>>>,
 }
 
 impl fmt::Debug for ArgsSource {
@@ -23,19 +24,22 @@ impl fmt::Debug for ArgsSource {
 impl ArgsSource {
     pub fn new(root: PathBuf, paths: Vec<PathBuf>) -> Self {
         Self {
-            entries: Arc::new(Self::build(&root, &paths)),
+            entries: Self::build(&root, &paths),
             root,
             paths,
         }
     }
 
-    fn build(root: &PathBuf, paths: &Vec<PathBuf>) -> Vec<WorkspaceEntry> {
+    fn build(root: &PathBuf, paths: &[PathBuf]) -> Result<Arc<Vec<WorkspaceEntry>>> {
         let workspace_entries = Arc::new(Mutex::new(vec![]));
 
         WalkerBuilder::new().build(paths).run(|| {
             let entries = workspace_entries.clone();
             Box::new(move |entry| {
-                let entry = entry.unwrap();
+                let entry = match entry {
+                    Ok(e) => e,
+                    Err(_) => return WalkState::Continue,
+                };
                 let path = entry.path();
 
                 let workspace_entry_kind = if path.is_dir() {
@@ -44,36 +48,55 @@ impl ArgsSource {
                     WorkspaceEntryKind::File
                 };
 
-                let clean_path = path
-                    .absolutize()
-                    .ok()
-                    .unwrap()
-                    .strip_prefix(root)
-                    .ok()
-                    .unwrap_or(path)
-                    .to_path_buf();
-                let metadata = entry.metadata().ok().unwrap();
+                let clean_path = match path.absolutize() {
+                    Ok(abs_path) => match abs_path.strip_prefix(root) {
+                        Ok(rel_path) => rel_path.to_path_buf(),
+                        Err(_) => path.to_path_buf(),
+                    },
+                    Err(_) => path.to_path_buf(),
+                };
 
-                entries.lock().unwrap().push(WorkspaceEntry {
-                    path: clean_path,
-                    content_modified: metadata.modified().ok().unwrap(),
-                    contents_size: metadata.len(),
-                    kind: workspace_entry_kind,
-                    language_name: None,
-                });
+                let metadata = match entry.metadata() {
+                    Ok(m) => m,
+                    Err(_) => return WalkState::Continue,
+                };
+
+                let content_modified = metadata
+                    .modified()
+                    .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+
+                if let Ok(mut entries_guard) = entries.lock() {
+                    entries_guard.push(WorkspaceEntry {
+                        path: clean_path,
+                        content_modified,
+                        contents_size: metadata.len(),
+                        kind: workspace_entry_kind,
+                        language_name: None,
+                    });
+                }
 
                 WalkState::Continue
             })
         });
 
-        let guard = workspace_entries.lock().unwrap();
-        guard.to_vec()
+        // Use a separate scope for the lock to ensure it's released before return
+        let entries_vec = {
+            let guard = workspace_entries
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Failed to lock workspace entries: {}", e))?;
+            guard.to_vec()
+        };
+
+        Ok(Arc::new(entries_vec))
     }
 }
 
 impl WorkspaceEntrySource for ArgsSource {
-    fn entries(&self) -> Arc<Vec<WorkspaceEntry>> {
-        self.entries.clone()
+    fn entries(&self) -> Result<Arc<Vec<WorkspaceEntry>>> {
+        match &self.entries {
+            Ok(entries) => Ok(entries.clone()),
+            Err(e) => Err(anyhow::anyhow!("Failed to get entries: {}", e)),
+        }
     }
 }
 
@@ -94,7 +117,7 @@ mod test {
 
         let mut paths = vec![];
 
-        for workspace_entry in source.entries().iter() {
+        for workspace_entry in source.entries().unwrap().iter() {
             let workspace_entry = workspace_entry.clone();
             paths.push((workspace_entry.path, workspace_entry.kind));
         }
@@ -129,7 +152,7 @@ mod test {
 
         let mut paths = vec![];
 
-        for workspace_entry in source.entries().iter() {
+        for workspace_entry in source.entries().unwrap().iter() {
             paths.push(workspace_entry.clone().path);
         }
 

--- a/qlty-analysis/src/workspace_entries/args_source.rs
+++ b/qlty-analysis/src/workspace_entries/args_source.rs
@@ -31,62 +31,139 @@ impl ArgsSource {
     }
 
     fn build(root: &PathBuf, paths: &[PathBuf]) -> Result<Arc<Vec<WorkspaceEntry>>> {
-        let workspace_entries = Arc::new(Mutex::new(vec![]));
+        // Using a channel to communicate potential errors from the walker callback
+        let (error_sender, error_receiver) = std::sync::mpsc::channel();
+        let entries = Arc::new(Mutex::new(vec![]));
 
-        WalkerBuilder::new().build(paths).run(|| {
-            let entries = workspace_entries.clone();
+        let walker = WalkerBuilder::new().build(paths);
+        let should_quit = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        
+        walker.run(|| {
+            let entries_clone = entries.clone();
+            let error_sender_clone = error_sender.clone();
+            let should_quit_clone = should_quit.clone();
+            
             Box::new(move |entry| {
+                // Check if we should quit due to a previous error
+                if should_quit_clone.load(std::sync::atomic::Ordering::Relaxed) {
+                    return WalkState::Quit;
+                }
+                
+                // Process the entry, handling any errors
                 let entry = match entry {
                     Ok(e) => e,
-                    Err(_) => return WalkState::Continue,
+                    Err(e) => {
+                        let err = anyhow::anyhow!("Failed to access entry: {}", e);
+                        let _ = error_sender_clone.send(err);
+                        should_quit_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+                        return WalkState::Quit;
+                    }
                 };
+                
                 let path = entry.path();
-
+                
                 let workspace_entry_kind = if path.is_dir() {
                     WorkspaceEntryKind::Directory
                 } else {
                     WorkspaceEntryKind::File
                 };
-
-                let clean_path = match path.absolutize() {
-                    Ok(abs_path) => match abs_path.strip_prefix(root) {
-                        Ok(rel_path) => rel_path.to_path_buf(),
-                        Err(_) => path.to_path_buf(),
-                    },
-                    Err(_) => path.to_path_buf(),
+                
+                // Handle absolutize errors
+                let abs_path = match path.absolutize() {
+                    Ok(p) => p,
+                    Err(e) => {
+                        let err = anyhow::anyhow!(
+                            "Failed to absolutize path {}: {}", 
+                            path.display(), e
+                        );
+                        let _ = error_sender_clone.send(err);
+                        should_quit_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+                        return WalkState::Quit;
+                    }
                 };
-
+                
+                // Handle strip_prefix errors
+                let clean_path = match abs_path.strip_prefix(root) {
+                    Ok(rel_path) => rel_path.to_path_buf(),
+                    Err(e) => {
+                        let err = anyhow::anyhow!(
+                            "Failed to strip prefix from path {}: {}", 
+                            abs_path.display(), e
+                        );
+                        let _ = error_sender_clone.send(err);
+                        should_quit_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+                        return WalkState::Quit;
+                    }
+                };
+                
+                // Handle metadata errors
                 let metadata = match entry.metadata() {
                     Ok(m) => m,
-                    Err(_) => return WalkState::Continue,
+                    Err(e) => {
+                        let err = anyhow::anyhow!(
+                            "Failed to get metadata for path {}: {}", 
+                            path.display(), e
+                        );
+                        let _ = error_sender_clone.send(err);
+                        should_quit_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+                        return WalkState::Quit;
+                    }
                 };
-
-                let content_modified = metadata
-                    .modified()
-                    .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-
-                if let Ok(mut entries_guard) = entries.lock() {
-                    entries_guard.push(WorkspaceEntry {
-                        path: clean_path,
-                        content_modified,
-                        contents_size: metadata.len(),
-                        kind: workspace_entry_kind,
-                        language_name: None,
-                    });
+                
+                // Handle modified time errors
+                let content_modified = match metadata.modified() {
+                    Ok(m) => m,
+                    Err(e) => {
+                        let err = anyhow::anyhow!(
+                            "Failed to get modification time for path {}: {}", 
+                            path.display(), e
+                        );
+                        let _ = error_sender_clone.send(err);
+                        should_quit_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+                        return WalkState::Quit;
+                    }
+                };
+                
+                // Handle lock errors
+                match entries_clone.lock() {
+                    Ok(mut entries_guard) => {
+                        entries_guard.push(WorkspaceEntry {
+                            path: clean_path,
+                            content_modified,
+                            contents_size: metadata.len(),
+                            kind: workspace_entry_kind,
+                            language_name: None,
+                        });
+                    },
+                    Err(e) => {
+                        let err = anyhow::anyhow!(
+                            "Failed to lock entries when processing path {}: {}", 
+                            path.display(), e
+                        );
+                        let _ = error_sender_clone.send(err);
+                        should_quit_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+                        return WalkState::Quit;
+                    }
                 }
-
+                
                 WalkState::Continue
             })
         });
-
-        // Use a separate scope for the lock to ensure it's released before return
+        
+        // Check if there was an error during the walk
+        drop(error_sender); // Drop the sender to close the channel
+        if let Ok(err) = error_receiver.try_recv() {
+            return Err(err);
+        }
+        
+        // Get the final entries
         let entries_vec = {
-            let guard = workspace_entries
+            let guard = entries
                 .lock()
-                .map_err(|e| anyhow::anyhow!("Failed to lock workspace entries: {}", e))?;
+                .map_err(|e| anyhow::anyhow!("Failed to lock workspace entries at final collection: {}", e))?;
             guard.to_vec()
         };
-
+        
         Ok(Arc::new(entries_vec))
     }
 }

--- a/qlty-analysis/src/workspace_entries/args_source.rs
+++ b/qlty-analysis/src/workspace_entries/args_source.rs
@@ -37,18 +37,18 @@ impl ArgsSource {
 
         let walker = WalkerBuilder::new().build(paths);
         let should_quit = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        
+
         walker.run(|| {
             let entries_clone = entries.clone();
             let error_sender_clone = error_sender.clone();
             let should_quit_clone = should_quit.clone();
-            
+
             Box::new(move |entry| {
                 // Check if we should quit due to a previous error
                 if should_quit_clone.load(std::sync::atomic::Ordering::Relaxed) {
                     return WalkState::Quit;
                 }
-                
+
                 // Process the entry, handling any errors
                 let entry = match entry {
                     Ok(e) => e,
@@ -59,71 +59,72 @@ impl ArgsSource {
                         return WalkState::Quit;
                     }
                 };
-                
+
                 let path = entry.path();
-                
+
                 let workspace_entry_kind = if path.is_dir() {
                     WorkspaceEntryKind::Directory
                 } else {
                     WorkspaceEntryKind::File
                 };
-                
+
                 // Handle absolutize errors
                 let abs_path = match path.absolutize() {
                     Ok(p) => p,
                     Err(e) => {
-                        let err = anyhow::anyhow!(
-                            "Failed to absolutize path {}: {}", 
-                            path.display(), e
-                        );
+                        let err =
+                            anyhow::anyhow!("Failed to absolutize path {}: {}", path.display(), e);
                         let _ = error_sender_clone.send(err);
                         should_quit_clone.store(true, std::sync::atomic::Ordering::Relaxed);
                         return WalkState::Quit;
                     }
                 };
-                
+
                 // Handle strip_prefix errors
                 let clean_path = match abs_path.strip_prefix(root) {
                     Ok(rel_path) => rel_path.to_path_buf(),
                     Err(e) => {
                         let err = anyhow::anyhow!(
-                            "Failed to strip prefix from path {}: {}", 
-                            abs_path.display(), e
+                            "Failed to strip prefix from path {}: {}",
+                            abs_path.display(),
+                            e
                         );
                         let _ = error_sender_clone.send(err);
                         should_quit_clone.store(true, std::sync::atomic::Ordering::Relaxed);
                         return WalkState::Quit;
                     }
                 };
-                
+
                 // Handle metadata errors
                 let metadata = match entry.metadata() {
                     Ok(m) => m,
                     Err(e) => {
                         let err = anyhow::anyhow!(
-                            "Failed to get metadata for path {}: {}", 
-                            path.display(), e
+                            "Failed to get metadata for path {}: {}",
+                            path.display(),
+                            e
                         );
                         let _ = error_sender_clone.send(err);
                         should_quit_clone.store(true, std::sync::atomic::Ordering::Relaxed);
                         return WalkState::Quit;
                     }
                 };
-                
+
                 // Handle modified time errors
                 let content_modified = match metadata.modified() {
                     Ok(m) => m,
                     Err(e) => {
                         let err = anyhow::anyhow!(
-                            "Failed to get modification time for path {}: {}", 
-                            path.display(), e
+                            "Failed to get modification time for path {}: {}",
+                            path.display(),
+                            e
                         );
                         let _ = error_sender_clone.send(err);
                         should_quit_clone.store(true, std::sync::atomic::Ordering::Relaxed);
                         return WalkState::Quit;
                     }
                 };
-                
+
                 // Handle lock errors
                 match entries_clone.lock() {
                     Ok(mut entries_guard) => {
@@ -134,36 +135,40 @@ impl ArgsSource {
                             kind: workspace_entry_kind,
                             language_name: None,
                         });
-                    },
+                    }
                     Err(e) => {
                         let err = anyhow::anyhow!(
-                            "Failed to lock entries when processing path {}: {}", 
-                            path.display(), e
+                            "Failed to lock entries when processing path {}: {}",
+                            path.display(),
+                            e
                         );
                         let _ = error_sender_clone.send(err);
                         should_quit_clone.store(true, std::sync::atomic::Ordering::Relaxed);
                         return WalkState::Quit;
                     }
                 }
-                
+
                 WalkState::Continue
             })
         });
-        
+
         // Check if there was an error during the walk
         drop(error_sender); // Drop the sender to close the channel
         if let Ok(err) = error_receiver.try_recv() {
             return Err(err);
         }
-        
+
         // Get the final entries
         let entries_vec = {
-            let guard = entries
-                .lock()
-                .map_err(|e| anyhow::anyhow!("Failed to lock workspace entries at final collection: {}", e))?;
+            let guard = entries.lock().map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to lock workspace entries at final collection: {}",
+                    e
+                )
+            })?;
             guard.to_vec()
         };
-        
+
         Ok(Arc::new(entries_vec))
     }
 }

--- a/qlty-analysis/src/workspace_entries/diff_source.rs
+++ b/qlty-analysis/src/workspace_entries/diff_source.rs
@@ -1,5 +1,6 @@
 use super::workspace_entry::{WorkspaceEntry, WorkspaceEntryKind};
 use crate::WorkspaceEntrySource;
+use anyhow::Result;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -53,8 +54,8 @@ impl DiffSource {
 }
 
 impl WorkspaceEntrySource for DiffSource {
-    fn entries(&self) -> Arc<Vec<WorkspaceEntry>> {
-        self.entries.clone()
+    fn entries(&self) -> Result<Arc<Vec<WorkspaceEntry>>> {
+        Ok(self.entries.clone())
     }
 }
 

--- a/qlty-analysis/src/workspace_entries/workspace_entry.rs
+++ b/qlty-analysis/src/workspace_entries/workspace_entry.rs
@@ -43,5 +43,5 @@ impl WorkspaceEntry {
 }
 
 pub trait WorkspaceEntrySource: std::fmt::Debug + Send + Sync {
-    fn entries(&self) -> Arc<Vec<WorkspaceEntry>>;
+    fn entries(&self) -> Result<Arc<Vec<WorkspaceEntry>>>;
 }

--- a/qlty-analysis/src/workspace_entries/workspace_entry_finder.rs
+++ b/qlty-analysis/src/workspace_entries/workspace_entry_finder.rs
@@ -74,7 +74,8 @@ impl WorkspaceEntryFinder {
 
         let mut workspace_entries = vec![];
 
-        for workspace_entry in self.source.entries().iter() {
+        let entries = self.source.entries()?;
+        for workspace_entry in entries.iter() {
             if let Some(workspace_entry) = self.matcher.matches(workspace_entry.clone()) {
                 trace!("Adding workspace entry: {:?}", &workspace_entry);
                 workspace_entries.push(workspace_entry);


### PR DESCRIPTION
## Summary
- Update WorkspaceEntrySource trait to return `Result<Arc<Vec<WorkspaceEntry>>>` instead of `Arc<Vec<WorkspaceEntry>>`
- Update all implementations (DiffSource, AllSource, ArgsSource) to handle errors properly  
- Update ArgsSource::build to properly handle errors instead of using unwraps
- Make ArgsSource::build treat all errors as fatal and bail immediately
- Use a channel and atomic flag to safely communicate errors from the walker closure
- Fix all tests to accommodate the new return type

## Test plan
- All existing tests have been updated and are passing
- Code has been linted and formatted
- Type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)