### PR TITLE
docs: link `CONTRIBUTING.md` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ cargo test
 
 ## Contributing
 
-1. Read the Guide to Contributing in CONTRIBUTING.md
+1. Read the Guide to Contributing in [CONTRIBUTING.md](https://github.com/qltysh/qlty/blob/main/CONTRIBUTING.md)
 2. Fork the repository and
 3. Submit a pull request.
 


### PR DESCRIPTION
 This patch updates the README to link directly to the `CONTRIBUTING.md` file on GitHub, making it easier to access.