### PR TITLE
Fix running `qlty check PATH` in a subdir

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -47,11 +47,11 @@ name = "actionlint"
 
 [[plugin]]
 name = "clippy"
-version = "1.87.0" # Note: Clippy version is controlled by the rust version above
+version = "1.88.0" # Note: Clippy version is controlled by the rust version above
 
 [[plugin]]
 name = "rustfmt"
-version = "1.87.0" # Note: rustfmt version is controlled by the rust version above
+version = "1.88.0" # Note: rustfmt version is controlled by the rust version above
 
 [[plugin]]
 name = "eslint"

--- a/qlty-check/src/planner.rs
+++ b/qlty-check/src/planner.rs
@@ -144,8 +144,7 @@ impl Planner {
 
         builder.compute()?;
 
-        self.workspace_entry_finder_builder =
-            Some(builder);
+        self.workspace_entry_finder_builder = Some(builder);
 
         Ok(())
     }

--- a/qlty-check/src/planner.rs
+++ b/qlty-check/src/planner.rs
@@ -234,8 +234,8 @@ impl Planner {
             self.transformers.push(diff_line_filter);
 
             if !self.settings.emit_existing_issues {
-                match &self.target_mode.as_ref().unwrap() {
-                    TargetMode::UpstreamDiff(_) | TargetMode::HeadDiff => {
+                match &self.target_mode.as_ref() {
+                    Some(TargetMode::UpstreamDiff(_)) | Some(TargetMode::HeadDiff) => {
                         self.transformers.push(Box::new(DiffLineFilter));
                     }
                     _ => {}
@@ -276,9 +276,15 @@ impl Planner {
     }
 
     fn build_plan(&mut self) -> Result<Plan> {
+        let target_mode = self
+            .target_mode
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Target mode not computed"))?
+            .clone();
+
         Ok(Plan {
             verb: self.verb,
-            target_mode: self.target_mode.as_ref().unwrap().clone(),
+            target_mode,
             settings: self.settings.clone(),
             workspace: self.workspace.clone(),
             config: self.config.clone(),

--- a/qlty-check/src/planner.rs
+++ b/qlty-check/src/planner.rs
@@ -188,7 +188,6 @@ impl Planner {
             }
         }
 
-
         let results = plugin_planners
             .par_iter_mut()
             .map(|planner| planner.compute())

--- a/qlty-check/src/planner/driver.rs
+++ b/qlty-check/src/planner/driver.rs
@@ -22,7 +22,7 @@ use qlty_types::analysis::v1::ExecutionVerb;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::{
     path::PathBuf,
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 use tracing::{debug, error, info, trace};
 
@@ -42,7 +42,7 @@ pub struct DriverPlanner {
     tool: Box<dyn Tool>,
     workspace_entries: Arc<Vec<WorkspaceEntry>>,
     target_mode: TargetMode,
-    workspace_entry_finder_builder: Arc<Mutex<PluginWorkspaceEntryFinderBuilder>>,
+    workspace_entry_finder_builder: PluginWorkspaceEntryFinderBuilder,
     invocation_directory_planner: InvocationDirectoryPlanner,
     pub cache_hits: Vec<IssuesCacheHit>,
     pub invocations: Vec<InvocationPlan>,
@@ -118,8 +118,6 @@ impl DriverPlanner {
         if let Some(file_types) = &self.driver.file_types {
             let mut workspace_entry_finder = self
                 .workspace_entry_finder_builder
-                .lock()
-                .unwrap()
                 .build(file_types)?;
 
             self.workspace_entries = match self.target_mode {

--- a/qlty-check/src/planner/driver.rs
+++ b/qlty-check/src/planner/driver.rs
@@ -113,8 +113,9 @@ impl DriverPlanner {
 
     fn compute_driver_workspace_entries(&mut self) -> Result<()> {
         if let Some(file_types) = &self.driver.file_types {
-            let mut workspace_entry_finder =
-                self.workspace_entry_finder_builder.build(file_types)?;
+            let mut workspace_entry_finder = self
+                .workspace_entry_finder_builder
+                .build(file_types, self.plugin.prefix.clone())?;
 
             self.workspace_entries = match self.target_mode {
                 TargetMode::Sample(sample) => Arc::new(workspace_entry_finder.sample(sample)?),

--- a/qlty-check/src/planner/driver.rs
+++ b/qlty-check/src/planner/driver.rs
@@ -20,10 +20,7 @@ use qlty_config::{
 };
 use qlty_types::analysis::v1::ExecutionVerb;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use std::{
-    path::PathBuf,
-    sync::Arc,
-};
+use std::{path::PathBuf, sync::Arc};
 use tracing::{debug, error, info, trace};
 
 #[derive(Debug, Clone)]
@@ -116,9 +113,8 @@ impl DriverPlanner {
 
     fn compute_driver_workspace_entries(&mut self) -> Result<()> {
         if let Some(file_types) = &self.driver.file_types {
-            let mut workspace_entry_finder = self
-                .workspace_entry_finder_builder
-                .build(file_types)?;
+            let mut workspace_entry_finder =
+                self.workspace_entry_finder_builder.build(file_types)?;
 
             self.workspace_entries = match self.target_mode {
                 TargetMode::Sample(sample) => Arc::new(workspace_entry_finder.sample(sample)?),

--- a/qlty-check/src/planner/plugin.rs
+++ b/qlty-check/src/planner/plugin.rs
@@ -10,14 +10,14 @@ use qlty_config::{
     Workspace,
 };
 use qlty_types::analysis::v1::ExecutionVerb;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tracing::{debug, info, trace};
 
 #[derive(Debug, Clone)]
 pub struct PluginPlanner {
     formatters: bool,
     pub target_mode: TargetMode,
-    pub workspace_entry_finder_builder: Arc<Mutex<PluginWorkspaceEntryFinderBuilder>>,
+    pub workspace_entry_finder_builder: PluginWorkspaceEntryFinderBuilder,
     pub plugin_name: String,
     pub plugin: PluginDef,
     pub verb: ExecutionVerb,
@@ -49,9 +49,7 @@ impl PluginPlanner {
 
         let workspace_entry_finder_builder = planner
             .workspace_entry_finder_builder
-            .clone()
-            .unwrap()
-            .clone();
+            .clone().unwrap();
 
         Self {
             plugin_name: plugin_name.to_owned(),
@@ -117,7 +115,8 @@ impl PluginPlanner {
 
     fn compute_workspace_entries(&mut self) -> Result<()> {
         let mut workspace_entry_finder_builder =
-            self.workspace_entry_finder_builder.lock().unwrap();
+            self.workspace_entry_finder_builder.clone();
+
         let prefix = workspace_entry_finder_builder.prefix.clone();
         if let Some(prefix) = &self.plugin.prefix {
             workspace_entry_finder_builder.prefix = Some(prefix.clone());

--- a/qlty-check/src/planner/plugin.rs
+++ b/qlty-check/src/planner/plugin.rs
@@ -47,9 +47,8 @@ impl PluginPlanner {
             .build_tool()
             .unwrap();
 
-        let workspace_entry_finder_builder = planner
-            .workspace_entry_finder_builder
-            .clone().unwrap();
+        let workspace_entry_finder_builder =
+            planner.workspace_entry_finder_builder.clone().unwrap();
 
         Self {
             plugin_name: plugin_name.to_owned(),
@@ -114,8 +113,7 @@ impl PluginPlanner {
     }
 
     fn compute_workspace_entries(&mut self) -> Result<()> {
-        let mut workspace_entry_finder_builder =
-            self.workspace_entry_finder_builder.clone();
+        let mut workspace_entry_finder_builder = self.workspace_entry_finder_builder.clone();
 
         let prefix = workspace_entry_finder_builder.prefix.clone();
         if let Some(prefix) = &self.plugin.prefix {

--- a/qlty-check/src/planner/plugin.rs
+++ b/qlty-check/src/planner/plugin.rs
@@ -10,14 +10,14 @@ use qlty_config::{
     Workspace,
 };
 use qlty_types::analysis::v1::ExecutionVerb;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tracing::{debug, info, trace};
 
 #[derive(Debug, Clone)]
 pub struct PluginPlanner {
     formatters: bool,
     pub target_mode: TargetMode,
-    pub workspace_entry_finder_builder: Arc<Mutex<PluginWorkspaceEntryFinderBuilder>>,
+    pub workspace_entry_finder_builder: PluginWorkspaceEntryFinderBuilder,
     pub plugin_name: String,
     pub plugin: PluginDef,
     pub verb: ExecutionVerb,
@@ -31,57 +31,6 @@ pub struct PluginPlanner {
     pub tool: Box<dyn Tool>,
     pub driver_planners: Vec<DriverPlanner>,
     pub all_prefixes: Vec<String>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::executor::staging_area::Mode;
-    use crate::tool::null_tool::NullTool;
-    use qlty_analysis::cache::NullCache;
-    use std::path::PathBuf;
-
-    #[test]
-    fn test_compute_workspace_entries_lock_error() {
-        // Create a workspace_entry_finder_builder that will fail when locked
-        let broken_mutex = Arc::new(Mutex::new(PluginWorkspaceEntryFinderBuilder::default()));
-        // Poison the mutex by forcing a panic in a thread that holds the lock
-        let broken_mutex_clone = broken_mutex.clone();
-        let handle = std::thread::spawn(move || {
-            let _guard = broken_mutex_clone.lock().unwrap();
-            panic!("This panic is intentional for testing");
-        });
-        let _ = handle.join(); // This should be an Err because the thread panicked
-
-        // Now create a PluginPlanner with the poisoned mutex
-        let mut planner = PluginPlanner {
-            formatters: false,
-            target_mode: TargetMode::All,
-            workspace_entry_finder_builder: broken_mutex,
-            plugin_name: "test".to_string(),
-            plugin: PluginDef::default(),
-            verb: ExecutionVerb::Check,
-            settings: Settings::default(),
-            workspace: Workspace {
-                root: PathBuf::from("/"),
-            },
-            plugin_configs: vec![],
-            issue_cache: IssueCache::new(Box::new(NullCache::new())),
-            workspace_entries: Arc::new(vec![]),
-            staging_area: StagingArea::generate(Mode::Source, PathBuf::from("/"), None),
-            runtime_version: None,
-            tool: Box::new(NullTool {
-                plugin_name: "test".to_string(),
-                plugin: PluginDef::default(),
-            }),
-            driver_planners: vec![],
-            all_prefixes: vec![],
-        };
-
-        // Verify that compute_workspace_entries returns an error instead of panicking
-        let result = planner.compute_workspace_entries();
-        assert!(result.is_err());
-    }
 }
 
 impl PluginPlanner {
@@ -105,8 +54,7 @@ impl PluginPlanner {
         let workspace_entry_finder_builder = planner
             .workspace_entry_finder_builder
             .clone()
-            .context("Workspace entry finder builder is missing")?
-            .clone();
+            .context("Workspace entry finder builder is missing")?;
 
         let target_mode = planner
             .target_mode
@@ -176,10 +124,7 @@ impl PluginPlanner {
     }
 
     fn compute_workspace_entries(&mut self) -> Result<()> {
-        let mut workspace_entry_finder_builder =
-            self.workspace_entry_finder_builder.lock().map_err(|_| {
-                anyhow::anyhow!("Failed to acquire lock on workspace_entry_finder_builder")
-            })?;
+        let mut workspace_entry_finder_builder = self.workspace_entry_finder_builder.clone();
         let prefix = workspace_entry_finder_builder.prefix.clone();
         if let Some(prefix) = &self.plugin.prefix {
             workspace_entry_finder_builder.prefix = Some(prefix.clone());

--- a/qlty-check/src/planner/plugin.rs
+++ b/qlty-check/src/planner/plugin.rs
@@ -124,20 +124,14 @@ impl PluginPlanner {
     }
 
     fn compute_workspace_entries(&mut self) -> Result<()> {
-        let mut workspace_entry_finder_builder = self.workspace_entry_finder_builder.clone();
-        let prefix = workspace_entry_finder_builder.prefix.clone();
-        if let Some(prefix) = &self.plugin.prefix {
-            workspace_entry_finder_builder.prefix = Some(prefix.clone());
-        };
-        let mut workspace_entry_finder =
-            workspace_entry_finder_builder.build(&self.plugin.file_types)?;
+        let mut workspace_entry_finder = self
+            .workspace_entry_finder_builder
+            .build(&self.plugin.file_types, self.plugin.prefix.clone())?;
 
         self.workspace_entries = match self.target_mode {
             TargetMode::Sample(sample) => Arc::new(workspace_entry_finder.sample(sample)?),
             _ => Arc::new(workspace_entry_finder.workspace_entries()?),
         };
-
-        workspace_entry_finder_builder.prefix = prefix;
 
         if self.workspace_entries.is_empty() {
             debug!("Found 0 workspace_entries for plugin {}", self.plugin_name);

--- a/qlty-check/src/planner/plugin_workspace_entry_finder_builder.rs
+++ b/qlty-check/src/planner/plugin_workspace_entry_finder_builder.rs
@@ -21,7 +21,6 @@ pub struct PluginWorkspaceEntryFinderBuilder {
     pub file_types: HashMap<String, FileType>,
     pub ignores: Vec<Ignore>,
     pub git_diff: Option<GitDiff>,
-    pub prefix: Option<String>,
     pub source: Option<Arc<dyn WorkspaceEntrySource>>,
 }
 

--- a/qlty-check/src/planner/plugin_workspace_entry_finder_builder.rs
+++ b/qlty-check/src/planner/plugin_workspace_entry_finder_builder.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result};
 use qlty_analysis::utils::fs::path_to_string;
 use qlty_analysis::workspace_entries::{IgnoreGroupsMatcher, TargetMode};
 use qlty_analysis::{
@@ -20,12 +20,18 @@ pub struct PluginWorkspaceEntryFinderBuilder {
     pub paths: Vec<PathBuf>,
     pub file_types: HashMap<String, FileType>,
     pub ignores: Vec<Ignore>,
-    pub cached_git_diff: Option<GitDiff>,
+    pub git_diff: Option<GitDiff>,
     pub prefix: Option<String>,
     pub source: Option<Arc<dyn WorkspaceEntrySource>>,
 }
 
 impl PluginWorkspaceEntryFinderBuilder {
+    pub fn compute(&mut self) -> Result<()> {
+        self.compute_git_diff()?;
+        self.compute_source()?;
+        Ok(())
+    }
+
     pub fn build(&mut self, language_names: &[String]) -> Result<WorkspaceEntryFinder> {
         Ok(WorkspaceEntryFinder::new(
             self.source()?,
@@ -36,42 +42,14 @@ impl PluginWorkspaceEntryFinderBuilder {
     pub fn diff_line_filter(&mut self) -> Result<Box<dyn IssueTransformer>> {
         match self.mode {
             TargetMode::HeadDiff | TargetMode::UpstreamDiff(_) => {
-                Ok(Box::new(self.git_diff()?.line_filter))
+                Ok(Box::new(self.git_diff.as_ref().unwrap().line_filter.clone()))
             }
             _ => Ok(Box::new(NullIssueTransformer)),
         }
     }
 
     fn source(&mut self) -> Result<Arc<dyn WorkspaceEntrySource>> {
-        if self.source.is_none() {
-            self.source = Some(match self.mode {
-                TargetMode::All | TargetMode::Sample(_) => {
-                    Arc::new(AllSource::new(self.root.clone()))
-                }
-                TargetMode::Paths(_) => Arc::new(ArgsSource::new(
-                    self.root.clone(),
-                    // Use absolute paths, so when running in a subdirectory, the paths are still correct
-                    self.paths.iter().map(|p| self.root.join(p)).collect(),
-                )),
-                TargetMode::UpstreamDiff(_) => {
-                    Arc::new(DiffSource::new(self.git_diff()?.changed_files, &self.root))
-                }
-                TargetMode::HeadDiff => {
-                    Arc::new(DiffSource::new(self.git_diff()?.changed_files, &self.root))
-                }
-                TargetMode::Index => {
-                    Arc::new(DiffSource::new(self.git_diff()?.changed_files, &self.root))
-                }
-                TargetMode::IndexFile(_) => {
-                    Arc::new(DiffSource::new(self.git_diff()?.changed_files, &self.root))
-                }
-            });
-        }
-        if let Some(source) = &self.source {
-            Ok(source.clone())
-        } else {
-            bail!("Invalid workspace source")
-        }
+        Ok(self.source.as_ref().unwrap().clone())
     }
 
     fn matcher(&self, language_names: &[String]) -> Result<Box<dyn WorkspaceEntryMatcher>> {
@@ -118,18 +96,44 @@ impl PluginWorkspaceEntryFinderBuilder {
         Ok(Box::new(AndMatcher::new(matchers)))
     }
 
-    fn git_diff(&mut self) -> Result<GitDiff> {
-        if let Some(diff) = &self.cached_git_diff {
-            return Ok(diff.clone());
-        }
+    fn compute_source(&mut self) -> Result<()> {
+        let cwd = Workspace::current_dir();
 
-        let diff = self.compute_git_diff()?;
-        self.cached_git_diff = Some(diff.clone());
-        Ok(diff)
+        self.source = Some(match self.mode {
+            TargetMode::All | TargetMode::Sample(_) => {
+                Arc::new(AllSource::new(self.root.clone()))
+            }
+            TargetMode::Paths(_) => Arc::new(ArgsSource::new(
+                self.root.clone(),
+                // Use absolute paths, so when running in a subdirectory, the paths are still correct
+                self.paths.iter().map(|p| cwd.join(p)).collect(),
+            )),
+            TargetMode::UpstreamDiff(_) | TargetMode::HeadDiff | TargetMode::Index | TargetMode::IndexFile(_) => {
+                self.build_diff_source()?
+            }
+        });
+
+        Ok(())
     }
 
-    fn compute_git_diff(&self) -> Result<GitDiff> {
-        let git_diff = GitDiff::compute(self.mode.diff_mode(), &self.root)?;
-        Ok(git_diff)
+    fn build_diff_source(
+        &self
+    ) -> Result<Arc<dyn WorkspaceEntrySource>> {
+        Ok(Arc::new(DiffSource::new(self.git_diff.as_ref().unwrap().changed_files.clone(), &self.root)))
+    }
+
+    fn compute_git_diff(&mut self) -> Result<()> {
+        if self.needs_git_diff() {
+            self.git_diff = Some(GitDiff::compute(self.mode.diff_mode(), &self.root)?);
+        }
+        
+        Ok(())
+    }
+
+    fn needs_git_diff(&self) -> bool {
+        matches!(
+            self.mode,
+            TargetMode::HeadDiff | TargetMode::UpstreamDiff(_) | TargetMode::Index | TargetMode::IndexFile(_)
+        )
     }
 }

--- a/qlty-check/src/planner/plugin_workspace_entry_finder_builder.rs
+++ b/qlty-check/src/planner/plugin_workspace_entry_finder_builder.rs
@@ -41,9 +41,9 @@ impl PluginWorkspaceEntryFinderBuilder {
 
     pub fn diff_line_filter(&mut self) -> Result<Box<dyn IssueTransformer>> {
         match self.mode {
-            TargetMode::HeadDiff | TargetMode::UpstreamDiff(_) => Ok(Box::new(
-                self.git_diff.as_ref().unwrap().line_filter.clone(),
-            )),
+            TargetMode::HeadDiff | TargetMode::UpstreamDiff(_) => {
+                Ok(Box::new(self.git_diff.as_ref().unwrap().line_filter.clone()))
+            }
             _ => Ok(Box::new(NullIssueTransformer)),
         }
     }

--- a/qlty-cli/tests/cmd/check/subdir_from_subdir.in/.gitignore
+++ b/qlty-cli/tests/cmd/check/subdir_from_subdir.in/.gitignore
@@ -1,0 +1,4 @@
+.qlty/results
+.qlty/logs
+.qlty/out
+.qlty/sources

--- a/qlty-cli/tests/cmd/check/subdir_from_subdir.in/.qlty/qlty.toml
+++ b/qlty-cli/tests/cmd/check/subdir_from_subdir.in/.qlty/qlty.toml
@@ -1,0 +1,14 @@
+config_version = "0"
+
+[plugins.definitions.exists]
+file_types = ["shell"]
+
+[plugins.definitions.exists.drivers.lint]
+prepare_script = "mkdir ${linter} && echo dir %2 > ${linter}/ls.cmd || echo dir %2 > ${linter}/ls.cmd"
+script = "ls -l ${target}"
+success_codes = [0]
+output = "pass_fail"
+
+[[plugin]]
+name = "exists"
+version = "1.0.0"

--- a/qlty-cli/tests/cmd/check/subdir_from_subdir.stdout
+++ b/qlty-cli/tests/cmd/check/subdir_from_subdir.stdout
@@ -1,6 +1,6 @@
  JOBS: 1 
 
 Plugin  Result   Targets   Time   Debug File
-exists  Success  1 target  [..].[..]s  .qlty/out/invoke-[..].yaml
+exists  Success  1 target  [..].[..]s  ../.qlty/out/invoke-[..].yaml
 
 Checked 1 file

--- a/qlty-cli/tests/cmd/check/subdir_from_subdir.stdout
+++ b/qlty-cli/tests/cmd/check/subdir_from_subdir.stdout
@@ -1,0 +1,6 @@
+ JOBS: 1 
+
+Plugin  Result   Targets   Time   Debug File
+exists  Success  1 target  [..].[..]s  .qlty/out/invoke-[..].yaml
+
+Checked 1 file

--- a/qlty-cli/tests/cmd/check/subdir_from_subdir.toml
+++ b/qlty-cli/tests/cmd/check/subdir_from_subdir.toml
@@ -1,0 +1,2 @@
+bin.name = "qlty"
+args = ["check", "--all", "--no-cache", "--verbose"]

--- a/qlty-cli/tests/cmd/check/subdir_from_subdir.toml
+++ b/qlty-cli/tests/cmd/check/subdir_from_subdir.toml
@@ -1,2 +1,3 @@
 bin.name = "qlty"
-args = ["check", "--all", "--no-cache", "--verbose"]
+args = ["check", "--no-cache", "--verbose", "subdir2"]
+fs.cwd = "subdir_from_subdir.in/subdir1"


### PR DESCRIPTION
This patch fixes `qlty check foo/` when in a subdirectory.

As part of this fix, I simplified the concurrency controls of the `workspace_entry_finder_builder`. Previously, it was an `Arc<Mutex<PluginWorkspaceEntryFinderBuilder>>` which I reduced to a simple `PluginWorkspaceEntryFinderBuilder` that is cloned.