### PR TITLE
Add SARIF output format for qlty check

### DIFF
--- a/qlty-cloud/src/format.rs
+++ b/qlty-cloud/src/format.rs
@@ -6,6 +6,7 @@ mod json;
 mod json_each;
 mod json_each_truncated;
 mod protos;
+mod sarif;
 
 pub use copy::CopyFormatter;
 pub use gz::GzFormatter;
@@ -13,6 +14,7 @@ pub use json::JsonFormatter;
 pub use json_each::JsonEachRowFormatter;
 pub use json_each_truncated::InvocationJsonFormatter;
 pub use protos::{ProtoFormatter, ProtosFormatter};
+pub use sarif::SarifFormatter;
 
 pub trait Formatter {
     fn write_to(&self, writer: &mut dyn std::io::Write) -> Result<()>;

--- a/qlty-cloud/src/format/sarif.rs
+++ b/qlty-cloud/src/format/sarif.rs
@@ -1,0 +1,189 @@
+use super::Formatter;
+use qlty_types::analysis::v1::{Issue, Level, Location};
+use serde_json::{json, Value};
+use std::convert::TryFrom;
+use std::io::Write;
+
+#[derive(Debug)]
+pub struct SarifFormatter {
+    issues: Vec<Issue>,
+}
+
+impl SarifFormatter {
+    pub fn new(issues: Vec<Issue>) -> Box<dyn Formatter> {
+        Box::new(Self { issues })
+    }
+
+    fn convert_level(&self, level: Level) -> &'static str {
+        match level {
+            Level::Unspecified => "none",
+            Level::Note => "note",
+            Level::Fmt => "note",
+            Level::Low => "note",
+            Level::Medium => "warning",
+            Level::High => "error",
+        }
+    }
+
+    fn get_sarif_locations(&self, location: &Option<Location>) -> Vec<Value> {
+        if let Some(location) = location {
+            let mut region = json!({});
+
+            if let Some(range) = &location.range {
+                region = json!({
+                    "startLine": range.start_line,
+                    "startColumn": range.start_column,
+                    "endLine": range.end_line,
+                    "endColumn": range.end_column
+                });
+            }
+
+            return vec![json!({
+                "physicalLocation": {
+                    "artifactLocation": {
+                        "uri": location.path
+                    },
+                    "region": region
+                }
+            })];
+        }
+
+        vec![]
+    }
+
+    fn create_sarif_document(&self) -> Value {
+        let mut rules = vec![];
+        let mut rule_ids = std::collections::HashSet::new();
+
+        // Collect all unique rules
+        for issue in &self.issues {
+            if !rule_ids.contains(&issue.rule_key) {
+                rule_ids.insert(issue.rule_key.clone());
+
+                let mut rule = json!({
+                    "id": issue.rule_key
+                });
+
+                if !issue.documentation_url.is_empty() {
+                    rule["helpUri"] = json!(issue.documentation_url.clone());
+                }
+
+                rules.push(rule);
+            }
+        }
+
+        // Convert issues to SARIF results
+        let results = self.issues.iter().map(|issue| {
+            json!({
+                "ruleId": issue.rule_key,
+                "level": self.convert_level(Level::try_from(issue.level).unwrap_or(Level::Medium)),
+                "message": {
+                    "text": issue.message
+                },
+                "locations": self.get_sarif_locations(&issue.location)
+            })
+        }).collect::<Vec<_>>();
+
+        // Create the SARIF document
+        json!({
+            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "qlty",
+                            "informationUri": "https://github.com/qlty/qlty",
+                            "rules": rules
+                        }
+                    },
+                    "results": results
+                }
+            ]
+        })
+    }
+}
+
+impl Formatter for SarifFormatter {
+    fn write_to(&self, writer: &mut dyn Write) -> anyhow::Result<()> {
+        let sarif = self.create_sarif_document();
+        let json = serde_json::to_string_pretty(&sarif)?;
+        writer.write_all(json.as_bytes())?;
+        writer.write_all(b"\n")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use qlty_types::analysis::v1::{Category, Range};
+
+    #[test]
+    fn test_sarif_formatter() {
+        let issues = vec![
+            Issue {
+                rule_key: "test-rule-1".to_string(),
+                message: "Test message 1".to_string(),
+                level: Level::High.into(),
+                location: Some(Location {
+                    path: "src/test.rs".to_string(),
+                    range: Some(Range {
+                        start_line: 10,
+                        start_column: 5,
+                        end_line: 10,
+                        end_column: 20,
+                        ..Default::default()
+                    }),
+                }),
+                documentation_url: "https://example.com/docs/test-rule-1".to_string(),
+                tool: "test-tool".to_string(),
+                category: Category::Lint.into(),
+                ..Default::default()
+            },
+            Issue {
+                rule_key: "test-rule-2".to_string(),
+                message: "Test message 2".to_string(),
+                level: Level::Medium.into(),
+                location: Some(Location {
+                    path: "src/test2.rs".to_string(),
+                    range: Some(Range {
+                        start_line: 15,
+                        start_column: 1,
+                        end_line: 20,
+                        end_column: 2,
+                        ..Default::default()
+                    }),
+                }),
+                tool: "test-tool".to_string(),
+                category: Category::Lint.into(),
+                ..Default::default()
+            },
+        ];
+
+        let formatter = SarifFormatter::new(issues);
+        let output = formatter.read().unwrap();
+        let output_str = String::from_utf8_lossy(&output);
+
+        // Ensure the output is valid JSON
+        let json_value: Value = serde_json::from_str(&output_str).unwrap();
+
+        // Verify basic structure
+        assert!(json_value.is_object());
+        assert!(json_value.get("runs").is_some());
+
+        // Verify there are 2 results
+        let results = json_value["runs"][0]["results"].as_array().unwrap();
+        assert_eq!(results.len(), 2);
+
+        // Verify the first result
+        assert_eq!(results[0]["ruleId"], "test-rule-1");
+        assert_eq!(results[0]["level"], "error");
+        assert_eq!(results[0]["message"]["text"], "Test message 1");
+
+        // Verify the second result
+        assert_eq!(results[1]["ruleId"], "test-rule-2");
+        assert_eq!(results[1]["level"], "warning");
+        assert_eq!(results[1]["message"]["text"], "Test message 2");
+    }
+}


### PR DESCRIPTION
## Summary
- Add SARIF (Static Analysis Results Interchange Format) output option to `qlty check` with `--sarif` flag
- Implement a `SarifFormatter` similar to the JSON formatter to generate SARIF 2.1.0 compliant output
- Include all relevant issue data in the SARIF format with proper rule mapping

## Test plan
- Run `qlty check --sarif [file]` to confirm valid SARIF output is generated
- Verify SARIF output is properly formatted and includes all necessary fields
- Ensure unit tests pass for the new formatter

🤖 Generated with [Claude Code](https://claude.ai/code)