### PR TITLE
Change the default generate .gitignore

### DIFF
--- a/qlty-cli/src/initializer/templates/gitignore.txt
+++ b/qlty-cli/src/initializer/templates/gitignore.txt
@@ -1,4 +1,6 @@
 *
 !configs
+!configs/**
 !hooks
+!hooks/**
 !qlty.toml


### PR DESCRIPTION
From my testing, the negated rule `!configs` does _not_ negate files within configs. I added `!configs/**` which seems to work