### PR TITLE
Test against lastest snapshot

### DIFF
--- a/qlty-plugins/plugins/package-lock.json
+++ b/qlty-plugins/plugins/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "node-fetch": "3.3.2",
+        "semver": "^7.7.1",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -13,6 +14,7 @@
         "@types/jest": "29.5.14",
         "@types/jest-specific-snapshot": "0.5.9",
         "@types/node-fetch": "3.0.2",
+        "@types/semver": "^7.7.0",
         "debug": "4.4.0",
         "fast-glob": "3.3.2",
         "jest": "29.7.0",
@@ -93,6 +95,16 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
@@ -125,6 +137,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-module-imports": {
@@ -1097,6 +1119,13 @@
         "node-fetch": "*"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -1266,6 +1295,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
@@ -2239,18 +2278,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -2770,18 +2797,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-specific-snapshot": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/jest-specific-snapshot/-/jest-specific-snapshot-8.0.0.tgz",
@@ -3003,18 +3018,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/make-error": {
@@ -3507,12 +3510,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -3786,18 +3792,6 @@
         "esbuild": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ts-node": {

--- a/qlty-plugins/plugins/package.json
+++ b/qlty-plugins/plugins/package.json
@@ -8,6 +8,7 @@
     "@types/jest": "29.5.14",
     "@types/jest-specific-snapshot": "0.5.9",
     "@types/node-fetch": "3.0.2",
+    "@types/semver": "^7.7.0",
     "debug": "4.4.0",
     "fast-glob": "3.3.2",
     "jest": "29.7.0",
@@ -21,6 +22,7 @@
   },
   "dependencies": {
     "node-fetch": "3.3.2",
+    "semver": "^7.7.1",
     "zod": "^3.24.2"
   }
 }

--- a/qlty-plugins/plugins/scripts/updateLinterVersions.ts
+++ b/qlty-plugins/plugins/scripts/updateLinterVersions.ts
@@ -133,7 +133,7 @@ async function main(): Promise<void> {
       try {
         console.log(`Testing ${linterLabel}...`);
         execSync(
-          `QLTY_PLUGINS_LINTER_VERSION=${latestLinterVersion} QLTY_PLUGINS_TEST_AGAINST_LATEST_SNAPSHOT=true npm test ${linter}.test.ts`,
+          `QLTY_PLUGINS_LINTER_VERSION=${latestLinterVersion} QLTY_PLUGINS_COMPARE_LATEST_SNAPSHOT=true npm test ${linter}.test.ts`,
           { stdio: "inherit" },
         );
 

--- a/qlty-plugins/plugins/scripts/updateLinterVersions.ts
+++ b/qlty-plugins/plugins/scripts/updateLinterVersions.ts
@@ -133,7 +133,7 @@ async function main(): Promise<void> {
       try {
         console.log(`Testing ${linterLabel}...`);
         execSync(
-          `QLTY_PLUGINS_LINTER_VERSION=${latestLinterVersion} QLTY_PLUGINS_TEST_AGAINST_KNOWN_GOOD_VERSION=true npm test ${linter}.test.ts`,
+          `QLTY_PLUGINS_LINTER_VERSION=${latestLinterVersion} QLTY_PLUGINS_TEST_AGAINST_LATEST_SNAPSHOT=true npm test ${linter}.test.ts`,
           { stdio: "inherit" },
         );
 

--- a/qlty-plugins/plugins/tests/driver.ts
+++ b/qlty-plugins/plugins/tests/driver.ts
@@ -184,21 +184,7 @@ export class QltyDriver {
   }
 
   snapshotPath(prefix: string): string {
-    if (OPTIONS.testAgainstKnownGoodVersion) {
-      const knownGoodVersion = getKnownGoodVersion(
-        this.pluginDir,
-        this.linterName,
-      );
-      const knownGoodSnapshot = path.resolve(
-        this.fixturesDir,
-        SNAPSHOTS_DIR,
-        `${prefix}_v${knownGoodVersion}.shot`,
-      );
-
-      return knownGoodSnapshot;
-    }
-
-    if (OPTIONS.testAgainstLatestSnapshot) {
+    if (OPTIONS.compareLatestSnapshots) {
       const knownGoodSnapshot = this.getLatestSnapshot(prefix);
 
       if (knownGoodSnapshot) {

--- a/qlty-plugins/plugins/tests/driver.ts
+++ b/qlty-plugins/plugins/tests/driver.ts
@@ -7,7 +7,7 @@ import * as git from "simple-git";
 import * as util from "util";
 import { getKnownGoodVersion } from "./runLinterTest";
 import { OPTIONS } from "./utils";
-import semver from 'semver';
+import semver from "semver";
 
 interface Issue {
   tool: string;
@@ -204,7 +204,9 @@ export class QltyDriver {
       if (knownGoodSnapshot) {
         return knownGoodSnapshot;
       } else {
-        throw new Error(`No snapshots found for prefix: ${prefix} in ${this.fixturesDir} snapshots directory`);
+        throw new Error(
+          `No snapshots found for prefix: ${prefix} in ${this.fixturesDir} snapshots directory`,
+        );
       }
     }
 

--- a/qlty-plugins/plugins/tests/driver.ts
+++ b/qlty-plugins/plugins/tests/driver.ts
@@ -5,7 +5,6 @@ import * as os from "os";
 import path from "path";
 import * as git from "simple-git";
 import * as util from "util";
-import { getKnownGoodVersion } from "./runLinterTest";
 import { OPTIONS } from "./utils";
 import semver from "semver";
 

--- a/qlty-plugins/plugins/tests/runLinterTest.ts
+++ b/qlty-plugins/plugins/tests/runLinterTest.ts
@@ -78,21 +78,7 @@ export const getVersionsForTarget = (
 
   const uniqueVersionsList = Array.from(new Set(versionsList)).sort();
 
-  if (
-    OPTIONS.linterVersion == "KnownGoodVersion" ||
-    OPTIONS.testAgainstKnownGoodVersion
-  ) {
-    const knownGoodVersion = getKnownGoodVersion(dirname, linterName);
-
-    console.log(
-      "Running test for ",
-      linterName,
-      " with known good version: ",
-      knownGoodVersion,
-    );
-
-    return [knownGoodVersion];
-  } else if (OPTIONS.testAgainstLatestSnapshot) {
+  if (OPTIONS.compareLatestSnapshots) {
     const latestSnapshotVersion = getLatestSnapshotVersion(
       prefix,
       snapshotsDir,

--- a/qlty-plugins/plugins/tests/runLinterTest.ts
+++ b/qlty-plugins/plugins/tests/runLinterTest.ts
@@ -6,7 +6,7 @@ import { testResults } from "tests";
 import toml from "toml";
 import { QltyDriver } from "./driver";
 import { OPTIONS } from "./utils";
-import semver from 'semver';
+import semver from "semver";
 
 Debug.inspectOpts!.hideDate = true;
 
@@ -24,7 +24,10 @@ type Target = {
   linterVersions: any[];
 };
 
-const getLatestSnapshotVersion = (prefix: string, snapshotsDir: string): string => {
+const getLatestSnapshotVersion = (
+  prefix: string,
+  snapshotsDir: string,
+): string => {
   const files = fs.readdirSync(snapshotsDir);
 
   const regex = new RegExp(`^${prefix}_v(\\d+\\.\\d+\\.\\d+)\\.shot$`);
@@ -43,9 +46,11 @@ const getLatestSnapshotVersion = (prefix: string, snapshotsDir: string): string 
   if (latestSnapshotVersion) {
     return latestSnapshotVersion;
   } else {
-    throw new Error(`No snapshots found for prefix: ${prefix} in ${snapshotsDir}`);
+    throw new Error(
+      `No snapshots found for prefix: ${prefix} in ${snapshotsDir}`,
+    );
   }
-}
+};
 
 export const getVersionsForTarget = (
   dirname: string,
@@ -87,8 +92,11 @@ export const getVersionsForTarget = (
     );
 
     return [knownGoodVersion];
-  } else if (OPTIONS.testAgainstLatestSnapshot){
-    const latestSnapshotVersion = getLatestSnapshotVersion(prefix, snapshotsDir);
+  } else if (OPTIONS.testAgainstLatestSnapshot) {
+    const latestSnapshotVersion = getLatestSnapshotVersion(
+      prefix,
+      snapshotsDir,
+    );
     console.log(
       "Running test for ",
       linterName,

--- a/qlty-plugins/plugins/tests/utils.ts
+++ b/qlty-plugins/plugins/tests/utils.ts
@@ -11,11 +11,8 @@ export interface EnvOptions {
   /** Prevents the deletion of sandbox test dirs. */
   sandboxDebug: boolean;
 
-  /** Test the output against the known good version output of the linter. */
-  testAgainstKnownGoodVersion: boolean;
-
   /** Test the output against the latest snapshots of the linter. */
-  testAgainstLatestSnapshot: boolean;
+  compareLatestSnapshots: boolean;
 }
 
 const parseLinterVersion = (value: string): LinterVersion | undefined => {
@@ -30,11 +27,8 @@ export const OPTIONS: EnvOptions = {
     process.env.QLTY_PLUGINS_LINTER_VERSION ?? "",
   ),
   sandboxDebug: Boolean(process.env.QLTY_PLUGINS_SANDBOX_DEBUG),
-  testAgainstKnownGoodVersion: Boolean(
-    process.env.QLTY_PLUGINS_TEST_AGAINST_KNOWN_GOOD_VERSION,
-  ),
-  testAgainstLatestSnapshot: Boolean(
-    process.env.QLTY_PLUGINS_TEST_AGAINST_LATEST_SNAPSHOT,
+  compareLatestSnapshots: Boolean(
+    process.env.QLTY_PLUGINS_COMPARE_LATEST_SNAPSHOT,
   ),
 };
 

--- a/qlty-plugins/plugins/tests/utils.ts
+++ b/qlty-plugins/plugins/tests/utils.ts
@@ -13,6 +13,9 @@ export interface EnvOptions {
 
   /** Test the output against the known good version output of the linter. */
   testAgainstKnownGoodVersion: boolean;
+
+  /** Test the output against the latest snapshots of the linter. */
+  testAgainstLatestSnapshot: boolean;
 }
 
 const parseLinterVersion = (value: string): LinterVersion | undefined => {
@@ -29,6 +32,9 @@ export const OPTIONS: EnvOptions = {
   sandboxDebug: Boolean(process.env.QLTY_PLUGINS_SANDBOX_DEBUG),
   testAgainstKnownGoodVersion: Boolean(
     process.env.QLTY_PLUGINS_TEST_AGAINST_KNOWN_GOOD_VERSION,
+  ),
+  testAgainstLatestSnapshot: Boolean(
+    process.env.QLTY_PLUGINS_TEST_AGAINST_LATEST_SNAPSHOT,
   ),
 };
 


### PR DESCRIPTION
Now that we may not have a known good version snapshot we should test with the highest version snapshot available for linter version updates