### PR TITLE
fix: update SARIF formatter in RFC3339 format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ flamegraph.svg
 /.markdownlint.json
 /.rustfmt.toml
 /.yamllint.yaml
+.idea
+.vscode

--- a/qlty-config/build.rs
+++ b/qlty-config/build.rs
@@ -48,6 +48,6 @@ fn main() {
         std::env::var("PROFILE").unwrap()
     );
 
-    let build_date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let build_date = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
     println!("cargo:rustc-env=BUILD_DATE={}", build_date);
 }


### PR DESCRIPTION
Close this :

https://github.com/qltysh/qlty/issues/1485

This pull request includes updates to the `qlty-cli/src/format/sarif.rs` file to enhance the SARIF formatter with dynamic release date handling and the addition of a new import.

Enhancements to SARIF formatter:

* [`qlty-cli/src/format/sarif.rs`](diffhunk://#diff-d124dbb2d858adb3d6504326903340cf51ac36feadbacabfdf11dc7095f0d02dR9): Added `chrono::Utc` to the imports for handling date and time operations.
* [`qlty-cli/src/format/sarif.rs`](diffhunk://#diff-d124dbb2d858adb3d6504326903340cf51ac36feadbacabfdf11dc7095f0d02dR301-R306): Introduced logic to dynamically set the `release_date` based on whether `BUILD_DATE` contains a time component, defaulting to the current UTC time in RFC 3339 format if not.
* [`qlty-cli/src/format/sarif.rs`](diffhunk://#diff-d124dbb2d858adb3d6504326903340cf51ac36feadbacabfdf11dc7095f0d02dL311-R318): Updated the SARIF output to use the dynamically determined `release_date` instead of the static `BUILD_DATE`.