### PR TITLE
Fixes for issues created by update linter version workflow.

### DIFF
--- a/qlty-plugins/plugins/linters/bandit/fixtures/__snapshots__/basic_v1.7.8.shot
+++ b/qlty-plugins/plugins/linters/bandit/fixtures/__snapshots__/basic_v1.7.8.shot
@@ -5,7 +5,7 @@ exports[`linter=bandit fixture=basic version=1.7.8 1`] = `
   "issues": [
     {
       "category": "CATEGORY_DEPENDENCY_ALERT",
-      "documentationUrl": "https://bandit.readthedocs.io/en/1.7.8/blacklists/blacklist_calls.html#b301-pickle",
+      "documentationUrl": "https://bandit.readthedocs.io/en/<version>/blacklists/blacklist_calls.html#b301-pickle",
       "level": "LEVEL_HIGH",
       "location": {
         "path": "basic.in.py",
@@ -33,7 +33,7 @@ dill.dump([1, 2, "3"], file_obj)",
     },
     {
       "category": "CATEGORY_DEPENDENCY_ALERT",
-      "documentationUrl": "https://bandit.readthedocs.io/en/1.7.8/blacklists/blacklist_imports.html#b403-import-pickle",
+      "documentationUrl": "https://bandit.readthedocs.io/en/<version>/blacklists/blacklist_imports.html#b403-import-pickle",
       "level": "LEVEL_HIGH",
       "location": {
         "path": "basic.in.py",

--- a/qlty-plugins/plugins/linters/bandit/fixtures/__snapshots__/basic_v1.7.9.shot
+++ b/qlty-plugins/plugins/linters/bandit/fixtures/__snapshots__/basic_v1.7.9.shot
@@ -5,7 +5,7 @@ exports[`linter=bandit fixture=basic version=1.7.9 1`] = `
   "issues": [
     {
       "category": "CATEGORY_DEPENDENCY_ALERT",
-      "documentationUrl": "https://bandit.readthedocs.io/en/1.7.9/blacklists/blacklist_calls.html#b301-pickle",
+      "documentationUrl": "https://bandit.readthedocs.io/en/<version>/blacklists/blacklist_calls.html#b301-pickle",
       "level": "LEVEL_HIGH",
       "location": {
         "path": "basic.in.py",
@@ -33,7 +33,7 @@ dill.dump([1, 2, "3"], file_obj)",
     },
     {
       "category": "CATEGORY_DEPENDENCY_ALERT",
-      "documentationUrl": "https://bandit.readthedocs.io/en/1.7.9/blacklists/blacklist_imports.html#b403-import-pickle",
+      "documentationUrl": "https://bandit.readthedocs.io/en/<version>/blacklists/blacklist_imports.html#b403-import-pickle",
       "level": "LEVEL_HIGH",
       "location": {
         "path": "basic.in.py",

--- a/qlty-plugins/plugins/linters/golangci-lint/fixtures/__snapshots__/basic_new_v2.0.2.shot
+++ b/qlty-plugins/plugins/linters/golangci-lint/fixtures/__snapshots__/basic_new_v2.0.2.shot
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`linter=golangci-lint fixture=basic_new version=2.0.2 1`] = `
+{
+  "issues": [
+    {
+      "category": "CATEGORY_LINT",
+      "level": "LEVEL_MEDIUM",
+      "location": {
+        "path": "basic.go",
+        "range": {
+          "startColumn": 12,
+          "startLine": 8,
+        },
+      },
+      "message": "Error return value of \`time.Parse\` is not checked",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "errcheck",
+      "snippet": "	time.Parse("asdf", "")",
+      "snippetWithContext": "package main
+
+import "time"
+
+// ✋✋✋✋
+// this is the main function 🏃
+func main() {
+	time.Parse("asdf", "")
+}",
+      "tool": "golangci-lint",
+    },
+    {
+      "category": "CATEGORY_LINT",
+      "level": "LEVEL_MEDIUM",
+      "location": {
+        "path": "basic.go",
+        "range": {
+          "startColumn": 1,
+          "startLine": 5,
+        },
+      },
+      "message": "Comment should end in a period",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "godot",
+      "snippet": "// ✋✋✋✋",
+      "snippetWithContext": "package main
+
+import "time"
+
+// ✋✋✋✋
+// this is the main function 🏃
+func main() {
+	time.Parse("asdf", "")
+}",
+      "tool": "golangci-lint",
+    },
+  ],
+}
+`;

--- a/qlty-plugins/plugins/linters/golangci-lint/fixtures/basic_new.in/.golangci.yml
+++ b/qlty-plugins/plugins/linters/golangci-lint/fixtures/basic_new.in/.golangci.yml
@@ -1,0 +1,42 @@
+version: "2"
+linters:
+  enable:
+    - asciicheck
+    - bodyclose
+    - depguard
+    - dogsled
+    - gochecknoinits
+    - godot
+    - goheader
+    - goprintffuncname
+    - gosec
+    - misspell
+    - nakedret
+    - nolintlint
+    - rowserrcheck
+    - staticcheck
+    - unconvert
+    - whitespace
+  settings:
+    errcheck:
+      check-type-assertions: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/qlty-plugins/plugins/linters/golangci-lint/fixtures/basic_new.in/basic.go
+++ b/qlty-plugins/plugins/linters/golangci-lint/fixtures/basic_new.in/basic.go
@@ -1,0 +1,9 @@
+package main
+
+import "time"
+
+// ✋✋✋✋
+// this is the main function 🏃
+func main() {
+	time.Parse("asdf", "")
+}

--- a/qlty-plugins/plugins/linters/golangci-lint/fixtures/basic_new.in/go.mod
+++ b/qlty-plugins/plugins/linters/golangci-lint/fixtures/basic_new.in/go.mod
@@ -1,0 +1,3 @@
+module golangcilint_linter_test
+
+go 1.18

--- a/qlty-plugins/plugins/linters/golangci-lint/plugin.toml
+++ b/qlty-plugins/plugins/linters/golangci-lint/plugin.toml
@@ -22,12 +22,24 @@ description = "A powerful Go linter runner"
 security = true
 suggested_mode = "comment"
 
-[plugins.definitions.golangci-lint.drivers.lint]
+[[plugins.definitions.golangci-lint.drivers.lint.version]]
+version_matcher = "<=2.0.0"
 script = "golangci-lint run --out-format json --timeout 10m --exclude gofmt --allow-parallel-runners --issues-exit-code 0 ${target}"
 target = { type = "literal", path = "./..." }
 runs_from = { type = "root_or_parent_with", path = "go.mod" }
 success_codes = [0, 2, 7]
 output = "stdout"
+output_format = "golangci_lint"
+suggested = "targets"
+output_missing = "parse"
+
+[[plugins.definitions.golangci-lint.drivers.lint.version]]
+version_matcher = ">=2.0.0"
+script = "golangci-lint run --output.json.path ${tmpfile} --timeout 10m --allow-parallel-runners --issues-exit-code 0 ${target}"
+target = { type = "literal", path = "./..." }
+runs_from = { type = "root_or_parent_with", path = "go.mod" }
+success_codes = [0, 2, 7]
+output = "tmpfile"
 output_format = "golangci_lint"
 suggested = "targets"
 output_missing = "parse"

--- a/qlty-plugins/plugins/linters/golangci-lint/plugin.toml
+++ b/qlty-plugins/plugins/linters/golangci-lint/plugin.toml
@@ -23,7 +23,7 @@ security = true
 suggested_mode = "comment"
 
 [[plugins.definitions.golangci-lint.drivers.lint.version]]
-version_matcher = "<=2.0.0"
+version_matcher = "<2.0.0"
 script = "golangci-lint run --out-format json --timeout 10m --exclude gofmt --allow-parallel-runners --issues-exit-code 0 ${target}"
 target = { type = "literal", path = "./..." }
 runs_from = { type = "root_or_parent_with", path = "go.mod" }

--- a/qlty-plugins/plugins/linters/pmd/fixtures/__snapshots__/apex_v7.0.0.shot
+++ b/qlty-plugins/plugins/linters/pmd/fixtures/__snapshots__/apex_v7.0.0.shot
@@ -5,7 +5,7 @@ exports[`linter=pmd fixture=apex version=7.0.0 1`] = `
   "issues": [
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-7.0.0/pmd_rules_apex_documentation.html#apexdoc",
+      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-<version>/pmd_rules_apex_documentation.html#apexdoc",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "apex.in.cls",
@@ -33,7 +33,7 @@ return 'Hello World!';
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-7.0.0/pmd_rules_apex_documentation.html#apexdoc",
+      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-<version>/pmd_rules_apex_documentation.html#apexdoc",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "apex.in.cls",
@@ -59,7 +59,7 @@ return 'Hello World!';
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-7.0.0/pmd_rules_apex_bestpractices.html#avoidglobalmodifier",
+      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-<version>/pmd_rules_apex_bestpractices.html#avoidglobalmodifier",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "apex.in.cls",

--- a/qlty-plugins/plugins/linters/pmd/fixtures/__snapshots__/batch_v7.0.0.shot
+++ b/qlty-plugins/plugins/linters/pmd/fixtures/__snapshots__/batch_v7.0.0.shot
@@ -5,7 +5,7 @@ exports[`linter=pmd fixture=batch version=7.0.0 1`] = `
   "issues": [
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-7.0.0/pmd_rules_java_codestyle.html#nopackage",
+      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-<version>/pmd_rules_java_codestyle.html#nopackage",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "hello.java",
@@ -31,7 +31,7 @@ class HelloWorld {
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-7.0.0/pmd_rules_java_codestyle.html#nopackage",
+      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-<version>/pmd_rules_java_codestyle.html#nopackage",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "second.java",
@@ -57,7 +57,7 @@ class HelloWorld {
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-7.0.0/pmd_rules_java_design.html#useutilityclass",
+      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-<version>/pmd_rules_java_design.html#useutilityclass",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "hello.java",
@@ -83,7 +83,7 @@ class HelloWorld {
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-7.0.0/pmd_rules_java_design.html#useutilityclass",
+      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-<version>/pmd_rules_java_design.html#useutilityclass",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "second.java",

--- a/qlty-plugins/plugins/linters/pmd/fixtures/__snapshots__/hello_v7.0.0.shot
+++ b/qlty-plugins/plugins/linters/pmd/fixtures/__snapshots__/hello_v7.0.0.shot
@@ -5,7 +5,7 @@ exports[`linter=pmd fixture=hello version=7.0.0 1`] = `
   "issues": [
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-7.0.0/pmd_rules_java_codestyle.html#nopackage",
+      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-<version>/pmd_rules_java_codestyle.html#nopackage",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "hello.in.java",
@@ -31,7 +31,7 @@ class HelloWorld {
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-7.0.0/pmd_rules_java_design.html#useutilityclass",
+      "documentationUrl": "https://docs.pmd-code.org/pmd-doc-<version>/pmd_rules_java_design.html#useutilityclass",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "hello.in.java",

--- a/qlty-plugins/plugins/linters/reek/fixtures/__snapshots__/basic_v6.3.0.shot
+++ b/qlty-plugins/plugins/linters/reek/fixtures/__snapshots__/basic_v6.3.0.shot
@@ -5,7 +5,7 @@ exports[`linter=reek fixture=basic version=6.3.0 1`] = `
   "issues": [
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/troessner/reek/blob/v6.3.0/docs/Manual-Dispatch.md",
+      "documentationUrl": "https://github.com/troessner/reek/blob/v<version>/docs/Manual-Dispatch.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "basic.in.rb",
@@ -31,7 +31,7 @@ end",
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/troessner/reek/blob/v6.3.0/docs/Manual-Dispatch.md",
+      "documentationUrl": "https://github.com/troessner/reek/blob/v<version>/docs/Manual-Dispatch.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "basic.in.rb",

--- a/qlty-plugins/plugins/linters/tflint/fixtures/__snapshots__/aws_nested_v0.51.1.shot
+++ b/qlty-plugins/plugins/linters/tflint/fixtures/__snapshots__/aws_nested_v0.51.1.shot
@@ -5,7 +5,7 @@ exports[`linter=tflint fixture=aws_nested version=0.51.1 1`] = `
   "issues": [
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.7.0/docs/rules/terraform_required_version.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_required_version.md",
       "level": "LEVEL_MEDIUM",
       "message": "terraform "required_version" attribute is required",
       "mode": "MODE_BLOCK",
@@ -14,7 +14,7 @@ exports[`linter=tflint fixture=aws_nested version=0.51.1 1`] = `
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.7.0/docs/rules/terraform_typed_variables.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_typed_variables.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "nested/aws.in.tf",
@@ -45,7 +45,7 @@ variable "foo" {
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.7.0/docs/rules/terraform_unused_declarations.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_unused_declarations.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "nested/aws.in.tf",
@@ -76,7 +76,7 @@ variable "foo" {
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.7.0/docs/rules/terraform_unused_declarations.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_unused_declarations.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "nested/aws.in.tf",

--- a/qlty-plugins/plugins/linters/tflint/fixtures/__snapshots__/aws_nested_v0.52.0.shot
+++ b/qlty-plugins/plugins/linters/tflint/fixtures/__snapshots__/aws_nested_v0.52.0.shot
@@ -5,7 +5,7 @@ exports[`linter=tflint fixture=aws_nested version=0.52.0 1`] = `
   "issues": [
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.8.0/docs/rules/terraform_required_version.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_required_version.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "nested/aws.in.tf",
@@ -17,7 +17,7 @@ exports[`linter=tflint fixture=aws_nested version=0.52.0 1`] = `
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.8.0/docs/rules/terraform_typed_variables.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_typed_variables.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "nested/aws.in.tf",
@@ -48,7 +48,7 @@ variable "foo" {
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.8.0/docs/rules/terraform_unused_declarations.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_unused_declarations.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "nested/aws.in.tf",
@@ -79,7 +79,7 @@ variable "foo" {
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.8.0/docs/rules/terraform_unused_declarations.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_unused_declarations.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "nested/aws.in.tf",

--- a/qlty-plugins/plugins/linters/tflint/fixtures/__snapshots__/aws_v0.51.1.shot
+++ b/qlty-plugins/plugins/linters/tflint/fixtures/__snapshots__/aws_v0.51.1.shot
@@ -5,7 +5,7 @@ exports[`linter=tflint fixture=aws version=0.51.1 1`] = `
   "issues": [
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.7.0/docs/rules/terraform_required_version.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_required_version.md",
       "level": "LEVEL_MEDIUM",
       "message": "terraform "required_version" attribute is required",
       "mode": "MODE_BLOCK",
@@ -14,7 +14,7 @@ exports[`linter=tflint fixture=aws version=0.51.1 1`] = `
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.7.0/docs/rules/terraform_typed_variables.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_typed_variables.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "aws.in.tf",
@@ -45,7 +45,7 @@ variable "foo" {
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.7.0/docs/rules/terraform_unused_declarations.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_unused_declarations.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "aws.in.tf",
@@ -76,7 +76,7 @@ variable "foo" {
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.7.0/docs/rules/terraform_unused_declarations.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_unused_declarations.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "aws.in.tf",

--- a/qlty-plugins/plugins/linters/tflint/fixtures/__snapshots__/aws_v0.52.0.shot
+++ b/qlty-plugins/plugins/linters/tflint/fixtures/__snapshots__/aws_v0.52.0.shot
@@ -5,7 +5,7 @@ exports[`linter=tflint fixture=aws version=0.52.0 1`] = `
   "issues": [
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.8.0/docs/rules/terraform_required_version.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_required_version.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "aws.in.tf",
@@ -17,7 +17,7 @@ exports[`linter=tflint fixture=aws version=0.52.0 1`] = `
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.8.0/docs/rules/terraform_typed_variables.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_typed_variables.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "aws.in.tf",
@@ -48,7 +48,7 @@ variable "foo" {
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.8.0/docs/rules/terraform_unused_declarations.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_unused_declarations.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "aws.in.tf",
@@ -79,7 +79,7 @@ variable "foo" {
     },
     {
       "category": "CATEGORY_LINT",
-      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.8.0/docs/rules/terraform_unused_declarations.md",
+      "documentationUrl": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v<version>/docs/rules/terraform_unused_declarations.md",
       "level": "LEVEL_MEDIUM",
       "location": {
         "path": "aws.in.tf",

--- a/qlty-plugins/plugins/scripts/updateLinterVersions.ts
+++ b/qlty-plugins/plugins/scripts/updateLinterVersions.ts
@@ -6,6 +6,7 @@ import { fetchLatestVersion } from "./fetchLatestVersion/fetchLatestVersion";
 
 const REPO_ROOT: string = path.resolve(__dirname, "..");
 const LINTERS_PATH: string = path.resolve(REPO_ROOT, "linters");
+const LINTERS_TO_SKIP: string[] = ["tsc"];
 
 // Return type for getLinterDef
 interface LinterDefinition {
@@ -52,7 +53,10 @@ const getLintersList = async (): Promise<string[]> => {
         })();
       }),
     );
-    return folders.filter((folder) => folder !== undefined);
+    return folders.filter(
+      (folder): folder is string =>
+        folder !== undefined && !LINTERS_TO_SKIP.includes(folder),
+    );
   } catch (err) {
     throw new Error(`Failed to read linters directory: ${err}`);
   }

--- a/qlty-plugins/plugins/tests/index.ts
+++ b/qlty-plugins/plugins/tests/index.ts
@@ -27,14 +27,15 @@ export const linterCheckTest = (linterName: string, dirname: string) =>
     if (Array.isArray(normalizedResults.issues)) {
       for (const issue of normalizedResults.issues) {
         if (issue.documentationUrl) {
-          issue.documentationUrl = issue.documentationUrl.replace(/\d+\.\d+\.\d+/, "<version>");
+          issue.documentationUrl = issue.documentationUrl.replace(
+            /\d+\.\d+\.\d+/,
+            "<version>",
+          );
         }
       }
     }
 
-    expect(normalizedResults).toMatchSpecificSnapshot(
-      snapshotPath,
-    );
+    expect(normalizedResults).toMatchSpecificSnapshot(snapshotPath);
   });
 
 export const linterStructureTest = (linterName: string, dirname: string) =>

--- a/qlty-plugins/plugins/tests/index.ts
+++ b/qlty-plugins/plugins/tests/index.ts
@@ -21,7 +21,18 @@ expect.extend({
 
 export const linterCheckTest = (linterName: string, dirname: string) =>
   runLinterTest(linterName, dirname, (testRunResult, snapshotPath) => {
-    expect(testRunResult.deterministicResults()).toMatchSpecificSnapshot(
+    const normalizedResults = testRunResult.deterministicResults();
+
+    // Remove documentationUrl from all issues
+    if (Array.isArray(normalizedResults.issues)) {
+      for (const issue of normalizedResults.issues) {
+        if (issue.documentationUrl) {
+          issue.documentationUrl = issue.documentationUrl.replace(/\d+\.\d+\.\d+/, "<version>");
+        }
+      }
+    }
+
+    expect(normalizedResults).toMatchSpecificSnapshot(
       snapshotPath,
     );
   });


### PR DESCRIPTION
1. Skip tsc since it doesn't have a test.
2. Add support for golangci-lint v2.
3. Normalize version numbers in documentation urls in test snapshots, simplifies upgrades for plugins such as tflint and bandit which have different version numbers in urls.