### PR TITLE
Fix missing smells when ignore rules are used in qlty.toml

### DIFF
--- a/qlty-analysis/src/workspace_entries/matchers/languages_shebang_matcher.rs
+++ b/qlty-analysis/src/workspace_entries/matchers/languages_shebang_matcher.rs
@@ -2,7 +2,7 @@ use super::WorkspaceEntryMatcher;
 use crate::{code::language_detector::get_language_from_shebang, WorkspaceEntry};
 use std::collections::HashMap;
 
-/// Matches workspace entries that have a sheband line that includes an interpretter
+/// Matches workspace entries that have a sheband line that includes an interpreter
 /// This requires reading the contents of the file.
 #[derive(Debug)]
 pub struct LanguagesShebangMatcher {

--- a/qlty-analysis/src/workspace_entries/workspace_entry_finder_builder.rs
+++ b/qlty-analysis/src/workspace_entries/workspace_entry_finder_builder.rs
@@ -117,7 +117,7 @@ impl WorkspaceEntryFinderBuilder {
 
             if !language.interpreters.is_empty() {
                 debug!(
-                    "Matching {} with interpretters: {:?}",
+                    "Matching {} with interpreters: {:?}",
                     language_name, language.interpreters
                 );
                 interpreters.insert(language_name.to_string(), language.interpreters.to_owned());


### PR DESCRIPTION
The following qlty.toml config will cause IgnoreGroup to register a blanket wildcard (`*`) ignore:

```
[[ignore]]
rules = ["tool:rule_name"]
```

Due to the way the qlty.toml is loaded, the `file_patterns` for this ignore definition will be set to `*`, thereby creating an ignore group that looks like:

```
["**/protos/**", "**/other_ignore/**", "*", "**/tailwind.css", ...]
```

Which will match (and ignore) all files.

The proposed fix is to skip an ignore wildcard if any rules are defined, as this should not be treated as a blanket workspace_entry ignore (an invocation must be run to determine what needs to be ignored).

There is a possible optimization for `tool:*` rules for the plugin workspace entry matcher, but I did not want to complicate the implementation.