### PR TITLE
Move inferred "fmt issues" to mode = comment

### DIFF
--- a/qlty-check/src/executor/invocation_result.rs
+++ b/qlty-check/src/executor/invocation_result.rs
@@ -387,6 +387,7 @@ impl InvocationResult {
                     category: Category::Style.into(),
                     level: Level::Fmt.into(),
                     rule_key: "fmt".to_string(),
+                    mode: IssueMode::Comment.into(),
                     tool: self.plan.plugin_name.clone(),
                     location: Some(Location {
                         path: prefixed_target_path_string.clone(),

--- a/qlty-check/src/executor/invocation_result.rs
+++ b/qlty-check/src/executor/invocation_result.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use chrono::prelude::*;
 use qlty_analysis::utils::fs::path_to_string;
 use qlty_config::{
-    config::{OutputDestination, OutputMissing, TargetType},
+    config::{IssueMode, OutputDestination, OutputMissing, TargetType},
     version::QLTY_VERSION,
 };
 use qlty_types::analysis::v1::{
@@ -387,7 +387,7 @@ impl InvocationResult {
                     category: Category::Style.into(),
                     level: Level::Fmt.into(),
                     rule_key: "fmt".to_string(),
-                    mode: IssueMode::Comment.into(),
+                    mode: IssueMode::Comment as i32,
                     tool: self.plan.plugin_name.clone(),
                     location: Some(Location {
                         path: prefixed_target_path_string.clone(),


### PR DESCRIPTION
This will keep them in the summary comment but avoid failing the `qlty check` status for them by default