### PR TITLE
Fix panic: byte index 80 is not a char boundary

### DIFF
--- a/qlty-check/src/llm/fixer.rs
+++ b/qlty-check/src/llm/fixer.rs
@@ -122,8 +122,9 @@ impl Fixer {
             .map(|issue| {
                 let task = self.progress.task("Generating AI Fix:", "");
 
-                let trimmed_message = if issue.message.len() > 80 {
-                    format!("{}...", &issue.message[..80])
+                let trimmed_message = if issue.message.chars().count() > 80 {
+                    let trimmed: String = issue.message.chars().take(80).collect();
+                    format!("{}...", trimmed)
                 } else {
                     issue.message.clone()
                 };


### PR DESCRIPTION
The stack trace is only partially helpful, potentially due to concurrency in this part of the code.

The panic error is `byte index 80 is not a char boundary` and my strong suspicion is that it comes from this line:

```rust
format!("{}...", &issue.message[..80])
```

The input `80` to the slice operator works is bytes not characters. If that byte location is not a character boundary, it panics.

Therefore, any unprotected string slice where the string is arbitrary content that may include multi-byte characters is a panic bug.