### PR TITLE
Enable summary in coverage publish

### DIFF
--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -85,10 +85,6 @@ pub struct Publish {
     /// JSON output
     pub json: bool,
 
-    #[arg(long, hide = true)]
-    /// Print a summary
-    pub summary: bool,
-
     #[clap(long, short)]
     pub quiet: bool,
 
@@ -461,52 +457,50 @@ impl Publish {
 
         eprintln_unless!(self.quiet, "");
 
-        if self.summary {
-            // Get formatted numbers first
-            let covered_lines = report.totals.covered_lines.to_formatted_string(&Locale::en);
-            let uncovered_lines = report
-                .totals
-                .uncovered_lines
-                .to_formatted_string(&Locale::en);
-            let omitted_lines = report.totals.omitted_lines.to_formatted_string(&Locale::en);
+        // Get formatted numbers first
+        let covered_lines = report.totals.covered_lines.to_formatted_string(&Locale::en);
+        let uncovered_lines = report
+            .totals
+            .uncovered_lines
+            .to_formatted_string(&Locale::en);
+        let omitted_lines = report.totals.omitted_lines.to_formatted_string(&Locale::en);
 
-            // Find the longest number for consistent spacing
-            let max_length = [&covered_lines, &uncovered_lines, &omitted_lines]
-                .iter()
-                .map(|s| s.len())
-                .max()
-                .unwrap_or(0);
+        // Find the longest number for consistent spacing
+        let max_length = [&covered_lines, &uncovered_lines, &omitted_lines]
+            .iter()
+            .map(|s| s.len())
+            .max()
+            .unwrap_or(0);
 
-            eprintln_unless!(
-                self.quiet,
-                "    Covered Lines:      {:>width$}",
-                covered_lines,
-                width = max_length
-            );
-            eprintln_unless!(
-                self.quiet,
-                "    Uncovered Lines:    {:>width$}",
-                uncovered_lines,
-                width = max_length
-            );
-            eprintln_unless!(
-                self.quiet,
-                "    Omitted Lines:      {:>width$}",
-                omitted_lines,
-                width = max_length
-            );
-            eprintln_unless!(self.quiet, "");
-            eprintln_unless!(
-                self.quiet,
-                "    {}",
-                style(format!(
-                    "Line Coverage:       {:.2}%",
-                    report.totals.coverage_percentage
-                ))
-                .bold()
-            );
-            eprintln_unless!(self.quiet, "");
-        }
+        eprintln_unless!(
+            self.quiet,
+            "    Covered Lines:      {:>width$}",
+            covered_lines,
+            width = max_length
+        );
+        eprintln_unless!(
+            self.quiet,
+            "    Uncovered Lines:    {:>width$}",
+            uncovered_lines,
+            width = max_length
+        );
+        eprintln_unless!(
+            self.quiet,
+            "    Omitted Lines:      {:>width$}",
+            omitted_lines,
+            width = max_length
+        );
+        eprintln_unless!(self.quiet, "");
+        eprintln_unless!(
+            self.quiet,
+            "    {}",
+            style(format!(
+                "Line Coverage:       {:.2}%",
+                report.totals.coverage_percentage
+            ))
+            .bold()
+        );
+        eprintln_unless!(self.quiet, "");
     }
 
     fn print_export_status(&self, export_path: &Option<PathBuf>) {
@@ -678,7 +672,6 @@ mod tests {
             paths: vec![],
             skip_missing_files: false,
             total_parts_count: None,
-            summary: false,
             verbose: false,
         }
     }

--- a/qlty-cli/tests/cmd/coverage/basic.toml
+++ b/qlty-cli/tests/cmd/coverage/basic.toml
@@ -6,7 +6,6 @@ args = [
   "2ca1bc45a94e37c8dbae6fd9e19fc069ba64bd67",
   "--override-build-id",
   "123",
-  "--summary",
   "lcov.info"
 ]
 bin.name = "qlty"

--- a/qlty-cli/tests/cmd/coverage/files_exist.stdout
+++ b/qlty-cli/tests/cmd/coverage/files_exist.stdout
@@ -12,7 +12,7 @@
     "commitTime": "2024-01-01T00:00:00+00:00",
     "uploadedAt": "[..]",
     "cliVersion": "[..]",
-    "publishCommand": "[..]qlty[..] coverage publish --dry-run --override-commit-sha 2ca1bc45a94e37c8dbae6fd9e19fc069ba64bd67 --override-build-id 123 lcov.info --print --json --skip-missing-files --summary"
+    "publishCommand": "[..]qlty[..] coverage publish --dry-run --override-commit-sha 2ca1bc45a94e37c8dbae6fd9e19fc069ba64bd67 --override-build-id 123 lcov.info --print --json --skip-missing-files"
   },
   "report_files": [
     {

--- a/qlty-cli/tests/cmd/coverage/files_exist.toml
+++ b/qlty-cli/tests/cmd/coverage/files_exist.toml
@@ -10,7 +10,6 @@ args = [
   "--print",
   "--json",
   "--skip-missing-files",
-  "--summary"
 ]
 bin.name = "qlty"
 

--- a/qlty-cli/tests/cmd/coverage/ignore_patterns.toml
+++ b/qlty-cli/tests/cmd/coverage/ignore_patterns.toml
@@ -6,7 +6,6 @@ args = [
   "822641a8a442eab5981096a0d734ac180aa40106",
   "--override-build-id",
   "123",
-  "--summary",
   "lcov.info"
 ]
 bin.name = "qlty"

--- a/qlty-cli/tests/cmd/coverage/json.stdout
+++ b/qlty-cli/tests/cmd/coverage/json.stdout
@@ -16,7 +16,7 @@
     "cliVersion": "[..]",
     "uploaderTool": "qltysh/qlty-action-coverage",
     "uploaderToolVersion": "v1.0.0",
-    "publishCommand": "[..]qlty[..] coverage publish --dry-run --print --json --override-commit-sha 2ca1bc45a94e37c8dbae6fd9e19fc069ba64bd67 --transform-add-prefix rails/ --tag rails --summary lcov.info"
+    "publishCommand": "[..]qlty[..] coverage publish --dry-run --print --json --override-commit-sha 2ca1bc45a94e37c8dbae6fd9e19fc069ba64bd67 --transform-add-prefix rails/ --tag rails lcov.info"
   },
   "report_files": [
     {

--- a/qlty-cli/tests/cmd/coverage/json.toml
+++ b/qlty-cli/tests/cmd/coverage/json.toml
@@ -10,7 +10,6 @@ args = [
   "rails/",
   "--tag",
   "rails",
-  "--summary",
   "lcov.info"
 ]
 bin.name = "qlty"

--- a/qlty-cli/tests/cmd/coverage/overrides.stdout
+++ b/qlty-cli/tests/cmd/coverage/overrides.stdout
@@ -15,7 +15,7 @@
     "tag": "rails",
     "uploadedAt": "[..]",
     "cliVersion": "[..]",
-    "publishCommand": "[..]qlty[..] coverage publish --dry-run --print --json --override-branch test-branch-1 --override-commit-sha 2ca1bc45a94e37c8dbae6fd9e19fc069ba64bd67 --override-pr-number 99 --transform-add-prefix rails/ --tag rails --summary lcov.info"
+    "publishCommand": "[..]qlty[..] coverage publish --dry-run --print --json --override-branch test-branch-1 --override-commit-sha 2ca1bc45a94e37c8dbae6fd9e19fc069ba64bd67 --override-pr-number 99 --transform-add-prefix rails/ --tag rails lcov.info"
   },
   "report_files": [
     {

--- a/qlty-cli/tests/cmd/coverage/overrides.toml
+++ b/qlty-cli/tests/cmd/coverage/overrides.toml
@@ -14,7 +14,6 @@ args = [
   "rails/",
   "--tag",
   "rails",
-  "--summary",
   "lcov.info"
 ]
 bin.name = "qlty"


### PR DESCRIPTION
Prior to this PR, the coverage summary was hidden behind a `--summary` flag. This PR removes the argument and makes `--summary` a standard behavior.