### PR TITLE
Add `**/templates/**` to default exclude patterns

### DIFF
--- a/qlty-cli/src/initializer/templates/qlty.toml
+++ b/qlty-cli/src/initializer/templates/qlty.toml
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/basic.stdout
+++ b/qlty-cli/tests/cmd/init/basic.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/config_based_multiple_versions.stdout
+++ b/qlty-cli/tests/cmd/init/config_based_multiple_versions.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/config_based_version_new.stdout
+++ b/qlty-cli/tests/cmd/init/config_based_version_new.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/config_based_version_old.stdout
+++ b/qlty-cli/tests/cmd/init/config_based_version_old.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/custom_source.stdout
+++ b/qlty-cli/tests/cmd/init/custom_source.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/package_file.stdout
+++ b/qlty-cli/tests/cmd/init/package_file.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/package_file_gemfile.stdout
+++ b/qlty-cli/tests/cmd/init/package_file_gemfile.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/package_file_gemfile_lock.stdout
+++ b/qlty-cli/tests/cmd/init/package_file_gemfile_lock.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/package_file_gemfile_with_gemspec.stdout
+++ b/qlty-cli/tests/cmd/init/package_file_gemfile_with_gemspec.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/package_file_package_json.stdout
+++ b/qlty-cli/tests/cmd/init/package_file_package_json.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/package_file_yarn_lock.stdout
+++ b/qlty-cli/tests/cmd/init/package_file_yarn_lock.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/prefix.stdout
+++ b/qlty-cli/tests/cmd/init/prefix.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [

--- a/qlty-cli/tests/cmd/init/skip_default_source.stdout
+++ b/qlty-cli/tests/cmd/init/skip_default_source.stdout
@@ -17,8 +17,9 @@ exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",
-  "**/*.d.ts",
   "**/.yarn/**",
+  "**/*.d.ts",
+  "**/assets/**",
   "**/bower_components/**",
   "**/build/**",
   "**/cache/**",
@@ -36,9 +37,9 @@ exclude_patterns = [
   "**/protos/**",
   "**/seed/**",
   "**/target/**",
+  "**/templates/**",
   "**/testdata/**",
   "**/vendor/**",
-  "**/assets/**",
 ]
 
 test_patterns = [


### PR DESCRIPTION
Often template files _look_ like files of type X but contain syntax that is invalid making them prone to parse errors