### PR TITLE
Config files to support path matching

### DIFF
--- a/qlty-check/src/executor.rs
+++ b/qlty-check/src/executor.rs
@@ -290,7 +290,7 @@ impl Executor {
             let file_name = entry.file_name().to_str().unwrap();
             let path = entry.path().to_str().unwrap();
 
-            if config_globset.is_match(file_name)
+            if (config_globset.is_match(file_name) || config_globset.is_match(path))
                 && !path.contains(
                     self.plan
                         .workspace

--- a/qlty-check/src/planner/config_files.rs
+++ b/qlty-check/src/planner/config_files.rs
@@ -100,7 +100,8 @@ pub fn plugin_configs(planner: &Planner) -> Result<HashMap<String, Vec<PluginCon
         if let Some(os_str) = entry.path().file_name() {
             let file_name = os_str.to_os_string();
             for plugin_config in &plugins_configs {
-                if plugin_config.config_globset.is_match(&file_name)
+                if (plugin_config.config_globset.is_match(&file_name)
+                    || plugin_config.config_globset.is_match(entry.path()))
                     && !ignore_globset.is_match(entry.path())
                 {
                     let entry_path = entry.path();


### PR DESCRIPTION
Right now config files only expects file names, which can be cumbersome if someone wants to add an entire folder with many files, this PR adds support for path matching for config files as well.