### PR TITLE
Add a default .shellcheckrc when enabling shellcheck

### DIFF
--- a/qlty-plugins/plugins/linters/shellcheck/.shellcheckrc
+++ b/qlty-plugins/plugins/linters/shellcheck/.shellcheckrc
@@ -1,0 +1,1 @@
+source-path=SCRIPTDIR


### PR DESCRIPTION
This just tells shellcheck to search the directory of the shell script for sourced files