### PR TITLE
Upgrade cargo-dist to dist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,14 +144,14 @@ whoami = "1.5.2"
 xml-rs = "0.8.25"
 zip = "2.6.1"
 
-# Config for 'cargo dist'
+# Config for 'dist'
 [workspace.metadata.dist]
-# The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.19.1"
+# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.28.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell", "homebrew"]
+installers = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = [
     "aarch64-apple-darwin",
@@ -162,10 +162,9 @@ targets = [
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
 ]
-
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
-# Publish jobs to run in CI
+# Which actions to run on pull requests
 pr-run-mode = "plan"
 # Whether to install an updater program
 install-updater = true

--- a/qlty-config/Cargo.toml
+++ b/qlty-config/Cargo.toml
@@ -45,3 +45,6 @@ tracing.workspace = true
 ureq.workspace = true
 url.workspace = true
 walkdir.workspace = true
+
+[package.metadata.dist]
+dist = false

--- a/qlty-coverage/Cargo.toml
+++ b/qlty-coverage/Cargo.toml
@@ -38,3 +38,6 @@ zip.workspace = true
 [dev-dependencies]
 insta.workspace = true
 tempfile.workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["xml-rs"]


### PR DESCRIPTION
- Upgrade cargo-dist to 0.28.0
- Block qlty-config from being packaged into releases (it got pulled in because it has a `qlty-config-generate-schema` binary)
- Disable shell and powershell installer generation (we use our own)
- Also, fix `cargo machete` false positive