### PR TITLE
Prevent .qlty/.gitignore from ignoring itself

### DIFF
--- a/.qlty/.gitignore
+++ b/.qlty/.gitignore
@@ -1,4 +1,7 @@
 *
 !configs
+!configs/**
 !hooks
+!hooks/**
 !qlty.toml
+!.gitignore

--- a/qlty-cli/src/initializer/templates/gitignore.txt
+++ b/qlty-cli/src/initializer/templates/gitignore.txt
@@ -4,3 +4,4 @@
 !hooks
 !hooks/**
 !qlty.toml
+!.gitignore


### PR DESCRIPTION
Add `!.gitignore` to .gitignore template so it gets tracked and prevent vcs issues.