### PR TITLE
Revert "Upgrade cargo-dist to dist"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,14 +144,14 @@ whoami = "1.5.2"
 xml-rs = "0.8.26"
 zip = "2.6.1"
 
-# Config for 'dist'
+# Config for 'cargo dist'
 [workspace.metadata.dist]
-# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.28.0"
+# The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.19.1"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["homebrew"]
+installers = ["shell", "powershell", "homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = [
     "aarch64-apple-darwin",
@@ -162,9 +162,10 @@ targets = [
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
 ]
+
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
-# Which actions to run on pull requests
+# Publish jobs to run in CI
 pr-run-mode = "plan"
 # Whether to install an updater program
 install-updater = true

--- a/qlty-config/Cargo.toml
+++ b/qlty-config/Cargo.toml
@@ -45,6 +45,3 @@ tracing.workspace = true
 ureq.workspace = true
 url.workspace = true
 walkdir.workspace = true
-
-[package.metadata.dist]
-dist = false

--- a/qlty-coverage/Cargo.toml
+++ b/qlty-coverage/Cargo.toml
@@ -38,6 +38,3 @@ zip.workspace = true
 [dev-dependencies]
 insta.workspace = true
 tempfile.workspace = true
-
-[package.metadata.cargo-machete]
-ignored = ["xml-rs"]


### PR DESCRIPTION
Reverts qltysh/qlty#1974

Releases failing due to: `Error: The template is not valid. .github/workflows/cli_release.yml (Line: 201, Col: 14): A mapping was not expected` on "Install cargo-dist" step

https://github.com/qltysh/cloud/actions/runs/14743273682/job/41385731518