### PR TITLE
Release tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ cargo-dist-version = "0.19.1"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell", "homebrew"]
+installers = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = [
     "aarch64-apple-darwin",

--- a/qlty-config/Cargo.toml
+++ b/qlty-config/Cargo.toml
@@ -45,3 +45,6 @@ tracing.workspace = true
 ureq.workspace = true
 url.workspace = true
 walkdir.workspace = true
+
+[package.metadata.dist]
+dist = false

--- a/qlty-coverage/Cargo.toml
+++ b/qlty-coverage/Cargo.toml
@@ -38,3 +38,6 @@ zip.workspace = true
 [dev-dependencies]
 insta.workspace = true
 tempfile.workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["xml-rs"]


### PR DESCRIPTION
- Block qlty-config from being packaged into releases (it got pulled in because it has a qlty-config-generate-schema binary)
- Disable shell and powershell installer generation (we use our own)
- Also, fix cargo machete false positive