### PR TITLE
Fix CI: Update flake8 snapshots

### DIFF
--- a/qlty-plugins/plugins/linters/flake8/fixtures/__snapshots__/basic_v6.0.0.shot
+++ b/qlty-plugins/plugins/linters/flake8/fixtures/__snapshots__/basic_v6.0.0.shot
@@ -14,27 +14,6 @@ exports[`linter=flake8 fixture=basic version=6.0.0 1`] = `
           "startLine": 4,
         },
       },
-      "message": "expected 2 blank lines after class or function definition, found 1",
-      "mode": "MODE_BLOCK",
-      "ruleKey": "E305",
-      "snippet": "import foo",
-      "snippetWithContext": "def main():
-    pass
-
-import foo",
-      "tool": "flake8",
-    },
-    {
-      "category": "CATEGORY_LINT",
-      "documentationUrl": "https://flake8.pycqa.org/en/latest/user/error-codes.html",
-      "level": "LEVEL_MEDIUM",
-      "location": {
-        "path": "basic.in.py",
-        "range": {
-          "startColumn": 1,
-          "startLine": 4,
-        },
-      },
       "message": "module level import not at top of file",
       "mode": "MODE_BLOCK",
       "ruleKey": "E402",

--- a/qlty-plugins/plugins/linters/flake8/fixtures/__snapshots__/basic_v6.1.0.shot
+++ b/qlty-plugins/plugins/linters/flake8/fixtures/__snapshots__/basic_v6.1.0.shot
@@ -14,27 +14,6 @@ exports[`linter=flake8 fixture=basic version=6.1.0 1`] = `
           "startLine": 4,
         },
       },
-      "message": "expected 2 blank lines after class or function definition, found 1",
-      "mode": "MODE_BLOCK",
-      "ruleKey": "E305",
-      "snippet": "import foo",
-      "snippetWithContext": "def main():
-    pass
-
-import foo",
-      "tool": "flake8",
-    },
-    {
-      "category": "CATEGORY_LINT",
-      "documentationUrl": "https://flake8.pycqa.org/en/latest/user/error-codes.html",
-      "level": "LEVEL_MEDIUM",
-      "location": {
-        "path": "basic.in.py",
-        "range": {
-          "startColumn": 1,
-          "startLine": 4,
-        },
-      },
       "message": "module level import not at top of file",
       "mode": "MODE_BLOCK",
       "ruleKey": "E402",

--- a/qlty-plugins/plugins/linters/flake8/fixtures/__snapshots__/basic_v7.1.1.shot
+++ b/qlty-plugins/plugins/linters/flake8/fixtures/__snapshots__/basic_v7.1.1.shot
@@ -14,27 +14,6 @@ exports[`linter=flake8 fixture=basic version=7.1.1 1`] = `
           "startLine": 4,
         },
       },
-      "message": "expected 2 blank lines after class or function definition, found 1",
-      "mode": "MODE_BLOCK",
-      "ruleKey": "E305",
-      "snippet": "import foo",
-      "snippetWithContext": "def main():
-    pass
-
-import foo",
-      "tool": "flake8",
-    },
-    {
-      "category": "CATEGORY_LINT",
-      "documentationUrl": "https://flake8.pycqa.org/en/latest/user/error-codes.html",
-      "level": "LEVEL_MEDIUM",
-      "location": {
-        "path": "basic.in.py",
-        "range": {
-          "startColumn": 1,
-          "startLine": 4,
-        },
-      },
       "message": "module level import not at top of file",
       "mode": "MODE_BLOCK",
       "ruleKey": "E402",


### PR DESCRIPTION
These snapshots became out-of-date once we fixed the bug to copy linter configs, because the `.flake8` config file suddenly started to be copied (before, it was ignored).

I confirmed that flake8 passes the tests in main if the `.flake8` file is removed, so it's working fine.

This is a blind update of the snapshots to get CI working