### PR TITLE
Fix bubbling of stderr to tool install log files

### DIFF
--- a/qlty-check/src/tool/php/composer.rs
+++ b/qlty-check/src/tool/php/composer.rs
@@ -107,7 +107,8 @@ impl Composer {
         let _ =
             finalize_installation_from_cmd_result(php_package, &result, &mut installation, script);
 
-        if result?.status.code() != Some(0) {
+        let output = result?;
+        if output.status.code() != Some(0) {
             bail!("Failed to install composer package file");
         }
 

--- a/qlty-check/src/tool/ruby/gemfile.rs
+++ b/qlty-check/src/tool/ruby/gemfile.rs
@@ -3,7 +3,7 @@ use crate::tool::finalize_installation_from_cmd_result;
 use crate::tool::installations::initialize_installation;
 use crate::ui::ProgressBar;
 use crate::{tool::Tool, ui::ProgressTask};
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use itertools::Itertools;
 use qlty_analysis::{join_path_string, utils::fs::path_to_native_string};
 use std::{collections::HashMap, path::PathBuf};
@@ -37,15 +37,13 @@ impl RubyGemfile {
         let result = list_command.run();
         let _ = finalize_installation_from_cmd_result(self, &result, &mut installation, script);
 
-        let list_output: std::process::Output =
-            result.with_context(|| "Failed to run: ruby -S bundle list")?;
-
-        let stdout = String::from_utf8_lossy(&list_output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&list_output.stderr).to_string();
+        let output = result?;
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
         info!("ruby -S bundle list list stdout: {}", stdout);
         info!("ruby -S bundle list list stderr: {}", stderr);
 
-        if !list_output.status.success() {
+        if !output.status.success() {
             bail!("Failed to run: ruby -S bundle list");
         }
 


### PR DESCRIPTION
Running duct::cmd::run() by default bails on non-zero exit codes, avoiding capture of any stderr. This change updates to run with `unchecked()` so that stderr can be captured into log files.

Due to this change, the specifics of Tool.run_command had to be updated to extract the original command for error display to maintain the original (somewhat helpful errors), as the Err object containing the command must now be synthesized manually (duct returned the err in the form `["program", "arg1", ...]` but this list of program/args is not available on the Expression object except via before_spawn).