### PR TITLE
ruby(linux): Install libyaml as dependency in binary install

### DIFF
--- a/.github/workflows/cli_integration.yml
+++ b/.github/workflows/cli_integration.yml
@@ -71,18 +71,18 @@ jobs:
           ]
         include:
           - container: ubuntu:24.04
-            package_install: apt-get update && apt-get install -y git curl libyaml-dev libgmp-dev build-essential
+            package_install: apt-get update && apt-get install -y git curl build-essential
           - container: debian:trixie-slim
-            package_install: apt-get update && apt-get install -y git curl libyaml-dev libgmp-dev build-essential
+            package_install: apt-get update && apt-get install -y git curl build-essential
           #- container: debian:bookworm-slim
-          #  package_install: apt-get update && apt-get install -y git curl libyaml-dev libgmp-dev build-essential
+          #  package_install: apt-get update && apt-get install -y git curl build-essential
           #- container: redhat/ubi9
-          #  package_install: yum install -y git gcc make libyaml-devel gmp-devel
+          #  package_install: yum install -y git gcc make gmp-devel
           # unsupported:
           # - container: ubuntu:20.04
-          #   package_install: apt-get update && apt-get install -y git curl libyaml-dev libgmp-dev build-essential
+          #   package_install: apt-get update && apt-get install -y git curl build-essential
           # - container: redhat/ubi8
-          #   package_install: yum install -y git gcc make libyaml-devel gmp-devel
+          #   package_install: yum install -y git gcc make gmp-devel
     container:
       image: ${{ matrix.container }}
       env:

--- a/qlty-check/src/tool/ruby/sys/linux.rs
+++ b/qlty-check/src/tool/ruby/sys/linux.rs
@@ -46,6 +46,14 @@ impl PlatformRuby for RubyLinux {
             "libx/libxcrypt/libcrypt1_4.4.18-4",
             vec![DependencyFile::new("libcrypt.so.1.1.0", "libcrypt.so.1")],
         )?;
+        self.install_dependency_deb(
+            tool,
+            "liby/libyaml/libyaml-0-2_0.2.5-2",
+            vec![
+                DependencyFile::both("libyaml-0.so.2"),
+                DependencyFile::both("libyaml-0.so.2.0.9"),
+            ],
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
This avoids the need for a preflight check and allows a hands-off sandboxed approach to Ruby installs.

Obviates #2007 