### PR TITLE
ruby(linux): disable binary builds on musl platforms

### DIFF
--- a/qlty-check/src/tool/php/composer.rs
+++ b/qlty-check/src/tool/php/composer.rs
@@ -107,7 +107,8 @@ impl Composer {
         let _ =
             finalize_installation_from_cmd_result(php_package, &result, &mut installation, script);
 
-        if result?.status.code() != Some(0) {
+        let output = result?;
+        if output.status.code() != Some(0) {
             bail!("Failed to install composer package file");
         }
 

--- a/qlty-check/src/tool/ruby/gemfile.rs
+++ b/qlty-check/src/tool/ruby/gemfile.rs
@@ -3,7 +3,7 @@ use crate::tool::finalize_installation_from_cmd_result;
 use crate::tool::installations::initialize_installation;
 use crate::ui::ProgressBar;
 use crate::{tool::Tool, ui::ProgressTask};
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use itertools::Itertools;
 use qlty_analysis::{join_path_string, utils::fs::path_to_native_string};
 use std::{collections::HashMap, path::PathBuf};
@@ -37,15 +37,13 @@ impl RubyGemfile {
         let result = list_command.run();
         let _ = finalize_installation_from_cmd_result(self, &result, &mut installation, script);
 
-        let list_output: std::process::Output =
-            result.with_context(|| "Failed to run: ruby -S bundle list")?;
-
-        let stdout = String::from_utf8_lossy(&list_output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&list_output.stderr).to_string();
+        let output = result?;
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
         info!("ruby -S bundle list list stdout: {}", stdout);
         info!("ruby -S bundle list list stderr: {}", stderr);
 
-        if !list_output.status.success() {
+        if !output.status.success() {
             bail!("Failed to run: ruby -S bundle list");
         }
 

--- a/qlty-check/src/tool/ruby/sys/linux.rs
+++ b/qlty-check/src/tool/ruby/sys/linux.rs
@@ -9,6 +9,7 @@ use crate::{
 use anyhow::{bail, Result};
 use ar::Entry;
 use chrono::Utc;
+use duct::cmd;
 use qlty_analysis::{join_path_string, utils::fs::path_to_string};
 use qlty_types::analysis::v1::Installation;
 use std::{
@@ -30,6 +31,16 @@ const DEBIAN_DATA_TAR_XZ: &[u8; 11] = b"data.tar.xz";
 pub struct RubyLinux {}
 
 impl PlatformRuby for RubyLinux {
+    fn binary_install_enabled(&self) -> bool {
+        !cmd!("ldd", "--version")
+            .stderr_to_stdout()
+            .stdout_capture()
+            .unchecked()
+            .read()
+            .unwrap_or_default()
+            .contains("musl")
+    }
+
     fn post_install(&self, tool: &dyn Tool, task: &ProgressTask) -> Result<()> {
         task.set_message("Setting up Ruby on Linux");
         self.rewrite_binstubs(tool)?;


### PR DESCRIPTION
We don't currently support binary builds on musl platforms (alpine, etc). Force ruby-build for these platforms.

Note that the system will need the following dependencies for a successful build (packages list for apk):

```sh
apk add -U bash perl gcc make openssl-dev musl-dev zlib-dev yaml-dev
```

For this reason, it might actually be easier to eventually support some kind of `QLTY_FEATURE_RUBY_USE_SYSTEM` opt-in for these types of setups, as it would be much simpler to `apk add -U ruby` than all of the above, and once we're depending on system deps, we've already broken the sandbox.