### PR TITLE
Add a `qlty coverage complete` sub-command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,8 +2548,10 @@ dependencies = [
 name = "qlty-cloud"
 version = "0.523.0"
 dependencies = [
+ "anyhow",
  "insta",
  "qlty-config",
+ "qlty-types",
  "tempfile",
  "ureq",
 ]
@@ -2608,6 +2610,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "time",
+ "tracing",
  "ureq",
  "xml-rs",
  "zip",

--- a/qlty-cli/src/commands/coverage.rs
+++ b/qlty-cli/src/commands/coverage.rs
@@ -1,6 +1,7 @@
 mod complete;
 mod publish;
 mod transform;
+mod utils;
 pub use complete::Complete;
 pub use publish::Publish;
 pub use transform::Transform;

--- a/qlty-cli/src/commands/coverage.rs
+++ b/qlty-cli/src/commands/coverage.rs
@@ -1,5 +1,7 @@
+mod complete;
 mod publish;
 mod transform;
+pub use complete::Complete;
 pub use publish::Publish;
 pub use transform::Transform;
 
@@ -22,6 +24,9 @@ pub enum Commands {
 
     /// Transform coverage data to the Qlty format
     Transform(Transform),
+
+    /// Mark coverage as complete on Qlty Cloud
+    Complete(Complete),
 }
 
 impl Arguments {
@@ -29,6 +34,7 @@ impl Arguments {
         match &self.command {
             Commands::Transform(command) => command.execute(args),
             Commands::Publish(command) => command.execute(args),
+            Commands::Complete(command) => command.execute(args),
         }
     }
 }

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -4,6 +4,7 @@ use super::utils::{
 use crate::{CommandError, CommandSuccess};
 use anyhow::{bail, Context, Result};
 use clap::Args;
+use console::style;
 use qlty_cloud::Client as QltyClient;
 use qlty_coverage::{
     publish::{Plan, Planner, Settings},
@@ -55,6 +56,7 @@ impl Complete {
 
         let settings = self.build_settings();
 
+        self.print_section_header(" SETTINGS ");
         print_settings(&settings);
 
         let token = load_auth_token(&self.token, self.project.as_deref())?;
@@ -62,7 +64,10 @@ impl Complete {
 
         self.validate_plan(&plan)?;
 
+        self.print_section_header(" METADATA ");
         print_metadata(&plan, self.quiet);
+
+        self.print_section_header(" AUTHENTICATION ");
         print_authentication_info(&token, self.quiet);
 
         let timer = Instant::now();
@@ -70,6 +75,15 @@ impl Complete {
         self.print_complete_success(timer.elapsed().as_secs_f32());
 
         CommandSuccess::ok()
+    }
+
+    fn print_section_header(&self, title: &str) {
+        if self.quiet {
+            return;
+        }
+
+        eprintln!("{}", style(title).bold().reverse());
+        eprintln!();
     }
 
     fn build_settings(&self) -> Settings {
@@ -100,10 +114,7 @@ impl Complete {
             return;
         }
 
-        eprintln!(
-            "    Coverage marked as complete in {:.2}s!",
-            elapsed_seconds
-        );
+        eprintln!("    Coverage marked as complete in {elapsed_seconds:.2}s!");
         eprintln!();
     }
 

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -104,7 +104,7 @@ impl Complete {
             "    Coverage marked as complete in {:.2}s!",
             elapsed_seconds
         );
-        eprintln!("");
+        eprintln!();
     }
 
     fn request_complete(

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -1,0 +1,403 @@
+use crate::{CommandError, CommandSuccess};
+use anyhow::{anyhow, Context};
+use anyhow::{bail, Result};
+use clap::Args;
+use console::style;
+use git2::Repository;
+use qlty_cloud::Client as QltyClient;
+use qlty_config::version::LONG_VERSION;
+use qlty_config::{QltyConfig, Workspace};
+use qlty_coverage::ci::{GitHub, CI};
+use qlty_coverage::eprintln_unless;
+use qlty_coverage::publish::{Plan, Planner, Settings};
+use regex::Regex;
+use serde_json::Value;
+use std::path::PathBuf;
+use std::time::Instant;
+use tracing::debug;
+
+const COVERAGE_TOKEN_WORKSPACE_PREFIX: &str = "qltcw_";
+const COVERAGE_TOKEN_PROJECT_PREFIX: &str = "qltcp_";
+const OIDC_REGEX: &str = r"^([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)$";
+const LEGACY_API_URL: &str = "https://qlty.sh/api";
+
+#[derive(Debug, Args, Default)]
+pub struct Complete {
+    #[arg(long)]
+    pub tag: Option<String>,
+
+    #[arg(long)]
+    /// Override the branch from the CI environment
+    pub override_branch: Option<String>,
+
+    #[arg(long)]
+    /// Override the commit SHA from the CI environment
+    pub override_commit_sha: Option<String>,
+
+    #[arg(long)]
+    /// Override the pull request number from the CI environment
+    pub override_pr_number: Option<String>,
+
+    #[arg(long, short)]
+    /// The token to use for authentication when uploading the report.
+    /// By default, it retrieves the token from the QLTY_COVERAGE_TOKEN environment variable.
+    pub token: Option<String>,
+
+    #[arg(long)]
+    /// The name of the project to associate the coverage report with. Only needed when coverage token represents a
+    /// workspace and if it cannot be inferred from the git origin.
+    pub project: Option<String>,
+
+    #[clap(long, short)]
+    pub quiet: bool,
+}
+
+impl Complete {
+    pub fn execute(&self, _args: &crate::Arguments) -> Result<CommandSuccess, CommandError> {
+        self.print_initial_messages();
+
+        let settings = self.build_settings();
+
+        self.print_settings(&settings);
+
+        let token = self.load_auth_token()?;
+        let plan = Planner::new(&Self::load_config(), &settings).compute()?;
+
+        self.validate_plan(&plan)?;
+
+        self.print_metadata(&plan);
+
+        self.print_section_header(" PREPARING TO UPLOAD... ");
+        self.print_authentication_info(&token);
+
+        self.print_section_header(" UPLOADING... ");
+        let timer = Instant::now();
+        self.request_complete(&plan.metadata, &token)
+            .context("Failed to complete coverage")?;
+        self.print_complete_success(timer.elapsed().as_secs_f32());
+
+        CommandSuccess::ok()
+    }
+
+    fn build_settings(&self) -> Settings {
+        Settings {
+            override_commit_sha: self.override_commit_sha.clone(),
+            override_branch: self.override_branch.clone(),
+            override_pull_request_number: self.override_pr_number.clone(),
+            tag: self.tag.clone(),
+            // Set empty values for parameters not needed in complete
+            paths: vec![],
+            add_prefix: None,
+            strip_prefix: None,
+            report_format: None,
+            skip_missing_files: false,
+            total_parts_count: None,
+            override_build_id: None,
+        }
+    }
+
+    fn validate_plan(&self, plan: &Plan) -> Result<()> {
+        if plan.metadata.commit_sha.is_empty() {
+            bail!(
+                "Unable to determine commit SHA from the environment.\nPlease provide it using --override-commit-sha"
+            )
+        }
+
+        Ok(())
+    }
+
+    fn print_initial_messages(&self) {
+        eprintln_unless!(self.quiet, "qlty {}", LONG_VERSION.as_str());
+        eprintln_unless!(self.quiet, "{}", style("https://qlty.sh/d/coverage").dim());
+        eprintln_unless!(self.quiet, "");
+    }
+
+    fn print_section_header(&self, title: &str) {
+        eprintln_unless!(self.quiet, "{}", style(title).bold().reverse());
+        eprintln_unless!(self.quiet, "");
+    }
+
+    fn print_settings(&self, _settings: &Settings) {
+        self.print_section_header(" SETTINGS ");
+
+        eprintln_unless!(
+            self.quiet,
+            "    cwd: {}",
+            std::env::current_dir()
+                .unwrap_or(PathBuf::from("ERROR"))
+                .to_string_lossy()
+        );
+
+        if let Some(tag) = &self.tag {
+            eprintln_unless!(self.quiet, "    tag: {}", tag);
+        }
+        if let Some(override_branch) = &self.override_branch {
+            eprintln_unless!(self.quiet, "    override-branch: {}", override_branch);
+        }
+        if let Some(override_commit_sha) = &self.override_commit_sha {
+            eprintln_unless!(
+                self.quiet,
+                "    override-commit-sha: {}",
+                override_commit_sha
+            );
+        }
+        if let Some(override_pr_number) = &self.override_pr_number {
+            eprintln_unless!(self.quiet, "    override-pr-number: {}", override_pr_number);
+        }
+        if let Some(project) = &self.project {
+            eprintln_unless!(self.quiet, "    project: {}", project);
+        }
+
+        eprintln_unless!(self.quiet, "");
+    }
+
+    fn print_metadata(&self, plan: &Plan) {
+        self.print_section_header(" METADATA ");
+        if !plan.metadata.ci.is_empty() {
+            eprintln_unless!(self.quiet, "    CI: {}", plan.metadata.ci);
+        }
+
+        eprintln_unless!(self.quiet, "    Commit: {}", plan.metadata.commit_sha);
+        if !plan.metadata.pull_request_number.is_empty() {
+            eprintln_unless!(
+                self.quiet,
+                "    Pull Request: #{}",
+                plan.metadata.pull_request_number
+            );
+        }
+
+        if !plan.metadata.branch.is_empty() {
+            eprintln_unless!(self.quiet, "    Branch: {}", plan.metadata.branch);
+        }
+
+        if !plan.metadata.build_id.is_empty() {
+            eprintln_unless!(self.quiet, "    Build ID: {}", plan.metadata.build_id);
+        }
+
+        eprintln_unless!(self.quiet, "");
+    }
+
+    fn print_authentication_info(&self, token: &str) {
+        let token_type = if token.starts_with(COVERAGE_TOKEN_WORKSPACE_PREFIX) {
+            "Workspace Token"
+        } else if token.starts_with(COVERAGE_TOKEN_PROJECT_PREFIX) {
+            "Project Token"
+        } else if let Ok(oidc_regex) = Regex::new(OIDC_REGEX) {
+            if oidc_regex.is_match(token) {
+                "OIDC"
+            } else {
+                "Unknown"
+            }
+        } else {
+            "ERROR"
+        };
+        eprintln_unless!(self.quiet, "    Auth Method: {}", token_type);
+        eprintln_unless!(self.quiet, "    Token: {}", token);
+        eprintln_unless!(self.quiet, "");
+    }
+
+    fn print_complete_success(&self, elapsed_seconds: f32) {
+        eprintln_unless!(
+            self.quiet,
+            "    Coverage marked as complete in {:.2}s!",
+            elapsed_seconds
+        );
+        eprintln_unless!(self.quiet, "");
+    }
+
+    fn load_auth_token(&self) -> Result<String> {
+        self.expand_token(match &self.token {
+            Some(token) => Ok(token.to_owned()),
+            None => std::env::var("QLTY_COVERAGE_TOKEN").map_err(|_| {
+                anyhow::Error::msg("QLTY_COVERAGE_TOKEN environment variable is required.")
+            }),
+        }?)
+    }
+
+    fn request_complete(
+        &self,
+        metadata: &qlty_types::tests::v1::CoverageMetadata,
+        token: &str,
+    ) -> Result<Value> {
+        let client = QltyClient::new(Some(LEGACY_API_URL), Some(token.into()));
+        let response_result = client.post("/coverage/complete").send_json(ureq::json!({
+            "data": metadata,
+        }));
+
+        match response_result {
+            Ok(resp) => resp.into_json::<Value>().map_err(|err| {
+                anyhow!(
+                    "JSON Error: {}: Unable to parse JSON response from success: {:?}",
+                    client.base_url,
+                    err
+                )
+            }),
+
+            Err(ureq::Error::Status(code, resp)) => match resp.into_string() {
+                Ok(body) => match serde_json::from_str::<Value>(&body) {
+                    Ok(json) => match json.get("error") {
+                        Some(error) => {
+                            bail!("HTTP Error {}: {}: {}", code, client.base_url, error)
+                        }
+                        None => {
+                            bail!("HTTP Error {}: {}: {}", code, client.base_url, body);
+                        }
+                    },
+                    Err(_) => bail!(
+                        "HTTP Error {}: {}: Unable to parse JSON response: {}",
+                        code,
+                        client.base_url,
+                        body
+                    ),
+                },
+                Err(err) => bail!(
+                    "HTTP Error {}: {}: Error reading response body: {:?}",
+                    code,
+                    client.base_url,
+                    err
+                ),
+            },
+            Err(ureq::Error::Transport(transport_error)) => bail!(
+                "Transport Error: {}: {:?}",
+                client.base_url,
+                transport_error
+            ),
+        }
+    }
+
+    /// Appends repository name to token if it is a workspace token
+    fn expand_token(&self, token: String) -> Result<String> {
+        if token.starts_with(COVERAGE_TOKEN_WORKSPACE_PREFIX) {
+            if token.contains('/') {
+                return Ok(token);
+            }
+            let project = if let Some(project) = &self.project {
+                project.clone()
+            } else if let Some(repository) = self.find_repository_name_from_env() {
+                repository
+            } else {
+                match self.find_repository_name_from_repository() {
+                    Ok(repository) => repository,
+                    Err(err) => {
+                        debug!("Find repository name: {}", err);
+                        bail!(
+                            "Could not infer project name from environment, please provide it using --project"
+                        )
+                    }
+                }
+            };
+            Ok(format!("{}/{}", token, project))
+        } else {
+            Ok(token)
+        }
+    }
+
+    fn find_repository_name_from_env(&self) -> Option<String> {
+        let repository = GitHub::default().repository_name();
+        if repository.is_empty() {
+            None
+        } else {
+            Self::extract_repository_name(&repository)
+        }
+    }
+
+    fn find_repository_name_from_repository(&self) -> Result<String> {
+        let root = Workspace::assert_within_git_directory()?;
+        let repo = Repository::open(root)?;
+        let remote = repo.find_remote("origin")?;
+        if let Some(name) = Self::extract_repository_name(remote.url().unwrap_or_default()) {
+            Ok(name)
+        } else {
+            bail!(
+                "Could not find repository name from git remote: {:?}",
+                remote.url()
+            )
+        }
+    }
+
+    fn extract_repository_name(value: &str) -> Option<String> {
+        value
+            .split('/')
+            .next_back()
+            .map(|s| s.strip_suffix(".git").unwrap_or(s).to_string())
+            .take_if(|v| !v.is_empty())
+    }
+
+    fn load_config() -> QltyConfig {
+        Workspace::new()
+            .and_then(|workspace| workspace.config())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn complete(project: Option<&str>) -> Complete {
+        Complete {
+            project: project.map(|s| s.to_string()),
+            quiet: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_expand_token_project() -> Result<()> {
+        let token = complete(None).expand_token("qltcp_123".to_string())?;
+        assert_eq!(token, "qltcp_123");
+        Ok(())
+    }
+
+    #[test]
+    fn test_expand_token_workspace_with_project() -> Result<()> {
+        let token = complete(Some("test")).expand_token("qltcw_123".to_string())?;
+        assert_eq!(token, "qltcw_123/test");
+        Ok(())
+    }
+
+    #[test]
+    fn test_expand_token_workspace_with_env() -> Result<()> {
+        let token = complete(None).expand_token("qltcw_123".to_string())?;
+        assert!(token.starts_with("qltcw_123/"));
+
+        std::env::set_var("GITHUB_REPOSITORY", "");
+        let token = complete(None).expand_token("qltcw_123".to_string())?;
+        assert!(token.starts_with("qltcw_123/"));
+
+        std::env::set_var("GITHUB_REPOSITORY", "a/b.git");
+        let token = complete(None).expand_token("qltcw_123".to_string())?;
+        assert_eq!(token, "qltcw_123/b");
+
+        std::env::set_var("GITHUB_REPOSITORY", "b/c");
+        let token = complete(None).expand_token("qltcw_123".to_string())?;
+        assert_eq!(token, "qltcw_123/c");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expand_token_already_expanded() -> Result<()> {
+        let token = complete(Some("test")).expand_token("qltcw_123/abc".to_string())?;
+        assert_eq!(token, "qltcw_123/abc");
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_repository_name() {
+        assert_eq!(Complete::extract_repository_name(""), None);
+        assert_eq!(Complete::extract_repository_name("a/"), None);
+        assert_eq!(
+            Complete::extract_repository_name("git@example.org:a/b"),
+            Some("b".into())
+        );
+        assert_eq!(
+            Complete::extract_repository_name("ssh://x@example.org:a/b"),
+            Some("b".into())
+        );
+        assert_eq!(
+            Complete::extract_repository_name("https://x:y@example.org/a/b"),
+            Some("b".into())
+        );
+    }
+}

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -286,7 +286,7 @@ impl Complete {
                     }
                 }
             };
-            Ok(format!("{}/{}", token, project))
+            Ok(format!("{token}/{project}"))
         } else {
             Ok(token)
         }

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -1,24 +1,17 @@
+use super::utils::{
+    load_config, print_authentication_info, print_initial_messages, print_metadata, print_settings,
+};
 use crate::{CommandError, CommandSuccess};
-use anyhow::{anyhow, Context};
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use clap::Args;
-use console::style;
-use git2::Repository;
 use qlty_cloud::Client as QltyClient;
-use qlty_config::version::LONG_VERSION;
-use qlty_config::{QltyConfig, Workspace};
-use qlty_coverage::ci::{GitHub, CI};
-use qlty_coverage::eprintln_unless;
-use qlty_coverage::publish::{Plan, Planner, Settings};
-use regex::Regex;
+use qlty_coverage::{
+    publish::{Plan, Planner, Settings},
+    token::load_auth_token,
+};
 use serde_json::Value;
-use std::path::PathBuf;
 use std::time::Instant;
-use tracing::debug;
 
-const COVERAGE_TOKEN_WORKSPACE_PREFIX: &str = "qltcw_";
-const COVERAGE_TOKEN_PROJECT_PREFIX: &str = "qltcp_";
-const OIDC_REGEX: &str = r"^([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)$";
 const LEGACY_API_URL: &str = "https://qlty.sh/api";
 
 #[derive(Debug, Args, Default)]
@@ -38,6 +31,10 @@ pub struct Complete {
     /// Override the pull request number from the CI environment
     pub override_pr_number: Option<String>,
 
+    #[arg(long)]
+    /// Override the build identifier from the CI environment
+    pub override_build_id: Option<String>,
+
     #[arg(long, short)]
     /// The token to use for authentication when uploading the report.
     /// By default, it retrieves the token from the QLTY_COVERAGE_TOKEN environment variable.
@@ -54,26 +51,22 @@ pub struct Complete {
 
 impl Complete {
     pub fn execute(&self, _args: &crate::Arguments) -> Result<CommandSuccess, CommandError> {
-        self.print_initial_messages();
+        print_initial_messages(self.quiet);
 
         let settings = self.build_settings();
 
-        self.print_settings(&settings);
+        print_settings(&settings);
 
-        let token = self.load_auth_token()?;
-        let plan = Planner::new(&Self::load_config(), &settings).compute()?;
+        let token = load_auth_token(&self.token, self.project.as_deref())?;
+        let plan = Planner::new(&load_config(), &settings).compute()?;
 
         self.validate_plan(&plan)?;
 
-        self.print_metadata(&plan);
+        print_metadata(&plan, self.quiet);
+        print_authentication_info(&token, self.quiet);
 
-        self.print_section_header(" PREPARING TO UPLOAD... ");
-        self.print_authentication_info(&token);
-
-        self.print_section_header(" UPLOADING... ");
         let timer = Instant::now();
-        self.request_complete(&plan.metadata, &token)
-            .context("Failed to complete coverage")?;
+        Self::request_complete(&plan.metadata, &token).context("Failed to complete coverage")?;
         self.print_complete_success(timer.elapsed().as_secs_f32());
 
         CommandSuccess::ok()
@@ -84,15 +77,11 @@ impl Complete {
             override_commit_sha: self.override_commit_sha.clone(),
             override_branch: self.override_branch.clone(),
             override_pull_request_number: self.override_pr_number.clone(),
+            override_build_id: self.override_build_id.clone(),
             tag: self.tag.clone(),
-            // Set empty values for parameters not needed in complete
-            paths: vec![],
-            add_prefix: None,
-            strip_prefix: None,
-            report_format: None,
-            skip_missing_files: false,
-            total_parts_count: None,
-            override_build_id: None,
+            quiet: self.quiet,
+            project: self.project.clone(),
+            ..Default::default()
         }
     }
 
@@ -106,298 +95,23 @@ impl Complete {
         Ok(())
     }
 
-    fn print_initial_messages(&self) {
-        eprintln_unless!(self.quiet, "qlty {}", LONG_VERSION.as_str());
-        eprintln_unless!(self.quiet, "{}", style("https://qlty.sh/d/coverage").dim());
-        eprintln_unless!(self.quiet, "");
-    }
-
-    fn print_section_header(&self, title: &str) {
-        eprintln_unless!(self.quiet, "{}", style(title).bold().reverse());
-        eprintln_unless!(self.quiet, "");
-    }
-
-    fn print_settings(&self, _settings: &Settings) {
-        self.print_section_header(" SETTINGS ");
-
-        eprintln_unless!(
-            self.quiet,
-            "    cwd: {}",
-            std::env::current_dir()
-                .unwrap_or(PathBuf::from("ERROR"))
-                .to_string_lossy()
-        );
-
-        if let Some(tag) = &self.tag {
-            eprintln_unless!(self.quiet, "    tag: {}", tag);
-        }
-        if let Some(override_branch) = &self.override_branch {
-            eprintln_unless!(self.quiet, "    override-branch: {}", override_branch);
-        }
-        if let Some(override_commit_sha) = &self.override_commit_sha {
-            eprintln_unless!(
-                self.quiet,
-                "    override-commit-sha: {}",
-                override_commit_sha
-            );
-        }
-        if let Some(override_pr_number) = &self.override_pr_number {
-            eprintln_unless!(self.quiet, "    override-pr-number: {}", override_pr_number);
-        }
-        if let Some(project) = &self.project {
-            eprintln_unless!(self.quiet, "    project: {}", project);
-        }
-
-        eprintln_unless!(self.quiet, "");
-    }
-
-    fn print_metadata(&self, plan: &Plan) {
-        self.print_section_header(" METADATA ");
-        if !plan.metadata.ci.is_empty() {
-            eprintln_unless!(self.quiet, "    CI: {}", plan.metadata.ci);
-        }
-
-        eprintln_unless!(self.quiet, "    Commit: {}", plan.metadata.commit_sha);
-        if !plan.metadata.pull_request_number.is_empty() {
-            eprintln_unless!(
-                self.quiet,
-                "    Pull Request: #{}",
-                plan.metadata.pull_request_number
-            );
-        }
-
-        if !plan.metadata.branch.is_empty() {
-            eprintln_unless!(self.quiet, "    Branch: {}", plan.metadata.branch);
-        }
-
-        if !plan.metadata.build_id.is_empty() {
-            eprintln_unless!(self.quiet, "    Build ID: {}", plan.metadata.build_id);
-        }
-
-        eprintln_unless!(self.quiet, "");
-    }
-
-    fn print_authentication_info(&self, token: &str) {
-        let token_type = if token.starts_with(COVERAGE_TOKEN_WORKSPACE_PREFIX) {
-            "Workspace Token"
-        } else if token.starts_with(COVERAGE_TOKEN_PROJECT_PREFIX) {
-            "Project Token"
-        } else if let Ok(oidc_regex) = Regex::new(OIDC_REGEX) {
-            if oidc_regex.is_match(token) {
-                "OIDC"
-            } else {
-                "Unknown"
-            }
-        } else {
-            "ERROR"
-        };
-        eprintln_unless!(self.quiet, "    Auth Method: {}", token_type);
-        eprintln_unless!(self.quiet, "    Token: {}", token);
-        eprintln_unless!(self.quiet, "");
-    }
-
     fn print_complete_success(&self, elapsed_seconds: f32) {
-        eprintln_unless!(
-            self.quiet,
+        if self.quiet {
+            return;
+        }
+
+        eprintln!(
             "    Coverage marked as complete in {:.2}s!",
             elapsed_seconds
         );
-        eprintln_unless!(self.quiet, "");
-    }
-
-    fn load_auth_token(&self) -> Result<String> {
-        self.expand_token(match &self.token {
-            Some(token) => Ok(token.to_owned()),
-            None => std::env::var("QLTY_COVERAGE_TOKEN").map_err(|_| {
-                anyhow::Error::msg("QLTY_COVERAGE_TOKEN environment variable is required.")
-            }),
-        }?)
+        eprintln!("");
     }
 
     fn request_complete(
-        &self,
         metadata: &qlty_types::tests::v1::CoverageMetadata,
         token: &str,
     ) -> Result<Value> {
         let client = QltyClient::new(Some(LEGACY_API_URL), Some(token.into()));
-        let response_result = client.post("/coverage/complete").send_json(ureq::json!({
-            "data": metadata,
-        }));
-
-        match response_result {
-            Ok(resp) => resp.into_json::<Value>().map_err(|err| {
-                anyhow!(
-                    "JSON Error: {}: Unable to parse JSON response from success: {:?}",
-                    client.base_url,
-                    err
-                )
-            }),
-
-            Err(ureq::Error::Status(code, resp)) => match resp.into_string() {
-                Ok(body) => match serde_json::from_str::<Value>(&body) {
-                    Ok(json) => match json.get("error") {
-                        Some(error) => {
-                            bail!("HTTP Error {}: {}: {}", code, client.base_url, error)
-                        }
-                        None => {
-                            bail!("HTTP Error {}: {}: {}", code, client.base_url, body);
-                        }
-                    },
-                    Err(_) => bail!(
-                        "HTTP Error {}: {}: Unable to parse JSON response: {}",
-                        code,
-                        client.base_url,
-                        body
-                    ),
-                },
-                Err(err) => bail!(
-                    "HTTP Error {}: {}: Error reading response body: {:?}",
-                    code,
-                    client.base_url,
-                    err
-                ),
-            },
-            Err(ureq::Error::Transport(transport_error)) => bail!(
-                "Transport Error: {}: {:?}",
-                client.base_url,
-                transport_error
-            ),
-        }
-    }
-
-    /// Appends repository name to token if it is a workspace token
-    fn expand_token(&self, token: String) -> Result<String> {
-        if token.starts_with(COVERAGE_TOKEN_WORKSPACE_PREFIX) {
-            if token.contains('/') {
-                return Ok(token);
-            }
-            let project = if let Some(project) = &self.project {
-                project.clone()
-            } else if let Some(repository) = self.find_repository_name_from_env() {
-                repository
-            } else {
-                match self.find_repository_name_from_repository() {
-                    Ok(repository) => repository,
-                    Err(err) => {
-                        debug!("Find repository name: {}", err);
-                        bail!(
-                            "Could not infer project name from environment, please provide it using --project"
-                        )
-                    }
-                }
-            };
-            Ok(format!("{token}/{project}"))
-        } else {
-            Ok(token)
-        }
-    }
-
-    fn find_repository_name_from_env(&self) -> Option<String> {
-        let repository = GitHub::default().repository_name();
-        if repository.is_empty() {
-            None
-        } else {
-            Self::extract_repository_name(&repository)
-        }
-    }
-
-    fn find_repository_name_from_repository(&self) -> Result<String> {
-        let root = Workspace::assert_within_git_directory()?;
-        let repo = Repository::open(root)?;
-        let remote = repo.find_remote("origin")?;
-        if let Some(name) = Self::extract_repository_name(remote.url().unwrap_or_default()) {
-            Ok(name)
-        } else {
-            bail!(
-                "Could not find repository name from git remote: {:?}",
-                remote.url()
-            )
-        }
-    }
-
-    fn extract_repository_name(value: &str) -> Option<String> {
-        value
-            .split('/')
-            .next_back()
-            .map(|s| s.strip_suffix(".git").unwrap_or(s).to_string())
-            .take_if(|v| !v.is_empty())
-    }
-
-    fn load_config() -> QltyConfig {
-        Workspace::new()
-            .and_then(|workspace| workspace.config())
-            .unwrap_or_default()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn complete(project: Option<&str>) -> Complete {
-        Complete {
-            project: project.map(|s| s.to_string()),
-            quiet: true,
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn test_expand_token_project() -> Result<()> {
-        let token = complete(None).expand_token("qltcp_123".to_string())?;
-        assert_eq!(token, "qltcp_123");
-        Ok(())
-    }
-
-    #[test]
-    fn test_expand_token_workspace_with_project() -> Result<()> {
-        let token = complete(Some("test")).expand_token("qltcw_123".to_string())?;
-        assert_eq!(token, "qltcw_123/test");
-        Ok(())
-    }
-
-    #[test]
-    fn test_expand_token_workspace_with_env() -> Result<()> {
-        let token = complete(None).expand_token("qltcw_123".to_string())?;
-        assert!(token.starts_with("qltcw_123/"));
-
-        std::env::set_var("GITHUB_REPOSITORY", "");
-        let token = complete(None).expand_token("qltcw_123".to_string())?;
-        assert!(token.starts_with("qltcw_123/"));
-
-        std::env::set_var("GITHUB_REPOSITORY", "a/b.git");
-        let token = complete(None).expand_token("qltcw_123".to_string())?;
-        assert_eq!(token, "qltcw_123/b");
-
-        std::env::set_var("GITHUB_REPOSITORY", "b/c");
-        let token = complete(None).expand_token("qltcw_123".to_string())?;
-        assert_eq!(token, "qltcw_123/c");
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_expand_token_already_expanded() -> Result<()> {
-        let token = complete(Some("test")).expand_token("qltcw_123/abc".to_string())?;
-        assert_eq!(token, "qltcw_123/abc");
-        Ok(())
-    }
-
-    #[test]
-    fn test_extract_repository_name() {
-        assert_eq!(Complete::extract_repository_name(""), None);
-        assert_eq!(Complete::extract_repository_name("a/"), None);
-        assert_eq!(
-            Complete::extract_repository_name("git@example.org:a/b"),
-            Some("b".into())
-        );
-        assert_eq!(
-            Complete::extract_repository_name("ssh://x@example.org:a/b"),
-            Some("b".into())
-        );
-        assert_eq!(
-            Complete::extract_repository_name("https://x:y@example.org/a/b"),
-            Some("b".into())
-        );
+        client.post_coverage_metadata("/coverage/complete", metadata)
     }
 }

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -1,7 +1,6 @@
 use super::utils::{
     load_config, print_authentication_info, print_initial_messages, print_metadata, print_settings,
 };
-use crate::commands::coverage::utils::print_section_header;
 use crate::{CommandError, CommandSuccess};
 use anyhow::{bail, Result};
 use clap::Args;
@@ -123,6 +122,7 @@ impl Publish {
 
         let settings = self.build_settings();
 
+        self.print_section_header(" SETTINGS ");
         print_settings(&settings);
         self.validate_options()?;
 
@@ -131,6 +131,7 @@ impl Publish {
 
         self.validate_plan(&plan)?;
 
+        self.print_section_header(" METADATA ");
         print_metadata(&plan, self.quiet);
         self.print_coverage_files(&plan);
 
@@ -150,11 +151,13 @@ impl Publish {
             return CommandSuccess::ok();
         }
 
+        self.print_section_header(" AUTHENTICATION ");
         print_authentication_info(&token, self.quiet);
 
+        self.print_section_header(" PREPARING TO UPLOAD... ");
         let upload = Upload::prepare(&token, &mut report)?;
 
-        print_section_header(" UPLOADING... ");
+        self.print_section_header(" UPLOADING... ");
         let timer = Instant::now();
         upload.upload(&export)?;
         let bytes = export.total_size_bytes()?;
@@ -297,7 +300,7 @@ impl Publish {
         let written =
             String::from_utf8(tw.into_inner().unwrap_or_default()).unwrap_or("ERROR".to_string());
 
-        eprintln!("{}", written);
+        eprintln!("{written}");
     }
 
     fn print_section_header(&self, title: &str) {
@@ -420,21 +423,9 @@ impl Publish {
             .max()
             .unwrap_or(0);
 
-        eprintln!(
-            "    Covered Lines:      {:>width$}",
-            covered_lines,
-            width = max_length
-        );
-        eprintln!(
-            "    Uncovered Lines:    {:>width$}",
-            uncovered_lines,
-            width = max_length
-        );
-        eprintln!(
-            "    Omitted Lines:      {:>width$}",
-            omitted_lines,
-            width = max_length
-        );
+        eprintln!("    Covered Lines:      {covered_lines:>max_length$}");
+        eprintln!("    Uncovered Lines:    {uncovered_lines:>max_length$}");
+        eprintln!("    Omitted Lines:      {omitted_lines:>max_length$}");
         eprintln!();
         eprintln!(
             "    {}",
@@ -475,7 +466,7 @@ impl Publish {
         );
 
         if !url.is_empty() {
-            eprintln!("    {}", style(format!("View report: {}", url)).bold());
+            eprintln!("    {}", style(format!("View report: {url}")).bold());
         }
 
         eprintln!();

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -1,27 +1,21 @@
+use super::utils::{
+    load_config, print_authentication_info, print_initial_messages, print_metadata, print_settings,
+};
+use crate::commands::coverage::utils::print_section_header;
 use crate::{CommandError, CommandSuccess};
 use anyhow::{bail, Result};
 use clap::Args;
 use console::style;
-use git2::Repository;
 use indicatif::HumanBytes;
 use num_format::{Locale, ToFormattedString as _};
-use qlty_config::version::LONG_VERSION;
-use qlty_config::{QltyConfig, Workspace};
-use qlty_coverage::ci::{GitHub, CI};
-use qlty_coverage::eprintln_unless;
 use qlty_coverage::formats::Formats;
 use qlty_coverage::print::{print_report_as_json, print_report_as_text};
 use qlty_coverage::publish::{Plan, Planner, Processor, Reader, Report, Settings, Upload};
-use regex::Regex;
+use qlty_coverage::token::load_auth_token;
 use std::io::Write as _;
 use std::path::PathBuf;
 use std::time::Instant;
 use tabwriter::TabWriter;
-use tracing::debug;
-
-const COVERAGE_TOKEN_WORKSPACE_PREFIX: &str = "qltcw_";
-const COVERAGE_TOKEN_PROJECT_PREFIX: &str = "qltcp_";
-const OIDC_REGEX: &str = r"^([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)$";
 
 #[derive(Debug, Args, Default)]
 pub struct Publish {
@@ -124,20 +118,20 @@ pub struct Publish {
 impl Publish {
     // TODO: Use CommandSuccess and CommandError, which is not straight forward since those types aren't available here.
     pub fn execute(&self, _args: &crate::Arguments) -> Result<CommandSuccess, CommandError> {
-        self.print_initial_messages();
+        print_initial_messages(self.quiet);
         self.print_deprecation_warnings();
 
         let settings = self.build_settings();
 
-        self.print_settings(&settings);
+        print_settings(&settings);
         self.validate_options()?;
 
-        let token = self.load_auth_token()?;
-        let plan = Planner::new(&Self::load_config(), &settings).compute()?;
+        let token = load_auth_token(&self.token, self.project.as_deref())?;
+        let plan = Planner::new(&load_config(), &settings).compute()?;
 
         self.validate_plan(&plan)?;
 
-        self.print_metadata(&plan);
+        print_metadata(&plan, self.quiet);
         self.print_coverage_files(&plan);
 
         let results = Reader::new(&plan).read()?;
@@ -156,11 +150,11 @@ impl Publish {
             return CommandSuccess::ok();
         }
 
-        self.print_authentication_info(&token);
+        print_authentication_info(&token, self.quiet);
 
         let upload = Upload::prepare(&token, &mut report)?;
 
-        self.print_section_header(" UPLOADING... ");
+        print_section_header(" UPLOADING... ");
         let timer = Instant::now();
         upload.upload(&export)?;
         let bytes = export.total_size_bytes()?;
@@ -189,25 +183,26 @@ impl Publish {
             skip_missing_files: self.skip_missing_files,
             total_parts_count: self.total_parts_count,
             incomplete,
+            quiet: self.quiet,
+            project: self.project.clone(),
+            dry_run: self.dry_run,
+            output_dir: self.output_dir.clone(),
         }
     }
 
     fn print_deprecation_warnings(&self) {
+        if self.quiet {
+            return;
+        }
+
         if self.report_format.is_some() {
-            eprintln_unless!(
-                self.quiet,
-                "WARNING: --report-format is deprecated, use --format instead\n"
-            );
+            eprintln!("WARNING: --report-format is deprecated, use --format instead\n");
         }
         if self.transform_add_prefix.is_some() {
-            eprintln_unless!(
-                self.quiet,
-                "WARNING: --transform-add-prefix is deprecated, use --add-prefix instead\n"
-            );
+            eprintln!("WARNING: --transform-add-prefix is deprecated, use --add-prefix instead\n");
         }
         if self.transform_strip_prefix.is_some() {
-            eprintln_unless!(
-                self.quiet,
+            eprintln!(
                 "WARNING: --transform-strip-prefix is deprecated, use --strip-prefix instead\n"
             );
         }
@@ -235,118 +230,12 @@ impl Publish {
         Ok(())
     }
 
-    fn print_initial_messages(&self) {
-        eprintln_unless!(self.quiet, "qlty {}", LONG_VERSION.as_str());
-        eprintln_unless!(self.quiet, "{}", style("https://qlty.sh/d/coverage").dim());
-        eprintln_unless!(self.quiet, "");
-    }
-
-    fn print_section_header(&self, title: &str) {
-        eprintln_unless!(self.quiet, "{}", style(title).bold().reverse());
-        eprintln_unless!(self.quiet, "");
-    }
-
-    fn print_settings(&self, settings: &Settings) {
-        self.print_section_header(" SETTINGS ");
-
-        eprintln_unless!(
-            self.quiet,
-            "    cwd: {}",
-            std::env::current_dir()
-                .unwrap_or(PathBuf::from("ERROR"))
-                .to_string_lossy()
-        );
-
-        if self.dry_run {
-            eprintln_unless!(self.quiet, "    dry-run: {}", self.dry_run);
-        }
-        if let Some(format) = &settings.report_format {
-            eprintln_unless!(self.quiet, "    format: {}", format);
-        }
-        if let Some(output_dir) = &self.output_dir {
-            eprintln_unless!(
-                self.quiet,
-                "    output-dir: {}",
-                output_dir.to_string_lossy()
-            );
-        }
-        if let Some(tag) = &self.tag {
-            eprintln_unless!(self.quiet, "    tag: {}", tag);
-        }
-        if let Some(override_build_id) = &self.override_build_id {
-            eprintln_unless!(self.quiet, "    override-build-id: {}", override_build_id);
-        }
-        if let Some(override_branch) = &self.override_branch {
-            eprintln_unless!(self.quiet, "    override-branch: {}", override_branch);
-        }
-        if let Some(override_commit_sha) = &self.override_commit_sha {
-            eprintln_unless!(
-                self.quiet,
-                "    override-commit-sha: {}",
-                override_commit_sha
-            );
-        }
-        if let Some(override_pr_number) = &self.override_pr_number {
-            eprintln_unless!(self.quiet, "    override-pr-number: {}", override_pr_number);
-        }
-        if let Some(add_prefix) = &settings.add_prefix {
-            eprintln_unless!(self.quiet, "    add-prefix: {}", add_prefix);
-        }
-        if let Some(strip_prefix) = &settings.strip_prefix {
-            eprintln_unless!(self.quiet, "    strip-prefix: {}", strip_prefix);
-        }
-        if let Some(project) = &self.project {
-            eprintln_unless!(self.quiet, "    project: {}", project);
-        }
-
-        if self.skip_missing_files {
-            eprintln_unless!(
-                self.quiet,
-                "    skip-missing-files: {}",
-                self.skip_missing_files
-            );
-        }
-
-        if let Some(total_parts_count) = self.total_parts_count {
-            eprintln_unless!(self.quiet, "    total-parts-count: {}", total_parts_count);
-        }
-
-        if self.incomplete {
-            eprintln_unless!(self.quiet, "    incomplete: {}", self.incomplete);
-        }
-
-        eprintln_unless!(self.quiet, "");
-    }
-
-    fn print_metadata(&self, plan: &Plan) {
-        self.print_section_header(" METADATA ");
-        if !plan.metadata.ci.is_empty() {
-            eprintln_unless!(self.quiet, "    CI: {}", plan.metadata.ci);
-        }
-
-        eprintln_unless!(self.quiet, "    Commit: {}", plan.metadata.commit_sha);
-        if !plan.metadata.pull_request_number.is_empty() {
-            eprintln_unless!(
-                self.quiet,
-                "    Pull Request: #{}",
-                plan.metadata.pull_request_number
-            );
-        }
-
-        if !plan.metadata.branch.is_empty() {
-            eprintln_unless!(self.quiet, "    Branch: {}", plan.metadata.branch);
-        }
-
-        if !plan.metadata.build_id.is_empty() {
-            eprintln_unless!(self.quiet, "    Build ID: {}", plan.metadata.build_id);
-        }
-
-        eprintln_unless!(self.quiet, "");
-    }
-
     fn print_coverage_files(&self, plan: &Plan) {
-        eprintln_unless!(
-            self.quiet,
+        if self.quiet {
+            return;
+        }
+
+        eprintln!(
             "{}{}{}",
             style(" COVERAGE FILES: ").bold().reverse(),
             style(plan.report_files.len().to_formatted_string(&Locale::en))
@@ -354,7 +243,7 @@ impl Publish {
                 .reverse(),
             style(" ").bold().reverse()
         );
-        eprintln_unless!(self.quiet, "");
+        eprintln!("");
 
         let mut tw = TabWriter::new(vec![]);
 
@@ -408,16 +297,28 @@ impl Publish {
         let written =
             String::from_utf8(tw.into_inner().unwrap_or_default()).unwrap_or("ERROR".to_string());
 
-        eprintln_unless!(self.quiet, "{}", written);
+        eprintln!("{}", written);
+    }
+
+    fn print_section_header(&self, title: &str) {
+        if self.quiet {
+            return;
+        }
+
+        eprintln!("{}", style(title).bold().reverse());
+        eprintln!("");
     }
 
     fn print_coverage_data(&self, report: &Report) {
+        if self.quiet {
+            return;
+        }
+
         self.print_section_header(" COVERAGE DATA ");
 
         let total_files_count = report.found_files.len() + report.missing_files.len();
 
-        eprintln_unless!(
-            self.quiet,
+        eprintln!(
             "    {} unique code file {}",
             total_files_count.to_formatted_string(&Locale::en),
             if total_files_count == 1 {
@@ -433,8 +334,7 @@ impl Publish {
         if !missing_files.is_empty() {
             let missing_percent = (missing_files.len() as f32 / total_files_count as f32) * 100.0;
 
-            eprintln_unless!(
-                self.quiet,
+            eprintln!(
                 "    {}",
                 style(format!(
                     "{} {} missing on disk ({:.1}%)",
@@ -455,20 +355,15 @@ impl Publish {
                 (std::cmp::min(20, missing_files.len()), false)
             };
 
-            eprintln_unless!(
-                self.quiet,
-                "\n    {}\n",
-                style("Missing code files:").bold().yellow()
-            );
+            eprintln!("\n    {}\n", style("Missing code files:").bold().yellow());
 
             for path in missing_files.iter().take(paths_to_show) {
-                eprintln_unless!(self.quiet, "      {}", style(path.to_string()).yellow());
+                eprintln!("      {}", style(path.to_string()).yellow());
             }
 
             if !show_all && paths_to_show < missing_files.len() {
                 let remaining = missing_files.len() - paths_to_show;
-                eprintln_unless!(
-                    self.quiet,
+                eprintln!(
                     "      {} {}",
                     style(format!(
                         "... and {} more",
@@ -480,39 +375,35 @@ impl Publish {
                 );
             }
 
-            eprintln_unless!(self.quiet, "");
+            eprintln!("");
 
             if missing_percent > 10.0 {
-                eprintln_unless!(
-                    self.quiet,
+                eprintln!(
                     "    {} {}",
                     style("TIP:").bold().yellow(),
                     style("Consider using add-prefix or strip-prefix to fix paths").bold()
                 );
             } else {
-                eprintln_unless!(
-                    self.quiet,
+                eprintln!(
                     "    {} Consider excluding these paths with your code coverage tool.",
                     style("TIP:").bold()
                 )
             }
 
-            eprintln_unless!(
-                self.quiet,
+            eprintln!(
                 "    {}",
                 style("https://qlty.sh/d/coverage-path-fixing").dim()
             );
 
-            eprintln_unless!(self.quiet, "");
+            eprintln!("");
         } else {
-            eprintln_unless!(
-                self.quiet,
+            eprintln!(
                 "    {}",
                 style("All code files in the coverage data were found on disk.").dim()
             );
         }
 
-        eprintln_unless!(self.quiet, "");
+        eprintln!("");
 
         // Get formatted numbers first
         let covered_lines = report.totals.covered_lines.to_formatted_string(&Locale::en);
@@ -529,27 +420,23 @@ impl Publish {
             .max()
             .unwrap_or(0);
 
-        eprintln_unless!(
-            self.quiet,
+        eprintln!(
             "    Covered Lines:      {:>width$}",
             covered_lines,
             width = max_length
         );
-        eprintln_unless!(
-            self.quiet,
+        eprintln!(
             "    Uncovered Lines:    {:>width$}",
             uncovered_lines,
             width = max_length
         );
-        eprintln_unless!(
-            self.quiet,
+        eprintln!(
             "    Omitted Lines:      {:>width$}",
             omitted_lines,
             width = max_length
         );
-        eprintln_unless!(self.quiet, "");
-        eprintln_unless!(
-            self.quiet,
+        eprintln!("");
+        eprintln!(
             "    {}",
             style(format!(
                 "Line Coverage:       {:.2}%",
@@ -557,68 +444,41 @@ impl Publish {
             ))
             .bold()
         );
-        eprintln_unless!(self.quiet, "");
+        eprintln!("");
     }
 
     fn print_export_status(&self, export_path: &Option<PathBuf>) {
+        if self.quiet {
+            return;
+        }
+
         self.print_section_header(" EXPORTING... ");
-        eprintln_unless!(
-            self.quiet,
+        eprintln!(
             "    Exported: {}/coverage.zip",
             export_path
                 .as_ref()
                 .unwrap_or(&PathBuf::from("ERROR"))
                 .to_string_lossy()
         );
-        eprintln_unless!(self.quiet, "");
-    }
-
-    fn print_authentication_info(&self, token: &str) {
-        self.print_section_header(" PREPARING TO UPLOAD... ");
-        let token_type = if token.starts_with(COVERAGE_TOKEN_WORKSPACE_PREFIX) {
-            "Workspace Token"
-        } else if token.starts_with(COVERAGE_TOKEN_PROJECT_PREFIX) {
-            "Project Token"
-        } else if let Ok(oidc_regex) = Regex::new(OIDC_REGEX) {
-            if oidc_regex.is_match(token) {
-                "OIDC"
-            } else {
-                "Unknown"
-            }
-        } else {
-            "ERROR"
-        };
-        eprintln_unless!(self.quiet, "    Auth Method: {}", token_type);
-        eprintln_unless!(self.quiet, "    Token: {}", token);
-        eprintln_unless!(self.quiet, "");
+        eprintln!("");
     }
 
     fn print_upload_complete(&self, bytes: u64, elapsed_seconds: f32, url: &str) {
-        eprintln_unless!(
-            self.quiet,
+        if self.quiet {
+            return;
+        }
+
+        eprintln!(
             "    Uploaded {} in {:.2}s!",
             HumanBytes(bytes),
             elapsed_seconds
         );
 
         if !url.is_empty() {
-            eprintln_unless!(
-                self.quiet,
-                "    {}",
-                style(format!("View report: {}", url)).bold()
-            );
+            eprintln!("    {}", style(format!("View report: {}", url)).bold());
         }
 
-        eprintln_unless!(self.quiet, "");
-    }
-
-    fn load_auth_token(&self) -> Result<String> {
-        self.expand_token(match &self.token {
-            Some(token) => Ok(token.to_owned()),
-            None => std::env::var("QLTY_COVERAGE_TOKEN").map_err(|_| {
-                anyhow::Error::msg("QLTY_COVERAGE_TOKEN environment variable is required.")
-            }),
-        }?)
+        eprintln!("");
     }
 
     fn validate_options(&self) -> Result<(), CommandError> {
@@ -638,207 +498,11 @@ impl Publish {
         Ok(())
     }
 
-    /// Appends repository name to token if it is a workspace token
-    fn expand_token(&self, token: String) -> Result<String> {
-        if token.starts_with(COVERAGE_TOKEN_WORKSPACE_PREFIX) {
-            if token.contains("/") {
-                return Ok(token);
-            }
-            let project = if let Some(project) = &self.project {
-                project.clone()
-            } else if let Some(repository) = self.find_repository_name_from_env() {
-                repository
-            } else {
-                match self.find_repository_name_from_repository() {
-                    Ok(repository) => repository,
-                    Err(err) => {
-                        debug!("Find repository name: {}", err);
-                        bail!(
-                            "Could not infer project name from environment, please provide it using --project"
-                        )
-                    }
-                }
-            };
-            Ok(format!("{}/{}", token, project))
-        } else {
-            Ok(token)
-        }
-    }
-
-    fn find_repository_name_from_env(&self) -> Option<String> {
-        let repository = GitHub::default().repository_name();
-        if repository.is_empty() {
-            None
-        } else {
-            Self::extract_repository_name(&repository)
-        }
-    }
-
-    fn find_repository_name_from_repository(&self) -> Result<String> {
-        let root = Workspace::assert_within_git_directory()?;
-        let repo = Repository::open(root)?;
-        let remote = repo.find_remote("origin")?;
-        if let Some(name) = Self::extract_repository_name(remote.url().unwrap_or_default()) {
-            Ok(name)
-        } else {
-            bail!(
-                "Could not find repository name from git remote: {:?}",
-                remote.url()
-            )
-        }
-    }
-
-    fn extract_repository_name(value: &str) -> Option<String> {
-        value
-            .split('/')
-            .last()
-            .map(|s| s.strip_suffix(".git").unwrap_or(s).to_string())
-            .take_if(|v| !v.is_empty())
-    }
-
     fn show_report(&self, report: &Report) -> Result<()> {
         if self.json {
             print_report_as_json(report)
         } else {
             print_report_as_text(report)
         }
-    }
-
-    fn load_config() -> QltyConfig {
-        Workspace::new()
-            .and_then(|workspace| workspace.config())
-            .unwrap_or_default()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn publish(project: Option<&str>) -> Publish {
-        Publish {
-            dry_run: true,
-            project: project.map(|s| s.to_string()),
-            quiet: true,
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn test_expand_token_project() -> Result<()> {
-        let token = publish(None).expand_token("qltcp_123".to_string())?;
-        assert_eq!(token, "qltcp_123");
-        Ok(())
-    }
-
-    #[test]
-    fn test_expand_token_workspace_with_project() -> Result<()> {
-        let token = publish(Some("test")).expand_token("qltcw_123".to_string())?;
-        assert_eq!(token, "qltcw_123/test");
-        Ok(())
-    }
-
-    #[test]
-    fn test_expand_token_workspace_with_env() -> Result<()> {
-        let token = publish(None).expand_token("qltcw_123".to_string())?;
-        assert!(token.starts_with("qltcw_123/"));
-
-        std::env::set_var("GITHUB_REPOSITORY", "");
-        let token = publish(None).expand_token("qltcw_123".to_string())?;
-        assert!(token.starts_with("qltcw_123/"));
-
-        std::env::set_var("GITHUB_REPOSITORY", "a/b.git");
-        let token = publish(None).expand_token("qltcw_123".to_string())?;
-        assert_eq!(token, "qltcw_123/b");
-
-        std::env::set_var("GITHUB_REPOSITORY", "b/c");
-        let token = publish(None).expand_token("qltcw_123".to_string())?;
-        assert_eq!(token, "qltcw_123/c");
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_expand_token_already_expanded() -> Result<()> {
-        let token = publish(Some("test")).expand_token("qltcw_123/abc".to_string())?;
-        assert_eq!(token, "qltcw_123/abc");
-        Ok(())
-    }
-
-    #[test]
-    fn test_extract_repository_name() {
-        assert_eq!(Publish::extract_repository_name(""), None);
-        assert_eq!(Publish::extract_repository_name("a/"), None);
-        assert_eq!(
-            Publish::extract_repository_name("git@example.org:a/b"),
-            Some("b".into())
-        );
-        assert_eq!(
-            Publish::extract_repository_name("ssh://x@example.org:a/b"),
-            Some("b".into())
-        );
-        assert_eq!(
-            Publish::extract_repository_name("https://x:y@example.org/a/b"),
-            Some("b".into())
-        );
-    }
-
-    #[test]
-    fn test_build_settings_sets_incomplete_when_total_parts_count_provided() {
-        let mut publish = Publish::default();
-        publish.incomplete = false;
-        publish.total_parts_count = Some(2);
-
-        let settings = publish.build_settings();
-
-        assert!(settings.incomplete);
-    }
-
-    #[test]
-    fn test_build_settings_does_not_set_incomplete_when_total_parts_count_is_one() {
-        let mut publish = Publish::default();
-        publish.incomplete = false;
-        publish.total_parts_count = Some(1);
-
-        let settings = publish.build_settings();
-
-        assert!(!settings.incomplete);
-    }
-
-    #[test]
-    fn test_validate_options_rejects_incomplete_with_total_parts_count_1() {
-        let mut publish = Publish::default();
-        publish.incomplete = true;
-        publish.total_parts_count = Some(1);
-
-        let result = publish.validate_options();
-        assert!(result.is_err());
-
-        if let Err(CommandError::InvalidOptions { message }) = result {
-            assert!(message.contains("ambiguous"));
-        } else {
-            panic!("Expected CommandError::InvalidOptions");
-        }
-    }
-
-    #[test]
-    fn test_validate_options_accepts_valid_combinations() {
-        // Just incomplete flag is valid
-        let mut publish = Publish::default();
-        publish.incomplete = true;
-        publish.total_parts_count = None;
-        assert!(publish.validate_options().is_ok());
-
-        // Total parts > 1 with incomplete is valid
-        let mut publish = Publish::default();
-        publish.incomplete = true;
-        publish.total_parts_count = Some(2);
-        assert!(publish.validate_options().is_ok());
-
-        // Total parts = 1 without incomplete is valid
-        let mut publish = Publish::default();
-        publish.incomplete = false;
-        publish.total_parts_count = Some(1);
-        assert!(publish.validate_options().is_ok());
     }
 }

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -243,7 +243,7 @@ impl Publish {
                 .reverse(),
             style(" ").bold().reverse()
         );
-        eprintln!("");
+        eprintln!();
 
         let mut tw = TabWriter::new(vec![]);
 
@@ -306,7 +306,7 @@ impl Publish {
         }
 
         eprintln!("{}", style(title).bold().reverse());
-        eprintln!("");
+        eprintln!();
     }
 
     fn print_coverage_data(&self, report: &Report) {
@@ -375,7 +375,7 @@ impl Publish {
                 );
             }
 
-            eprintln!("");
+            eprintln!();
 
             if missing_percent > 10.0 {
                 eprintln!(
@@ -395,7 +395,7 @@ impl Publish {
                 style("https://qlty.sh/d/coverage-path-fixing").dim()
             );
 
-            eprintln!("");
+            eprintln!();
         } else {
             eprintln!(
                 "    {}",
@@ -403,7 +403,7 @@ impl Publish {
             );
         }
 
-        eprintln!("");
+        eprintln!();
 
         // Get formatted numbers first
         let covered_lines = report.totals.covered_lines.to_formatted_string(&Locale::en);
@@ -435,7 +435,7 @@ impl Publish {
             omitted_lines,
             width = max_length
         );
-        eprintln!("");
+        eprintln!();
         eprintln!(
             "    {}",
             style(format!(
@@ -444,7 +444,7 @@ impl Publish {
             ))
             .bold()
         );
-        eprintln!("");
+        eprintln!();
     }
 
     fn print_export_status(&self, export_path: &Option<PathBuf>) {
@@ -460,7 +460,7 @@ impl Publish {
                 .unwrap_or(&PathBuf::from("ERROR"))
                 .to_string_lossy()
         );
-        eprintln!("");
+        eprintln!();
     }
 
     fn print_upload_complete(&self, bytes: u64, elapsed_seconds: f32, url: &str) {
@@ -478,7 +478,7 @@ impl Publish {
             eprintln!("    {}", style(format!("View report: {}", url)).bold());
         }
 
-        eprintln!("");
+        eprintln!();
     }
 
     fn validate_options(&self) -> Result<(), CommandError> {

--- a/qlty-cli/src/commands/coverage/transform.rs
+++ b/qlty-cli/src/commands/coverage/transform.rs
@@ -1,8 +1,6 @@
 use crate::{CommandError, CommandSuccess};
 use anyhow::Result;
 use clap::Args;
-use console::style;
-use qlty_config::version::LONG_VERSION;
 use qlty_coverage::{
     eprintln_unless,
     formats::Formats,
@@ -12,6 +10,8 @@ use qlty_coverage::{
 use qlty_formats::{Formatter, JsonEachRowFormatter};
 use qlty_types::tests::v1::FileCoverage;
 use std::path::PathBuf;
+
+use super::utils::print_initial_messages;
 
 #[derive(Debug, Args)]
 pub struct Transform {
@@ -54,7 +54,7 @@ pub struct Transform {
 
 impl Transform {
     pub fn execute(&self, _args: &crate::Arguments) -> Result<CommandSuccess, CommandError> {
-        self.print_initial_messages();
+        print_initial_messages(self.quiet);
 
         if !self.quiet {
             eprintln!("Transforming coverage report {}", self.path);
@@ -87,12 +87,6 @@ impl Transform {
         }
 
         CommandSuccess::ok()
-    }
-
-    fn print_initial_messages(&self) {
-        eprintln_unless!(self.quiet, "qlty {}", LONG_VERSION.as_str());
-        eprintln_unless!(self.quiet, "{}", style("https://qlty.sh/d/coverage").dim());
-        eprintln_unless!(self.quiet, "");
     }
 
     fn output(&self) -> String {

--- a/qlty-cli/src/commands/coverage/utils.rs
+++ b/qlty-cli/src/commands/coverage/utils.rs
@@ -16,14 +16,14 @@ pub fn load_config() -> QltyConfig {
 
 pub fn print_section_header(title: &str) {
     eprintln!("{}", style(title).bold().reverse());
-    eprintln!("");
+    eprintln!();
 }
 
 pub fn print_initial_messages(quiet: bool) {
     if !quiet {
         eprintln!("qlty {}", LONG_VERSION.as_str());
         eprintln!("{}", style("https://qlty.sh/d/coverage").dim());
-        eprintln!("");
+        eprintln!();
     }
 }
 
@@ -87,7 +87,7 @@ pub fn print_settings(settings: &Settings) {
         eprintln!("    incomplete: {}", settings.incomplete);
     }
 
-    eprintln!("");
+    eprintln!();
 }
 
 pub fn print_metadata(plan: &Plan, quiet: bool) {
@@ -113,7 +113,7 @@ pub fn print_metadata(plan: &Plan, quiet: bool) {
         eprintln!("    Build ID: {}", plan.metadata.build_id);
     }
 
-    eprintln!("");
+    eprintln!();
 }
 
 pub fn print_authentication_info(token: &str, quiet: bool) {
@@ -137,5 +137,5 @@ pub fn print_authentication_info(token: &str, quiet: bool) {
     };
     eprintln!("    Auth Method: {}", token_type);
     eprintln!("    Token: {}", token);
-    eprintln!("");
+    eprintln!();
 }

--- a/qlty-cli/src/commands/coverage/utils.rs
+++ b/qlty-cli/src/commands/coverage/utils.rs
@@ -1,0 +1,141 @@
+use console::style;
+use qlty_config::{version::LONG_VERSION, QltyConfig, Workspace};
+use qlty_coverage::publish::{Plan, Settings};
+use regex::Regex;
+use std::path::PathBuf;
+
+const COVERAGE_TOKEN_WORKSPACE_PREFIX: &str = "qltcw_";
+const COVERAGE_TOKEN_PROJECT_PREFIX: &str = "qltcp_";
+const OIDC_REGEX: &str = r"^([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)$";
+
+pub fn load_config() -> QltyConfig {
+    Workspace::new()
+        .and_then(|workspace| workspace.config())
+        .unwrap_or_default()
+}
+
+pub fn print_section_header(title: &str) {
+    eprintln!("{}", style(title).bold().reverse());
+    eprintln!("");
+}
+
+pub fn print_initial_messages(quiet: bool) {
+    if !quiet {
+        eprintln!("qlty {}", LONG_VERSION.as_str());
+        eprintln!("{}", style("https://qlty.sh/d/coverage").dim());
+        eprintln!("");
+    }
+}
+
+pub fn print_settings(settings: &Settings) {
+    if settings.quiet {
+        return;
+    }
+
+    print_section_header(" SETTINGS ");
+
+    eprintln!(
+        "    cwd: {}",
+        std::env::current_dir()
+            .unwrap_or(PathBuf::from("ERROR"))
+            .to_string_lossy()
+    );
+
+    if settings.dry_run {
+        eprintln!("    dry-run: {}", settings.dry_run);
+    }
+    if let Some(format) = &settings.report_format {
+        eprintln!("    format: {}", format);
+    }
+    if let Some(output_dir) = &settings.output_dir {
+        eprintln!("    output-dir: {}", output_dir.to_string_lossy());
+    }
+    if let Some(tag) = &settings.tag {
+        eprintln!("    tag: {}", tag);
+    }
+    if let Some(override_build_id) = &settings.override_build_id {
+        eprintln!("    override-build-id: {}", override_build_id);
+    }
+    if let Some(override_branch) = &settings.override_branch {
+        eprintln!("    override-branch: {}", override_branch);
+    }
+    if let Some(override_commit_sha) = &settings.override_commit_sha {
+        eprintln!("    override-commit-sha: {}", override_commit_sha);
+    }
+    if let Some(override_pr_number) = &settings.override_pull_request_number {
+        eprintln!("    override-pr-number: {}", override_pr_number);
+    }
+    if let Some(add_prefix) = &settings.add_prefix {
+        eprintln!("    add-prefix: {}", add_prefix);
+    }
+    if let Some(strip_prefix) = &settings.strip_prefix {
+        eprintln!("    strip-prefix: {}", strip_prefix);
+    }
+    if let Some(project) = &settings.project {
+        eprintln!("    project: {}", project);
+    }
+
+    if settings.skip_missing_files {
+        eprintln!("    skip-missing-files: {}", settings.skip_missing_files);
+    }
+
+    if let Some(total_parts_count) = settings.total_parts_count {
+        eprintln!("    total-parts-count: {}", total_parts_count);
+    }
+
+    if settings.incomplete {
+        eprintln!("    incomplete: {}", settings.incomplete);
+    }
+
+    eprintln!("");
+}
+
+pub fn print_metadata(plan: &Plan, quiet: bool) {
+    if quiet {
+        return;
+    }
+
+    print_section_header(" METADATA ");
+    if !plan.metadata.ci.is_empty() {
+        eprintln!("    CI: {}", plan.metadata.ci);
+    }
+
+    eprintln!("    Commit: {}", plan.metadata.commit_sha);
+    if !plan.metadata.pull_request_number.is_empty() {
+        eprintln!("    Pull Request: #{}", plan.metadata.pull_request_number);
+    }
+
+    if !plan.metadata.branch.is_empty() {
+        eprintln!("    Branch: {}", plan.metadata.branch);
+    }
+
+    if !plan.metadata.build_id.is_empty() {
+        eprintln!("    Build ID: {}", plan.metadata.build_id);
+    }
+
+    eprintln!("");
+}
+
+pub fn print_authentication_info(token: &str, quiet: bool) {
+    if quiet {
+        return;
+    }
+
+    print_section_header(" PREPARING TO UPLOAD... ");
+    let token_type = if token.starts_with(COVERAGE_TOKEN_WORKSPACE_PREFIX) {
+        "Workspace Token"
+    } else if token.starts_with(COVERAGE_TOKEN_PROJECT_PREFIX) {
+        "Project Token"
+    } else if let Ok(oidc_regex) = Regex::new(OIDC_REGEX) {
+        if oidc_regex.is_match(token) {
+            "OIDC"
+        } else {
+            "Unknown"
+        }
+    } else {
+        "ERROR"
+    };
+    eprintln!("    Auth Method: {}", token_type);
+    eprintln!("    Token: {}", token);
+    eprintln!("");
+}

--- a/qlty-cli/src/commands/coverage/utils.rs
+++ b/qlty-cli/src/commands/coverage/utils.rs
@@ -14,11 +14,6 @@ pub fn load_config() -> QltyConfig {
         .unwrap_or_default()
 }
 
-pub fn print_section_header(title: &str) {
-    eprintln!("{}", style(title).bold().reverse());
-    eprintln!();
-}
-
 pub fn print_initial_messages(quiet: bool) {
     if !quiet {
         eprintln!("qlty {}", LONG_VERSION.as_str());
@@ -32,8 +27,6 @@ pub fn print_settings(settings: &Settings) {
         return;
     }
 
-    print_section_header(" SETTINGS ");
-
     eprintln!(
         "    cwd: {}",
         std::env::current_dir()
@@ -45,34 +38,34 @@ pub fn print_settings(settings: &Settings) {
         eprintln!("    dry-run: {}", settings.dry_run);
     }
     if let Some(format) = &settings.report_format {
-        eprintln!("    format: {}", format);
+        eprintln!("    format: {format}");
     }
     if let Some(output_dir) = &settings.output_dir {
         eprintln!("    output-dir: {}", output_dir.to_string_lossy());
     }
     if let Some(tag) = &settings.tag {
-        eprintln!("    tag: {}", tag);
+        eprintln!("    tag: {tag}");
     }
     if let Some(override_build_id) = &settings.override_build_id {
-        eprintln!("    override-build-id: {}", override_build_id);
+        eprintln!("    override-build-id: {override_build_id}");
     }
     if let Some(override_branch) = &settings.override_branch {
-        eprintln!("    override-branch: {}", override_branch);
+        eprintln!("    override-branch: {override_branch}");
     }
     if let Some(override_commit_sha) = &settings.override_commit_sha {
-        eprintln!("    override-commit-sha: {}", override_commit_sha);
+        eprintln!("    override-commit-sha: {override_commit_sha}");
     }
     if let Some(override_pr_number) = &settings.override_pull_request_number {
-        eprintln!("    override-pr-number: {}", override_pr_number);
+        eprintln!("    override-pr-number: {override_pr_number}");
     }
     if let Some(add_prefix) = &settings.add_prefix {
-        eprintln!("    add-prefix: {}", add_prefix);
+        eprintln!("    add-prefix: {add_prefix}");
     }
     if let Some(strip_prefix) = &settings.strip_prefix {
-        eprintln!("    strip-prefix: {}", strip_prefix);
+        eprintln!("    strip-prefix: {strip_prefix}");
     }
     if let Some(project) = &settings.project {
-        eprintln!("    project: {}", project);
+        eprintln!("    project: {project}");
     }
 
     if settings.skip_missing_files {
@@ -80,7 +73,7 @@ pub fn print_settings(settings: &Settings) {
     }
 
     if let Some(total_parts_count) = settings.total_parts_count {
-        eprintln!("    total-parts-count: {}", total_parts_count);
+        eprintln!("    total-parts-count: {total_parts_count}");
     }
 
     if settings.incomplete {
@@ -95,7 +88,6 @@ pub fn print_metadata(plan: &Plan, quiet: bool) {
         return;
     }
 
-    print_section_header(" METADATA ");
     if !plan.metadata.ci.is_empty() {
         eprintln!("    CI: {}", plan.metadata.ci);
     }
@@ -121,7 +113,6 @@ pub fn print_authentication_info(token: &str, quiet: bool) {
         return;
     }
 
-    print_section_header(" PREPARING TO UPLOAD... ");
     let token_type = if token.starts_with(COVERAGE_TOKEN_WORKSPACE_PREFIX) {
         "Workspace Token"
     } else if token.starts_with(COVERAGE_TOKEN_PROJECT_PREFIX) {
@@ -135,7 +126,7 @@ pub fn print_authentication_info(token: &str, quiet: bool) {
     } else {
         "ERROR"
     };
-    eprintln!("    Auth Method: {}", token_type);
-    eprintln!("    Token: {}", token);
+    eprintln!("    Auth Method: {token_type}");
+    eprintln!("    Token: {token}");
     eprintln!();
 }

--- a/qlty-cloud/Cargo.toml
+++ b/qlty-cloud/Cargo.toml
@@ -16,6 +16,8 @@ doctest = false
 [dependencies]
 qlty-config.workspace = true
 ureq.workspace = true
+qlty-types.workspace = true
+anyhow.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/qlty-cloud/src/lib.rs
+++ b/qlty-cloud/src/lib.rs
@@ -1,5 +1,8 @@
+use anyhow::{anyhow, bail, Result};
 use qlty_config::version::QLTY_VERSION;
-use ureq::Request;
+use qlty_types::tests::v1::CoverageMetadata;
+use serde_json::Value;
+use ureq::{json, serde_json, Error, Request};
 
 const QLTY_API_URL: &str = "https://api.qlty.sh";
 const USER_AGENT_PREFIX: &str = "qlty";
@@ -31,12 +34,12 @@ impl Client {
         }
     }
 
-    pub fn post(&self, path: &str) -> ureq::Request {
+    pub fn post(&self, path: &str) -> Request {
         let url = self.build_url(path);
         self.build_request(ureq::post(&url))
     }
 
-    pub fn get(&self, path: &str) -> ureq::Request {
+    pub fn get(&self, path: &str) -> Request {
         let url = self.build_url(path);
         self.build_request(ureq::get(&url))
     }
@@ -62,5 +65,49 @@ impl Client {
 
     fn authorization_header(&self) -> Option<String> {
         self.token.as_ref().map(|token| format!("Bearer {}", token))
+    }
+
+    pub fn post_coverage_metadata(&self, url: &str, metadata: &CoverageMetadata) -> Result<Value> {
+        let response_result = self.post(url).send_json(json!({
+            "data": metadata,
+        }));
+
+        match response_result {
+            Ok(resp) => resp.into_json::<Value>().map_err(|err| {
+                anyhow!(
+                    "JSON Error: {}: Unable to parse JSON response from success: {:?}",
+                    self.base_url,
+                    err
+                )
+            }),
+
+            Err(Error::Status(code, resp)) => match resp.into_string() {
+                Ok(body) => match serde_json::from_str::<Value>(&body) {
+                    Ok(json) => match json.get("error") {
+                        Some(error) => {
+                            bail!("HTTP Error {}: {}: {}", code, self.base_url, error)
+                        }
+                        None => {
+                            bail!("HTTP Error {}: {}: {}", code, self.base_url, body);
+                        }
+                    },
+                    Err(_) => bail!(
+                        "HTTP Error {}: {}: Unable to parse JSON response: {}",
+                        code,
+                        self.base_url,
+                        body
+                    ),
+                },
+                Err(err) => bail!(
+                    "HTTP Error {}: {}: Error reading response body: {:?}",
+                    code,
+                    self.base_url,
+                    err
+                ),
+            },
+            Err(Error::Transport(transport_error)) => {
+                bail!("Transport Error: {}: {:?}", self.base_url, transport_error)
+            }
+        }
     }
 }

--- a/qlty-coverage/Cargo.toml
+++ b/qlty-coverage/Cargo.toml
@@ -31,6 +31,7 @@ serde_json.workspace = true
 serde-xml-rs.workspace = true
 serde.workspace = true
 time.workspace = true
+tracing.workspace = true
 ureq.workspace = true
 xml-rs.workspace = true
 zip.workspace = true

--- a/qlty-coverage/src/lib.rs
+++ b/qlty-coverage/src/lib.rs
@@ -6,6 +6,7 @@ pub mod git;
 pub mod parser;
 pub mod print;
 pub mod publish;
+pub mod token;
 pub mod transform;
 mod transformer;
 mod utils;

--- a/qlty-coverage/src/publish/settings.rs
+++ b/qlty-coverage/src/publish/settings.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::formats::Formats;
 use serde::{Deserialize, Serialize};
 
@@ -20,4 +22,9 @@ pub struct Settings {
     pub skip_missing_files: bool,
     pub total_parts_count: Option<u32>,
     pub incomplete: bool,
+
+    pub project: Option<String>,
+    pub output_dir: Option<PathBuf>,
+    pub dry_run: bool,
+    pub quiet: bool,
 }

--- a/qlty-coverage/src/token.rs
+++ b/qlty-coverage/src/token.rs
@@ -1,0 +1,139 @@
+use crate::ci::{GitHub, CI};
+use anyhow::{bail, Result};
+use git2::Repository;
+use qlty_config::Workspace;
+use tracing::debug;
+
+const COVERAGE_TOKEN_WORKSPACE_PREFIX: &str = "qltcw_";
+
+pub fn load_auth_token(token: &Option<String>, project: Option<&str>) -> Result<String> {
+    expand_token(
+        match token {
+            Some(token) => Ok(token.to_owned()),
+            None => std::env::var("QLTY_COVERAGE_TOKEN").map_err(|_| {
+                anyhow::Error::msg("QLTY_COVERAGE_TOKEN environment variable is required.")
+            }),
+        }?,
+        project,
+    )
+}
+
+fn expand_token(token: String, project: Option<&str>) -> Result<String> {
+    if token.starts_with(COVERAGE_TOKEN_WORKSPACE_PREFIX) {
+        if token.contains('/') {
+            return Ok(token);
+        }
+        let project = if let Some(project) = project {
+            project.to_string()
+        } else if let Some(repository) = find_repository_name_from_env() {
+            repository
+        } else {
+            match find_repository_name_from_repository() {
+                Ok(repository) => repository,
+                Err(err) => {
+                    debug!("Find repository name: {}", err);
+                    bail!(
+                        "Could not infer project name from environment, please provide it using --project"
+                    )
+                }
+            }
+        };
+        Ok(format!("{token}/{project}"))
+    } else {
+        Ok(token)
+    }
+}
+
+fn find_repository_name_from_env() -> Option<String> {
+    let repository = GitHub::default().repository_name();
+    if repository.is_empty() {
+        None
+    } else {
+        extract_repository_name(&repository)
+    }
+}
+
+fn find_repository_name_from_repository() -> Result<String> {
+    let root = Workspace::assert_within_git_directory()?;
+    let repo = Repository::open(root)?;
+    let remote = repo.find_remote("origin")?;
+    if let Some(name) = extract_repository_name(remote.url().unwrap_or_default()) {
+        Ok(name)
+    } else {
+        bail!(
+            "Could not find repository name from git remote: {:?}",
+            remote.url()
+        )
+    }
+}
+fn extract_repository_name(value: &str) -> Option<String> {
+    value
+        .split('/')
+        .last()
+        .map(|s| s.strip_suffix(".git").unwrap_or(s).to_string())
+        .filter(|v| !v.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_repository_name() {
+        assert_eq!(extract_repository_name(""), None);
+        assert_eq!(extract_repository_name("a/"), None);
+        assert_eq!(
+            extract_repository_name("git@example.org:a/b"),
+            Some("b".into())
+        );
+        assert_eq!(
+            extract_repository_name("ssh://x@example.org:a/b"),
+            Some("b".into())
+        );
+        assert_eq!(
+            extract_repository_name("https://x:y@example.org/a/b"),
+            Some("b".into())
+        );
+    }
+
+    #[test]
+    fn test_expand_token_project() -> Result<()> {
+        let token = expand_token("qltcp_123".to_string(), None)?;
+        assert_eq!(token, "qltcp_123");
+        Ok(())
+    }
+
+    #[test]
+    fn test_expand_token_workspace_with_project() -> Result<()> {
+        let token = expand_token("qltcw_123".to_string(), Some("test"))?;
+        assert_eq!(token, "qltcw_123/test");
+        Ok(())
+    }
+
+    #[test]
+    fn test_expand_token_workspace_with_env() -> Result<()> {
+        let token = expand_token("qltcw_123".to_string(), None)?;
+        assert!(token.starts_with("qltcw_123/"));
+
+        std::env::set_var("GITHUB_REPOSITORY", "");
+        let token = expand_token("qltcw_123".to_string(), None)?;
+        assert!(token.starts_with("qltcw_123/"));
+
+        std::env::set_var("GITHUB_REPOSITORY", "a/b.git");
+        let token = expand_token("qltcw_123".to_string(), None)?;
+        assert_eq!(token, "qltcw_123/b");
+
+        std::env::set_var("GITHUB_REPOSITORY", "b/c");
+        let token = expand_token("qltcw_123".to_string(), None)?;
+        assert_eq!(token, "qltcw_123/c");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expand_token_already_expanded() -> Result<()> {
+        let token = expand_token("qltcw_123/abc".to_string(), Some("test"))?;
+        assert_eq!(token, "qltcw_123/abc");
+        Ok(())
+    }
+}

--- a/qlty-coverage/src/token.rs
+++ b/qlty-coverage/src/token.rs
@@ -69,7 +69,7 @@ fn find_repository_name_from_repository() -> Result<String> {
 fn extract_repository_name(value: &str) -> Option<String> {
     value
         .split('/')
-        .last()
+        .next_back()
         .map(|s| s.strip_suffix(".git").unwrap_or(s).to_string())
         .filter(|v| !v.is_empty())
 }


### PR DESCRIPTION
Intended to help support a new server-side aggregation model where client sends partial reports (with --incomplete) and then sends, at the end of the build, a `qlty coverage complete` to inform qlty.sh that the build has finished sending parts.

Some notes:

It takes a subset of the arguments that `qlty coverage publish` takes. Here's the current arguments:

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/a681264e-daac-4397-94cb-9e3c2b757cb0" />

Some arguments `qlty coverage publish` takes that `qlty coverage complete` does not:

--dry-run (only relevant when uploading coverage)
--format <FORMAT> (only relevant when uploading coverage)
--override-build-id <OVERRIDE_BUILD_ID> (this one I'm on the fence about ... `qlty coverage publish` actually _requires_ this argument, but I don't think it's necessary for this server side aggregation algorithm
--add-prefix (only relevant when uploading coverage)
--strip-prefix (only relevant when uploading coverage)
--print (prints coverage, and there's no coverage to print)
--total-parts-count (not relevant)
--incomplete (not relevant)

I had Claude help with this code, and there's a fair amount of duplication.