### PR TITLE
Fix coverage format specification for absolute paths on Windows

### DIFF
--- a/qlty-coverage/src/formats.rs
+++ b/qlty-coverage/src/formats.rs
@@ -7,7 +7,7 @@ use std::convert::TryFrom;
 use std::path::Path;
 use std::str::FromStr;
 
-#[derive(clap::ValueEnum, Debug, Serialize, Deserialize, Clone, Copy)]
+#[derive(clap::ValueEnum, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub enum Formats {
     Simplecov,
     Clover,

--- a/qlty-coverage/src/utils.rs
+++ b/qlty-coverage/src/utils.rs
@@ -7,22 +7,77 @@ use std::str::FromStr;
 // 1. The format specified in the path, e.g.: simplecov:./coverage/coverage.json
 // 2. The format specified in the command line arguments, through --report-format simplecov
 // 3. The format is inferred from the file extension or contents
-// TODO: Write unit tests
 pub fn extract_path_and_format(
     path: &str,
     base_format: Option<Formats>,
 ) -> Result<(PathBuf, Formats)> {
-    if path.contains(':') {
-        match path.split_once(':') {
-            Some((format, p)) => Ok((PathBuf::from(p), Formats::from_str(format)?)),
-            None => Err(anyhow::anyhow!(
-                "Expected ':' in the path to split format and path."
-            )),
+    if let Some((potential_format, rest)) = path.split_once(':') {
+        match Formats::from_str(potential_format) {
+            Ok(fmt) => Ok((PathBuf::from(rest), fmt)),
+            Err(_) => match base_format {
+                Some(fmt) => Ok((PathBuf::from(path), fmt)),
+                None => Ok((PathBuf::from(path), Formats::try_from(path.as_ref())?)),
+            },
         }
-    } else if base_format.is_some() {
-        return Ok((PathBuf::from(path), base_format.unwrap()));
+    } else if let Some(fmt) = base_format {
+        Ok((PathBuf::from(path), fmt))
     } else {
-        let format = Formats::try_from(path.as_ref())?;
-        return Ok((PathBuf::from(path), format));
+        Ok((PathBuf::from(path), Formats::try_from(path.as_ref())?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formats::Formats;
+
+    #[test]
+    fn test_format_in_path_explicit() {
+        let path = "simplecov:./coverage/coverage.json";
+        let result = extract_path_and_format(path, None).unwrap();
+        assert_eq!(result.0, PathBuf::from("./coverage/coverage.json"));
+        assert_eq!(result.1, Formats::Simplecov);
+    }
+
+    #[test]
+    fn test_format_in_path_invalid_but_base_format_used() {
+        let path = "invalidfmt:./coverage/coverage.json";
+        let base = Some(Formats::Lcov);
+        let result = extract_path_and_format(path, base).unwrap();
+        assert_eq!(result.0, PathBuf::from(path));
+        assert_eq!(result.1, Formats::Lcov);
+    }
+
+    #[test]
+    fn test_format_in_path_invalid_and_no_base_format_fallbacks_to_try_from() {
+        // Suppose "invalidfmt:./foo.txt" fails parsing and TryFrom also fails
+        let path = "invalidfmt:./foo.txt";
+        let result = extract_path_and_format(path, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_format_not_in_path_but_base_format_provided() {
+        let path = "./coverage/lcov.info";
+        let base = Some(Formats::Lcov);
+        let result = extract_path_and_format(path, base).unwrap();
+        assert_eq!(result.0, PathBuf::from(path));
+        assert_eq!(result.1, Formats::Lcov);
+    }
+
+    #[test]
+    fn test_format_not_in_path_or_base_infer_from_path() {
+        let path = "./coverage/lcov.info"; // Assuming try_from recognizes this
+        let result = extract_path_and_format(path, None).unwrap();
+        assert_eq!(result.0, PathBuf::from(path));
+        assert_eq!(result.1, Formats::Lcov);
+    }
+
+    #[test]
+    fn test_windows_path() {
+        let path = "D:/a/qlty-action/qlty-action/coverage/coverage/clover.xml";
+        let result = extract_path_and_format(path, None).unwrap();
+        assert_eq!(result.0, PathBuf::from(path));
+        assert_eq!(result.1, Formats::Clover);
     }
 }

--- a/qlty-coverage/src/utils.rs
+++ b/qlty-coverage/src/utils.rs
@@ -13,14 +13,14 @@ pub fn extract_path_and_format(
 ) -> Result<(PathBuf, Formats)> {
     if let Some((potential_format, rest)) = path.split_once(':') {
         match Formats::from_str(potential_format) {
-            Ok(fmt) => Ok((PathBuf::from(rest), fmt)),
+            Ok(format) => Ok((PathBuf::from(rest), format)),
             Err(_) => match base_format {
-                Some(fmt) => Ok((PathBuf::from(path), fmt)),
+                Some(format) => Ok((PathBuf::from(path), format)),
                 None => Ok((PathBuf::from(path), Formats::try_from(path.as_ref())?)),
             },
         }
-    } else if let Some(fmt) = base_format {
-        Ok((PathBuf::from(path), fmt))
+    } else if let Some(format) = base_format {
+        Ok((PathBuf::from(path), format))
     } else {
         Ok((PathBuf::from(path), Formats::try_from(path.as_ref())?))
     }


### PR DESCRIPTION
Right now for absoluete paths on windows i-e `D:/a/qlty-action/qlty-action/coverage/coverage/clover.xml` We run into error because it assume `D` must be a format