### PR TITLE
Fix: Allow coverage publish --dry-run to work without token

### DIFF
--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -141,7 +141,12 @@ impl Publish {
         print_settings(&settings);
         self.validate_options()?;
 
-        let token = load_auth_token(&self.token, self.project.as_deref())?;
+        let token = if self.dry_run {
+            load_auth_token(&self.token, self.project.as_deref()).unwrap_or_default()
+        } else {
+            load_auth_token(&self.token, self.project.as_deref())?
+        };
+
         let plan = Planner::new(&load_config(), &settings).compute()?;
 
         self.validate_plan(&plan)?;


### PR DESCRIPTION
## Summary
- Fix a bug where `qlty coverage publish --dry-run` incorrectly required the QLTY_COVERAGE_TOKEN environment variable
- When running with --dry-run, the command should be able to export coverage data locally without needing API authentication

## Test plan
- Run `unset QLTY_COVERAGE_TOKEN && cargo run -- coverage publish --dry-run --override-commit-sha a006464 ./lcov.info`
- Verify the command successfully exports the coverage data without requiring a token
- Confirm that normal usage (without dry-run) still requires a token

🤖 Generated with [Claude Code](https://claude.ai/code)