### PR TITLE
Add skip_full_branch directive

### DIFF
--- a/qlty-check/src/planner/config.rs
+++ b/qlty-check/src/planner/config.rs
@@ -69,6 +69,16 @@ fn configure_plugins(planner: &Planner) -> Result<Vec<ActivePlugin>> {
             }
         }
 
+        if let Some(TargetMode::All) = &planner.target_mode {
+            if enabled_plugin.skip_full_branch.unwrap_or(false) {
+                debug!(
+                    "Enabled plugin {} skip_full_branch is true, skipping plugin in --all mode.",
+                    enabled_plugin.name
+                );
+                continue;
+            }
+        }
+
         if !enabled_plugin.triggers.is_empty()
             && !enabled_plugin.triggers.contains(&planner.settings.trigger)
         {

--- a/qlty-cli/tests/cmd/check/skip_full_branch.in/.gitignore
+++ b/qlty-cli/tests/cmd/check/skip_full_branch.in/.gitignore
@@ -1,0 +1,4 @@
+.qlty/results
+.qlty/logs
+.qlty/out
+.qlty/sources

--- a/qlty-cli/tests/cmd/check/skip_full_branch.in/.qlty/qlty.toml
+++ b/qlty-cli/tests/cmd/check/skip_full_branch.in/.qlty/qlty.toml
@@ -1,0 +1,27 @@
+config_version = "0"
+
+[plugins.definitions.should_run]
+file_types = ["shell"]
+
+[plugins.definitions.should_run.drivers.lint]
+script = "true"
+success_codes = [0]
+output = "pass_fail"
+
+[plugins.definitions.should_not_run]
+file_types = ["shell"]
+
+[plugins.definitions.should_not_run.drivers.lint]
+script = "false"
+success_codes = [0]
+output = "pass_fail"
+
+
+[[plugin]]
+name = "should_run"
+version = "1.0.0"
+
+[[plugin]]
+name = "should_not_run"
+version = "1.0.0"
+skip_full_branch = true

--- a/qlty-cli/tests/cmd/check/skip_full_branch.in/sample.sh
+++ b/qlty-cli/tests/cmd/check/skip_full_branch.in/sample.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "$foo"

--- a/qlty-cli/tests/cmd/check/skip_full_branch.stderr
+++ b/qlty-cli/tests/cmd/check/skip_full_branch.stderr
@@ -1,0 +1,3 @@
+     [0/1] [..] Planning...  [..]s
+     [1/1] [..] Analyzing all targets... 
+✔ No issues

--- a/qlty-cli/tests/cmd/check/skip_full_branch.stdout
+++ b/qlty-cli/tests/cmd/check/skip_full_branch.stdout
@@ -1,0 +1,6 @@
+ JOBS: 1 
+
+Plugin      Result   Targets   Time   Debug File
+should_run  Success  1 target  [..]s  .qlty/out/invoke-[..].yaml
+
+Checked 1 file

--- a/qlty-cli/tests/cmd/check/skip_full_branch.toml
+++ b/qlty-cli/tests/cmd/check/skip_full_branch.toml
@@ -1,0 +1,2 @@
+bin.name = "qlty"
+args = ["check", "--all", "--no-cache", "--verbose"]

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -669,6 +669,9 @@ pub struct EnabledPlugin {
     pub skip_upstream: Option<bool>,
 
     #[serde(default)]
+    pub skip_full_branch: Option<bool>,
+
+    #[serde(default)]
     pub triggers: Vec<CheckTrigger>,
 
     #[serde(default)]


### PR DESCRIPTION
Allows skipping enabled plugins on full branch analysis, for plugins which you want only to run on upstream diff mode. 

Useful for slow plugins which can't batch targets on full branch analysis.