### PR TITLE
ruby(macos): add preflight dependency checks to Ruby binary install

### DIFF
--- a/qlty-check/Cargo.toml
+++ b/qlty-check/Cargo.toml
@@ -31,6 +31,7 @@ git2.workspace = true
 globset.workspace = true
 ignore.workspace = true
 indicatif.workspace = true
+indoc.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true
 lzma-rs.workspace = true
@@ -61,7 +62,6 @@ zip.workspace = true
 
 [dev-dependencies]
 assert-json-diff.workspace = true
-indoc.workspace = true
 insta.workspace = true
 qlty-test-utilities.workspace = true
 tracing-test.workspace = true

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -306,8 +306,13 @@ pub trait Tool: Debug + Sync + Send {
         }
     }
 
+    fn install_max_retries(&self) -> u32 {
+        MAX_TOOL_INSTALL_ATTEMPTS
+    }
+
     fn install_with_retry(&self, task: &ProgressTask) -> Result<()> {
         let mut attempts = 0;
+        let max_attempts = self.install_max_retries() + 1;
 
         loop {
             match self.install(task) {
@@ -316,7 +321,7 @@ pub trait Tool: Debug + Sync + Send {
                     error!("{}: tool installation error: {:?}", self.name(), e);
 
                     attempts += 1;
-                    if attempts >= MAX_TOOL_INSTALL_ATTEMPTS {
+                    if attempts >= max_attempts {
                         error!(
                             "Max attempts reached for tool installation: {}",
                             self.name()

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -312,7 +312,7 @@ pub trait Tool: Debug + Sync + Send {
 
     fn install_with_retry(&self, task: &ProgressTask) -> Result<()> {
         let mut attempts = 0;
-        let max_attempts = self.install_max_retries() + 1;
+        let max_attempts = self.install_max_retries();
 
         loop {
             match self.install(task) {

--- a/qlty-check/src/tool/ruby.rs
+++ b/qlty-check/src/tool/ruby.rs
@@ -31,6 +31,10 @@ pub trait PlatformRuby {
         true
     }
 
+    fn pre_install(&self, _tool: &dyn Tool, _task: &ProgressTask) -> Result<()> {
+        Ok(())
+    }
+
     fn post_install(&self, tool: &dyn Tool, task: &ProgressTask) -> Result<()>;
     fn extra_env_paths(&self, tool: &dyn Tool) -> Vec<String>;
     fn extra_env_vars(&self, tool: &dyn Tool, env: &mut HashMap<String, String>) -> Result<()>;
@@ -42,6 +46,7 @@ pub trait PlatformRuby {
 
     fn install(&self, tool: &dyn Tool, task: &ProgressTask, download: Download) -> Result<()> {
         task.set_message("Installing Ruby");
+        self.pre_install(tool, task)?;
         download.install(tool)?;
         self.install_load_path_script(tool)
     }
@@ -175,6 +180,10 @@ impl Tool for Ruby {
 
     fn version(&self) -> Option<String> {
         self.platform_tool.version(&self.version)
+    }
+
+    fn install_max_retries(&self) -> u32 {
+        0 // no retries for Ruby
     }
 
     fn install(&self, task: &ProgressTask) -> Result<()> {


### PR DESCRIPTION
We need gmp, libyaml, and openssl in order to install Ruby on any macOS system. This pre-flight check (ported from #2007) validates that the libraries are installed via Homebrew.

This PR also adds this check for x86_64 architectures, as well as disables retries for the Ruby tool installer. If we don't disable retries, this (slow) check will be run 3+ times (9 total brew checks).

Note that an improvement of this approach would be to simply request permission from the user to install these libraries instead of exiting. This could be implemented as a follow-up.