### PR TITLE
Display version command on failure for user debuggability

### DIFF
--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -50,7 +50,7 @@ fn exit_status_code(status: &std::process::ExitStatus) -> i32 {
     use std::os::unix::process::ExitStatusExt;
     status
         .code()
-        .unwrap_or_else(|| cmd_output.status.signal().unwrap_or_default())
+        .unwrap_or_else(|| status.signal().unwrap_or_default())
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
Version command output was being hidden from error making it unnecessarily difficult to understand a failure. This PR shows the output on failure providing much faster determination of an error. Example for Ruby (before applying #2028):

Before:

```
 > Error installing ruby@3.4.2.
 >
 >     See more: /Users/loren/.qlty/cache/tools/ruby/3.4.2-6e382f1c8049-install.log
 >
 > Caused by:
 >     Failed to get version for package "ruby": (command sh -c "ruby --version" exited with code 0)
```

After:

```
 > Error installing ruby@3.4.2.
 >
 >     See more: /Users/loren/.qlty/cache/tools/ruby/3.4.2-6e382f1c8049-install.log
 >
 > Caused by:
 >     Failed to get version for package "ruby": (command sh -c "ruby --version" exited with code 6)
 >
 >     dyld[96492]: Library not loaded: /opt/homebrew/opt/gmp/lib/libgmp.10.dylib
 >       Referenced from: <A6BC37D1-46DA-3257-8F2A-6CEE022FF4E2> /Users/loren/.qlty/cache/tools/ruby/3.4.2-6e382f1c8049/bin/ruby
 >       Reason: tried: '/opt/homebrew/opt/gmp/lib/libgmp.10.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/gmp/lib/libgmp.10.dylib' (no such file), '/opt/homebrew/opt/gmp/lib/libgmp.10.dylib' (no such file)
 ```

 Note that the error code is also incorrectly displayed as "0" prior to this patch creating confusion around the potential cause.