### PR TITLE
Print the report URL after the complete command runs

### DIFF
--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -75,7 +75,8 @@ impl Complete {
         print_authentication_info(&token, self.quiet);
 
         let timer = Instant::now();
-        let result = Self::request_complete(&plan.metadata, &token).context("Failed to complete coverage")?;
+        let result = Self::request_complete(&plan.metadata, &token)
+            .context("Failed to complete coverage")?;
         self.print_complete_success(timer.elapsed().as_secs_f32(), &result.url);
 
         CommandSuccess::ok()
@@ -119,11 +120,11 @@ impl Complete {
         }
 
         eprintln!("    Coverage marked as complete in {elapsed_seconds:.2}s!");
-        
+
         if !url.is_empty() {
             eprintln!("    {}", style(format!("View report: {url}")).bold());
         }
-        
+
         eprintln!();
     }
 
@@ -133,13 +134,13 @@ impl Complete {
     ) -> Result<CompleteResult> {
         let client = QltyClient::new(Some(LEGACY_API_URL), Some(token.into()));
         let response = client.post_coverage_metadata("/coverage/complete", metadata)?;
-            
+
         let url = response
             .get("data")
             .and_then(|data| data.get("url"))
             .and_then(|url| url.as_str())
             .unwrap_or_default();
-            
+
         Ok(CompleteResult {
             url: url.to_string(),
         })

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -132,7 +132,8 @@ impl Complete {
         metadata: &qlty_types::tests::v1::CoverageMetadata,
         token: &str,
     ) -> Result<CompleteResult> {
-        let client = QltyClient::new(Some(&get_legacy_api_url()), Some(token.into()));
+        let legacy_api_url = get_legacy_api_url();
+        let client = QltyClient::new(Some(&legacy_api_url), Some(token.into()));
         let response = client.post_coverage_metadata("/coverage/complete", metadata)?;
 
         let url = response

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -14,7 +14,7 @@ use std::time::Instant;
 
 #[derive(Debug, Default, Clone)]
 pub struct CompleteResult {
-    pub url: String,
+    pub url: Option<String>,
 }
 
 #[derive(Debug, Args, Default)]
@@ -114,14 +114,14 @@ impl Complete {
         Ok(())
     }
 
-    fn print_complete_success(&self, elapsed_seconds: f32, url: &str) {
+    fn print_complete_success(&self, elapsed_seconds: f32, url: &Option<String>) {
         if self.quiet {
             return;
         }
 
         eprintln!("    Coverage marked as complete in {elapsed_seconds:.2}s!");
 
-        if !url.is_empty() {
+        if let Some(url) = url {
             eprintln!("    {}", style(format!("View report: {url}")).bold());
         }
 
@@ -140,10 +140,8 @@ impl Complete {
             .get("data")
             .and_then(|data| data.get("url"))
             .and_then(|url| url.as_str())
-            .unwrap_or_default();
+            .map(String::from);
 
-        Ok(CompleteResult {
-            url: url.to_string(),
-        })
+        Ok(CompleteResult { url })
     }
 }

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -78,7 +78,7 @@ impl Complete {
         let result = Self::request_complete(&plan.metadata, &token)
             .context("Failed to complete coverage")?;
 
-        self.print_section_header(" COMPLETION REQUEST");
+        self.print_section_header(" MARKING COMPLETE...");
         self.print_complete_success(timer.elapsed().as_secs_f32(), &result.url);
 
         CommandSuccess::ok()

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -73,10 +73,9 @@ impl Complete {
         print_authentication_info(&token, self.quiet);
 
         let timer = Instant::now();
+        self.print_section_header(" COMPLETING... ");
         let result = Self::request_complete(&plan.metadata, &token)
             .context("Failed to complete coverage")?;
-
-        self.print_section_header(" COMPLETING... ");
         self.print_complete_success(timer.elapsed().as_secs_f32(), &result.url);
 
         CommandSuccess::ok()

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -77,6 +77,8 @@ impl Complete {
         let timer = Instant::now();
         let result = Self::request_complete(&plan.metadata, &token)
             .context("Failed to complete coverage")?;
+
+        self.print_section_header(" COMPLETION REQUEST");
         self.print_complete_success(timer.elapsed().as_secs_f32(), &result.url);
 
         CommandSuccess::ok()

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -76,7 +76,7 @@ impl Complete {
         let result = Self::request_complete(&plan.metadata, &token)
             .context("Failed to complete coverage")?;
 
-        self.print_section_header(" MARKING COMPLETE...");
+        self.print_section_header(" COMPLETING... ");
         self.print_complete_success(timer.elapsed().as_secs_f32(), &result.url);
 
         CommandSuccess::ok()


### PR DESCRIPTION
I also added a section header before printing the response information. Note the below is slightly inaccurate -- it says "MARKING COMPLETE ... " now.

<img width="1406" alt="image" src="https://github.com/user-attachments/assets/f5ed0700-8e45-494b-a882-a6cc2bca59da" />
