### PR TITLE
feat: Add support for `--sarif` flag to `qlty smells` command

### DIFF
--- a/qlty-analysis/Cargo.toml
+++ b/qlty-analysis/Cargo.toml
@@ -27,6 +27,7 @@ path-absolutize.workspace = true
 pbjson-types.workspace = true
 qlty-config.workspace = true
 qlty-types.workspace = true
+qlty-formats.workspace = true
 rand.workspace = true
 rayon.workspace = true
 regex.workspace = true

--- a/qlty-analysis/src/report.rs
+++ b/qlty-analysis/src/report.rs
@@ -191,8 +191,6 @@ impl Report {
     }
 }
 
-// impl SarifFormatter for Report {}
-
 impl SarifTrait for Report {
     fn issues(&self) -> Vec<Issue> {
         self.issues.clone()

--- a/qlty-analysis/src/report.rs
+++ b/qlty-analysis/src/report.rs
@@ -1,6 +1,7 @@
 use crate::utils::fs::path_to_string;
 use pbjson_types::Timestamp;
 use qlty_config::issue_transformer::IssueTransformer;
+use qlty_formats::SarifTrait;
 use qlty_types::analysis::v1::{
     AnalysisResult, ComponentType, Invocation, Issue, Message, Metadata, Stats,
 };
@@ -187,5 +188,17 @@ impl Report {
             seconds: now.unix_timestamp(),
             nanos: now.nanosecond() as i32,
         }
+    }
+}
+
+// impl SarifFormatter for Report {}
+
+impl SarifTrait for Report {
+    fn issues(&self) -> Vec<Issue> {
+        self.issues.clone()
+    }
+
+    fn messages(&self) -> Vec<Message> {
+        self.messages.clone()
     }
 }

--- a/qlty-check/Cargo.toml
+++ b/qlty-check/Cargo.toml
@@ -41,6 +41,7 @@ prost.workspace = true
 qlty-analysis.workspace = true
 qlty-cloud.workspace = true
 qlty-config.workspace = true
+qlty-formats.workspace = true
 qlty-types.workspace = true
 rand.workspace = true
 rayon.workspace = true

--- a/qlty-check/src/report.rs
+++ b/qlty-check/src/report.rs
@@ -8,19 +8,6 @@ use std::{
     path::PathBuf,
 };
 
-/*
-from: qlty-analysis/src/report.rs
-
-#[derive(Clone, Debug, Serialize, Default)]
-pub struct Report {
-    pub metadata: Metadata,
-    pub messages: Vec<Message>,
-    pub invocations: Vec<Invocation>,
-    pub issues: Vec<Issue>,
-    pub stats: Vec<Stats>,
-}
-*/
-
 #[derive(Clone, Debug)]
 pub struct Report {
     pub verb: ExecutionVerb,
@@ -89,7 +76,6 @@ impl Report {
     }
 }
 
-// impl SarifFormatter for Report {}
 impl SarifTrait for Report {
     fn issues(&self) -> Vec<Issue> {
         self.issues.clone()

--- a/qlty-check/src/report.rs
+++ b/qlty-check/src/report.rs
@@ -1,11 +1,25 @@
 use crate::{results::FixedResult, InvocationResult};
 use itertools::Itertools;
 use qlty_analysis::{workspace_entries::TargetMode, IssueCount};
+use qlty_formats::SarifTrait;
 use qlty_types::analysis::v1::{ExecutionVerb, Issue, Level, Message};
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,
 };
+
+/*
+from: qlty-analysis/src/report.rs
+
+#[derive(Clone, Debug, Serialize, Default)]
+pub struct Report {
+    pub metadata: Metadata,
+    pub messages: Vec<Message>,
+    pub invocations: Vec<Invocation>,
+    pub issues: Vec<Issue>,
+    pub stats: Vec<Stats>,
+}
+*/
 
 #[derive(Clone, Debug)]
 pub struct Report {
@@ -72,5 +86,16 @@ impl Report {
 
         paths.sort();
         paths
+    }
+}
+
+// impl SarifFormatter for Report {}
+impl SarifTrait for Report {
+    fn issues(&self) -> Vec<Issue> {
+        self.issues.clone()
+    }
+
+    fn messages(&self) -> Vec<Message> {
+        self.messages.clone()
     }
 }

--- a/qlty-cli/src/commands/smells.rs
+++ b/qlty-cli/src/commands/smells.rs
@@ -211,12 +211,13 @@ impl Smells {
 
     fn write_stdout(&self, workspace: &Workspace, report: &Report) -> Result<()> {
         if self.json {
-            self.write_stdout_json(report.issues)
+            self.write_stdout_json(&report.issues)
         } else if self.sarif {
             let formatter = SarifFormatter::boxed(report.clone());
             formatter.write_to(&mut std::io::stdout())?;
+            Ok(())
         } else {
-            self.write_stdout_text(workspace, report.issues)
+            self.write_stdout_text(workspace, &report.issues)
         }
     }
 

--- a/qlty-cli/src/commands/smells.rs
+++ b/qlty-cli/src/commands/smells.rs
@@ -106,7 +106,7 @@ impl Smells {
 
         steps.start(SPARKLES, "Reporting... ");
         println!();
-        self.write_stdout(&workspace, &report.issues)?;
+        self.write_stdout(&workspace, &report)?;
 
         CommandSuccess::ok()
     }
@@ -209,15 +209,14 @@ impl Smells {
         Ok(executor.report())
     }
 
-    fn write_stdout(&self, workspace: &Workspace, issues: &[Issue]) -> Result<()> {
+    fn write_stdout(&self, workspace: &Workspace, report: &Report) -> Result<()> {
         if self.json {
-            self.write_stdout_json(issues)
+            self.write_stdout_json(report.issues.clone())
         } else if self.sarif {
             let formatter = SarifFormatter::boxed(report.clone());
             formatter.write_to(&mut std::io::stdout())?;
-            Ok(false)
         } else {
-            self.write_stdout_text(workspace, issues)
+            self.write_stdout_text(workspace, report.issues.clone())
         }
     }
 

--- a/qlty-cli/src/commands/smells.rs
+++ b/qlty-cli/src/commands/smells.rs
@@ -211,12 +211,12 @@ impl Smells {
 
     fn write_stdout(&self, workspace: &Workspace, report: &Report) -> Result<()> {
         if self.json {
-            self.write_stdout_json(report.issues.clone())
+            self.write_stdout_json(report.issues)
         } else if self.sarif {
             let formatter = SarifFormatter::boxed(report.clone());
             formatter.write_to(&mut std::io::stdout())?;
         } else {
-            self.write_stdout_text(workspace, report.issues.clone())
+            self.write_stdout_text(workspace, report.issues)
         }
     }
 

--- a/qlty-cli/src/commands/smells.rs
+++ b/qlty-cli/src/commands/smells.rs
@@ -1,3 +1,4 @@
+use crate::format::SarifFormatter;
 use crate::ui::Highlighter;
 use crate::ui::Steps;
 use crate::{Arguments, CommandError, CommandSuccess};
@@ -46,8 +47,12 @@ pub struct Smells {
     pub quiet: bool,
 
     /// JSON output
-    #[arg(long, hide = true)]
+    #[arg(long, hide = true, conflicts_with = "sarif")]
     json: bool,
+
+    /// SARIF output
+    #[arg(long, conflicts_with = "json")]
+    sarif: bool,
 
     /// Files to analyze
     pub paths: Vec<PathBuf>,
@@ -207,6 +212,10 @@ impl Smells {
     fn write_stdout(&self, workspace: &Workspace, issues: &[Issue]) -> Result<()> {
         if self.json {
             self.write_stdout_json(issues)
+        } else if self.sarif {
+            let formatter = SarifFormatter::boxed(report.clone());
+            formatter.write_to(&mut std::io::stdout())?;
+            Ok(false)
         } else {
             self.write_stdout_text(workspace, issues)
         }

--- a/qlty-cli/src/format/sarif.rs
+++ b/qlty-cli/src/format/sarif.rs
@@ -1,23 +1,42 @@
 use anyhow::Result;
-use qlty_check::Report;
+// use qlty_check::Report;
 use qlty_config::version::{BUILD_DATE, LONG_VERSION, QLTY_VERSION};
-use qlty_formats::Formatter;
+use qlty_formats::{Formatter, SarifTrait};
 use qlty_types::analysis::v1::{Category, Issue, Language, Level, Location, Message, MessageLevel};
 use serde_json::{json, Map, Value};
 use std::convert::TryFrom;
 use std::io::Write;
 
 #[derive(Debug)]
+pub struct SarifReport {
+    // pub verb: ExecutionVerb,
+    // pub target_mode: TargetMode,
+    pub messages: Vec<Message>,
+    // pub invocations: Vec<InvocationResult>,
+    pub issues: Vec<Issue>,
+    // pub formatted: Vec<PathBuf>,
+    // pub fixed: HashSet<FixedResult>,
+    // pub fixable: HashSet<FixedResult>,
+    // pub counts: IssueCount,
+}
+
+#[derive(Debug)]
 pub struct SarifFormatter {
-    report: Report,
+    report: SarifReport,
 }
 
 impl SarifFormatter {
-    pub fn new(report: Report) -> Self {
-        Self { report }
+    pub fn new<R: SarifTrait>(report: R) -> Self {
+        // Self { report }
+        Self {
+            report: SarifReport {
+                messages: report.messages(),
+                issues: report.issues(),
+            }
+        }
     }
 
-    pub fn boxed(report: Report) -> Box<dyn Formatter> {
+    pub fn boxed<R: SarifTrait>(report: R) -> Box<dyn Formatter> {
         Box::new(Self::new(report))
     }
 
@@ -482,16 +501,16 @@ mod test {
             ..Default::default()
         };
 
-        let report = Report {
-            verb: ExecutionVerb::Check,
-            target_mode: TargetMode::default(),
+        let report = SarifReport {
+            // verb: ExecutionVerb::Check,
+            // target_mode: TargetMode::default(),
             messages: vec![info_message, warning_message],
-            invocations: vec![],
+            // invocations: vec![],
             issues: vec![comprehensive_issue, simple_issue],
-            formatted: vec![],
-            fixed: HashSet::new(),
-            fixable: HashSet::new(),
-            counts: IssueCount::default(),
+            // formatted: vec![],
+            // fixed: HashSet::new(),
+            // fixable: HashSet::new(),
+            // counts: IssueCount::default(),
         };
 
         let formatter = SarifFormatter::boxed(report);

--- a/qlty-cli/src/format/sarif.rs
+++ b/qlty-cli/src/format/sarif.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-// use qlty_check::Report;
+use qlty_check::Report;
 use qlty_config::version::{BUILD_DATE, LONG_VERSION, QLTY_VERSION};
 use qlty_formats::{Formatter, SarifTrait};
 use qlty_types::analysis::v1::{Category, Issue, Language, Level, Location, Message, MessageLevel};
@@ -9,15 +9,8 @@ use std::io::Write;
 
 #[derive(Debug)]
 pub struct SarifReport {
-    // pub verb: ExecutionVerb,
-    // pub target_mode: TargetMode,
     pub messages: Vec<Message>,
-    // pub invocations: Vec<InvocationResult>,
     pub issues: Vec<Issue>,
-    // pub formatted: Vec<PathBuf>,
-    // pub fixed: HashSet<FixedResult>,
-    // pub fixable: HashSet<FixedResult>,
-    // pub counts: IssueCount,
 }
 
 #[derive(Debug)]
@@ -27,7 +20,6 @@ pub struct SarifFormatter {
 
 impl SarifFormatter {
     pub fn new<R: SarifTrait>(report: R) -> Self {
-        // Self { report }
         Self {
             report: SarifReport {
                 messages: report.messages(),
@@ -501,16 +493,16 @@ mod test {
             ..Default::default()
         };
 
-        let report = SarifReport {
-            // verb: ExecutionVerb::Check,
-            // target_mode: TargetMode::default(),
+        let report = Report {
+            verb: ExecutionVerb::Check,
+            target_mode: TargetMode::default(),
             messages: vec![info_message, warning_message],
-            // invocations: vec![],
+            invocations: vec![],
             issues: vec![comprehensive_issue, simple_issue],
-            // formatted: vec![],
-            // fixed: HashSet::new(),
-            // fixable: HashSet::new(),
-            // counts: IssueCount::default(),
+            formatted: vec![],
+            fixed: HashSet::new(),
+            fixable: HashSet::new(),
+            counts: IssueCount::default(),
         };
 
         let formatter = SarifFormatter::boxed(report);

--- a/qlty-formats/src/lib.rs
+++ b/qlty-formats/src/lib.rs
@@ -14,6 +14,7 @@ pub use json::JsonFormatter;
 pub use json_each::JsonEachRowFormatter;
 pub use json_each_truncated::InvocationJsonFormatter;
 pub use protos::{ProtoFormatter, ProtosFormatter};
+use qlty_types::analysis::v1::{Issue, Message};
 
 pub trait Formatter {
     fn write_to(&self, writer: &mut dyn std::io::Write) -> Result<()>;
@@ -35,4 +36,9 @@ pub trait Formatter {
         self.write_to(&mut buffer)?;
         Ok(buffer)
     }
+}
+
+pub trait SarifTrait {
+    fn issues(&self) -> Vec<Issue>;
+    fn messages(&self) -> Vec<Message>;
 }


### PR DESCRIPTION
This PR adds support for generating SARIF output using the --sarif flag when running the qlty smells command.

Notes:


I'm not an expert in Rust, and I encountered a few challenges while implementing this feature, so happy for any comments to improve it. 

The main issue was that the existing `SarifFormatter` only supported a single type: `qlty_check::Report`. Since Rust doesn't have inheritance, I resolved this by extracting a shared trait (`SarifTrait`) and implementing it for both `qlty_check::Report` and `qlty_analysis::Report`. The `SarifFormatter` was then updated to accept any type that implements this trait.

I'm not completely confident that all the structs and traits are placed in the most appropriate modules, so I'm open to feedback or suggestions about how to better organize them according to project conventions or best practices.

