### PR TITLE
Centralize API URL retrieval and allow overriding with env var

### DIFF
--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -5,7 +5,7 @@ use crate::{CommandError, CommandSuccess};
 use anyhow::{bail, Context, Result};
 use clap::Args;
 use console::style;
-use qlty_cloud::{Client as QltyClient, LEGACY_API_URL};
+use qlty_cloud::{get_legacy_api_url, Client as QltyClient};
 use qlty_coverage::{
     publish::{Plan, Planner, Settings},
     token::load_auth_token,
@@ -120,7 +120,8 @@ impl Complete {
         metadata: &qlty_types::tests::v1::CoverageMetadata,
         token: &str,
     ) -> Result<Value> {
-        let client = QltyClient::new(Some(LEGACY_API_URL), Some(token.into()));
+        let legacy_api_url = get_legacy_api_url();
+        let client = QltyClient::new(Some(&legacy_api_url), Some(token.into()));
         client.post_coverage_metadata("/coverage/complete", metadata)
     }
 }

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -5,15 +5,13 @@ use crate::{CommandError, CommandSuccess};
 use anyhow::{bail, Context, Result};
 use clap::Args;
 use console::style;
-use qlty_cloud::Client as QltyClient;
+use qlty_cloud::{Client as QltyClient, LEGACY_API_URL};
 use qlty_coverage::{
     publish::{Plan, Planner, Settings},
     token::load_auth_token,
 };
 use serde_json::Value;
 use std::time::Instant;
-
-const LEGACY_API_URL: &str = "https://qlty.sh/api";
 
 #[derive(Debug, Args, Default)]
 pub struct Complete {

--- a/qlty-cloud/src/lib.rs
+++ b/qlty-cloud/src/lib.rs
@@ -4,8 +4,17 @@ use qlty_types::tests::v1::CoverageMetadata;
 use serde_json::Value;
 use ureq::{json, serde_json, Error, Request};
 
+const ENV_QLTY_API_URL: &str = "QLTY_API_URL";
 const QLTY_API_URL: &str = "https://api.qlty.sh";
-pub const LEGACY_API_URL: &str = "https://qlty.sh/api";
+const LEGACY_API_URL: &str = "https://qlty.sh/api";
+
+pub fn get_api_url() -> String {
+    std::env::var(ENV_QLTY_API_URL).unwrap_or_else(|_| QLTY_API_URL.to_string())
+}
+
+pub fn get_legacy_api_url() -> String {
+    std::env::var(ENV_QLTY_API_URL).unwrap_or_else(|_| LEGACY_API_URL.to_string())
+}
 const USER_AGENT_PREFIX: &str = "qlty";
 
 #[derive(Debug, Clone)]
@@ -26,10 +35,7 @@ impl Client {
             base_url: if let Some(url) = base_url {
                 url.to_string()
             } else {
-                match std::env::var("QLTY_API_URL") {
-                    Ok(url) => url,
-                    Err(_) => QLTY_API_URL.to_string(),
-                }
+                get_api_url()
             },
             token,
         }

--- a/qlty-cloud/src/lib.rs
+++ b/qlty-cloud/src/lib.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use ureq::{json, serde_json, Error, Request};
 
 const QLTY_API_URL: &str = "https://api.qlty.sh";
+pub const LEGACY_API_URL: &str = "https://qlty.sh/api";
 const USER_AGENT_PREFIX: &str = "qlty";
 
 #[derive(Debug, Clone)]

--- a/qlty-coverage/src/publish/upload.rs
+++ b/qlty-coverage/src/publish/upload.rs
@@ -2,12 +2,10 @@ use crate::export::CoverageExport;
 use crate::publish::Report;
 use anyhow::{anyhow, bail};
 use anyhow::{Context, Result};
-use qlty_cloud::Client as QltyClient;
+use qlty_cloud::{Client as QltyClient, LEGACY_API_URL};
 use qlty_types::tests::v1::CoverageMetadata;
 use serde_json::Value;
 use std::path::PathBuf;
-
-const LEGACY_API_URL: &str = "https://qlty.sh/api";
 
 #[derive(Default, Clone, Debug)]
 pub struct Upload {

--- a/qlty-coverage/src/publish/upload.rs
+++ b/qlty-coverage/src/publish/upload.rs
@@ -2,7 +2,7 @@ use crate::export::CoverageExport;
 use crate::publish::Report;
 use anyhow::{anyhow, bail};
 use anyhow::{Context, Result};
-use qlty_cloud::{Client as QltyClient, LEGACY_API_URL};
+use qlty_cloud::{get_legacy_api_url, Client as QltyClient};
 use qlty_types::tests::v1::CoverageMetadata;
 use serde_json::Value;
 use std::path::PathBuf;
@@ -104,7 +104,8 @@ impl Upload {
     }
 
     fn request_api(metadata: &CoverageMetadata, token: &str) -> Result<Value> {
-        let client = QltyClient::new(Some(LEGACY_API_URL), Some(token.into()));
+        let legacy_api_url = get_legacy_api_url();
+        let client = QltyClient::new(Some(&legacy_api_url), Some(token.into()));
         client.post_coverage_metadata("/coverage", metadata)
     }
 }


### PR DESCRIPTION
Necessary / helpful for local development when you want to point the QLTY API to localhost.