### PR TITLE
fix: support head diff mode for `qlty smells`

### DIFF
--- a/qlty-analysis/src/workspace_entries/workspace_entry_finder_builder.rs
+++ b/qlty-analysis/src/workspace_entries/workspace_entry_finder_builder.rs
@@ -59,7 +59,7 @@ impl WorkspaceEntryFinderBuilder {
                 // Use absolute paths, so when running in a subdirectory, the paths are still correct
                 self.paths.iter().map(|p| self.root.join(p)).collect(),
             ))),
-            TargetMode::UpstreamDiff(_) => Ok(Arc::new(DiffSource::new(
+            TargetMode::HeadDiff | TargetMode::UpstreamDiff(_) => Ok(Arc::new(DiffSource::new(
                 self.git_diff()?.changed_files,
                 &self.root,
             ))),


### PR DESCRIPTION

Fixes the issue when git in detached mode (happens when gitlab initialise project):

```
... [some gitlab runner initialisation phase]
Getting source from Git repository
Fetching changes with git depth set to 50...
Initialized empty Git repository in /builds/some-reponame-tests/.git/
Created fresh repository.
Checking out 3bd76a7f as spike-test-qlty-component...
...


$ git status
HEAD detached at 3bd76a7

$ echo "Initializing project with Qlty..."
Initializing project with Qlty...

$ qlty init --no || echo "Already initialized"
› Initializing qlty in the current directory...
✔ Created .qlty/ directory
Plugin        Version     Targets   Config
checkov       known_good  6 files   
yamllint      known_good  1 files   .yamllint.yaml
markdownlint  known_good  1 files   
trufflehog    known_good  86 files  
trivy         known_good  1 files   
prettier      known_good  7 files   
✔ Created qlty.toml config file with 6 plugins
What's next?
  1. Read the documentation: https://qlty.sh/docs
  2. Get help and give feedback
     Our developers are on Discord: https://qlty.sh/discord

$ echo "Running qlty smells"
Running qlty smells

$ qlty smells
     [0/3] Analyzing vs. HEAD... 
   ERROR   
 > Unsupported workspace entry mode: HeadDiff
```