### PR TITLE
Package and export configuration files from plugins

### DIFF
--- a/qlty-check/src/executor.rs
+++ b/qlty-check/src/executor.rs
@@ -292,11 +292,11 @@ impl Executor {
             }
         }
 
-        let exported_config_files = self
+        let exported_config_paths = self
             .plan
             .invocations
             .iter()
-            .flat_map(|invocation| invocation.plugin.exported_config_files.clone())
+            .flat_map(|invocation| invocation.plugin.exported_config_paths.clone())
             .unique()
             .collect_vec();
 
@@ -349,7 +349,7 @@ impl Executor {
             }
         }
 
-        for config_file in &exported_config_files {
+        for config_file in &exported_config_paths {
             if self.plan.workspace.root != self.plan.staging_area.destination_directory {
                 // for formatters
                 let loaded_config_file = load_config_file_from_source(

--- a/qlty-check/src/executor.rs
+++ b/qlty-check/src/executor.rs
@@ -327,7 +327,7 @@ impl Executor {
             if self.plan.workspace.root != self.plan.staging_area.destination_directory {
                 // for formatters
                 let loaded_config_file = load_config_file_from_qlty_dir(
-                    &PathBuf::from(config_file),
+                    config_file,
                     &self.plan.workspace,
                     &self.plan.staging_area.destination_directory,
                 )?;
@@ -339,7 +339,7 @@ impl Executor {
 
             // for linters
             let loaded_config_file = load_config_file_from_qlty_dir(
-                &PathBuf::from(config_file),
+                config_file,
                 &self.plan.workspace,
                 &self.plan.workspace.root,
             )?;
@@ -353,7 +353,7 @@ impl Executor {
             if self.plan.workspace.root != self.plan.staging_area.destination_directory {
                 // for formatters
                 let loaded_config_file = load_config_file_from_source(
-                    &PathBuf::from(config_file),
+                    config_file,
                     &self.plan.staging_area.destination_directory,
                 )?;
 
@@ -363,10 +363,8 @@ impl Executor {
             }
 
             // for linters
-            let loaded_config_file = load_config_file_from_source(
-                &PathBuf::from(config_file),
-                &self.plan.workspace.root,
-            )?;
+            let loaded_config_file =
+                load_config_file_from_source(&config_file, &self.plan.workspace.root)?;
 
             if !loaded_config_file.is_empty() {
                 loaded_config_files.push(loaded_config_file);

--- a/qlty-check/src/executor/staging_area.rs
+++ b/qlty-check/src/executor/staging_area.rs
@@ -262,10 +262,7 @@ fn load_config_file_from(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result
         return Ok(to.display().to_string());
     }
 
-    debug!(
-        "Symlinking config file from qlty dir: {:?} -> {:?}",
-        from, to
-    );
+    debug!("Symlinking config file: {:?} -> {:?}", from, to);
 
     symlink(from, to).with_context(|| {
         format!(

--- a/qlty-check/src/executor/staging_area.rs
+++ b/qlty-check/src/executor/staging_area.rs
@@ -394,6 +394,23 @@ mod test {
     }
 
     #[test]
+    fn test_load_config_file_from_symlink_fail() {
+        let (_, paths) = new_staging_area(Mode::ReadWrite);
+
+        let config_file = paths.source.path().join("abc").join("conf.yml");
+        create_dir_all(config_file.parent().unwrap()).unwrap();
+
+        std::fs::write(&config_file, "repository_config_content").unwrap();
+
+        let workspace = Workspace::for_root(paths.source.path()).unwrap();
+        let result = load_config_file_from_repository(&config_file, &workspace, paths.dest.path());
+        assert!(result.is_err());
+
+        let dest_file = paths.dest.path().join("abc").join("conf.yml");
+        assert!(!dest_file.exists());
+    }
+
+    #[test]
     fn test_load_config_file_from_source() {
         let (_, paths) = new_staging_area(Mode::ReadWrite);
 

--- a/qlty-cli/tests/cmd/check/exported_config_files.in/.gitignore
+++ b/qlty-cli/tests/cmd/check/exported_config_files.in/.gitignore
@@ -1,0 +1,4 @@
+.qlty/results
+.qlty/logs
+.qlty/out
+.qlty/sources

--- a/qlty-cli/tests/cmd/check/exported_config_files.in/.qlty/qlty.toml
+++ b/qlty-cli/tests/cmd/check/exported_config_files.in/.qlty/qlty.toml
@@ -1,0 +1,9 @@
+config_version = "0"
+
+[[source]]
+name = "config-exporter"
+directory = "config-exporter"
+
+[[plugin]]
+name = "config-exporter"
+version = "1.0.0"

--- a/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/config.yml
+++ b/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/config.yml
@@ -1,0 +1,1 @@
+configuration: true

--- a/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/results.txt
+++ b/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/results.txt
@@ -1,0 +1,1 @@
+sample.sh:2:1: ERROR invalid line

--- a/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/source.toml
+++ b/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/source.toml
@@ -3,7 +3,7 @@ config_version = "0"
 [plugins.definitions.config-exporter]
 file_types = ["shell"]
 config_files = ["config.yml", "config.alternate.yml", "results.txt"]
-exported_config_files = [
+exported_config_paths = [
   "config.yml",
   "results.txt",
   "subdir/config.alternate.yml",

--- a/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/source.toml
+++ b/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/source.toml
@@ -1,0 +1,18 @@
+config_version = "0"
+
+[plugins.definitions.config-exporter]
+file_types = ["shell"]
+config_files = ["config.yml", "config.alternate.yml"]
+exported_config_files = ["config.yml", "subdir/config.alternate.yml"]
+
+[plugins.definitions.config-exporter.drivers.lint]
+prepare_script = "mkdir ${linter} && echo dir %2 > ${linter}/ls.cmd || echo dir %2 > ${linter}/ls.cmd"
+script = "ls -l config.yml"
+success_codes = [0]
+output = "pass_fail"
+
+[plugins.definitions.config-exporter.drivers.lint2]
+prepare_script = "mkdir ${linter} && echo dir %2 > ${linter}/ls.cmd || echo dir %2 > ${linter}/ls.cmd"
+script = "ls -l config.alternate.yml"
+success_codes = [0]
+output = "pass_fail"

--- a/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/source.toml
+++ b/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/source.toml
@@ -2,8 +2,12 @@ config_version = "0"
 
 [plugins.definitions.config-exporter]
 file_types = ["shell"]
-config_files = ["config.yml", "config.alternate.yml"]
-exported_config_files = ["config.yml", "subdir/config.alternate.yml"]
+config_files = ["config.yml", "config.alternate.yml", "results.txt"]
+exported_config_files = [
+  "config.yml",
+  "results.txt",
+  "subdir/config.alternate.yml",
+]
 
 [plugins.definitions.config-exporter.drivers.lint]
 prepare_script = "mkdir ${linter} && echo dir %2 > ${linter}/ls.cmd || echo dir %2 > ${linter}/ls.cmd"
@@ -16,3 +20,10 @@ prepare_script = "mkdir ${linter} && echo dir %2 > ${linter}/ls.cmd || echo dir 
 script = "ls -l config.alternate.yml"
 success_codes = [0]
 output = "pass_fail"
+
+[plugins.definitions.config-exporter.drivers.lint3]
+prepare_script = "mkdir ${linter} && echo type %2 > ${linter}/cat.cmd || echo type %2 > ${linter}/cat.cmd"
+script = "cat results.txt"
+output_format = "regex"
+output_regex = "((?P<path>.*):(?P<line>-?\\d+):(?P<col>-?\\d+): (?P<code>\\S+) (?P<message>.+))\n"
+success_codes = [0]

--- a/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/source.toml
+++ b/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/source.toml
@@ -22,7 +22,7 @@ success_codes = [0]
 output = "pass_fail"
 
 [plugins.definitions.config-exporter.drivers.lint3]
-prepare_script = "mkdir ${linter} && echo type %2 > ${linter}/cat.cmd || echo type %2 > ${linter}/cat.cmd"
+prepare_script = "mkdir ${linter} && echo type %1 > ${linter}/cat.cmd || echo type %1 > ${linter}/cat.cmd"
 script = "cat results.txt"
 output_format = "regex"
 output_regex = "((?P<path>.*):(?P<line>-?\\d+):(?P<col>-?\\d+): (?P<code>\\S+) (?P<message>.+))\n"

--- a/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/subdir/config.alternate.yml
+++ b/qlty-cli/tests/cmd/check/exported_config_files.in/config-exporter/subdir/config.alternate.yml
@@ -1,0 +1,1 @@
+configuration: true

--- a/qlty-cli/tests/cmd/check/exported_config_files.in/results.txt
+++ b/qlty-cli/tests/cmd/check/exported_config_files.in/results.txt
@@ -1,0 +1,1 @@
+sample.sh:2:1: OVERRIDE valid line

--- a/qlty-cli/tests/cmd/check/exported_config_files.in/sample.sh
+++ b/qlty-cli/tests/cmd/check/exported_config_files.in/sample.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo hi

--- a/qlty-cli/tests/cmd/check/exported_config_files.stderr
+++ b/qlty-cli/tests/cmd/check/exported_config_files.stderr
@@ -1,0 +1,1 @@
+✔ No issues

--- a/qlty-cli/tests/cmd/check/exported_config_files.stderr
+++ b/qlty-cli/tests/cmd/check/exported_config_files.stderr
@@ -1,1 +1,1 @@
-✔ No issues
+✖ 1 issue

--- a/qlty-cli/tests/cmd/check/exported_config_files.stdout
+++ b/qlty-cli/tests/cmd/check/exported_config_files.stdout
@@ -1,0 +1,6 @@
+
+ ISSUES: 1[..]
+
+sample.sh:2:0
+    2:0  medium  valid line  config-exporter:OVERRIDE[..]
+[..]

--- a/qlty-cli/tests/cmd/check/exported_config_files.toml
+++ b/qlty-cli/tests/cmd/check/exported_config_files.toml
@@ -1,0 +1,2 @@
+bin.name = "qlty"
+args = ["check", "--all", "--no-cache"]

--- a/qlty-cli/tests/cmd/check/exported_config_files.toml
+++ b/qlty-cli/tests/cmd/check/exported_config_files.toml
@@ -1,2 +1,3 @@
 bin.name = "qlty"
 args = ["check", "--all", "--no-cache"]
+status.code = 1

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -336,7 +336,7 @@ pub struct PluginDef {
     pub config_files: Vec<PathBuf>,
 
     #[serde(default)]
-    pub exported_config_files: Vec<PathBuf>,
+    pub exported_config_paths: Vec<PathBuf>,
 
     #[serde(default)]
     pub downloads: Vec<String>,

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -336,6 +336,9 @@ pub struct PluginDef {
     pub config_files: Vec<PathBuf>,
 
     #[serde(default)]
+    pub exported_config_files: Vec<PathBuf>,
+
+    #[serde(default)]
     pub downloads: Vec<String>,
 
     #[serde(default)]

--- a/qlty-config/src/sources/source.rs
+++ b/qlty-config/src/sources/source.rs
@@ -133,7 +133,7 @@ pub trait Source: SourceFetch {
             .contents
             .parse::<toml::Value>()
             .with_context(|| format!("Could not parse {}", source_file.path.display()))?;
-        self.add_context_to_exported_config_files(&mut contents_toml, source_file);
+        self.add_context_to_exported_config_paths(&mut contents_toml, source_file);
 
         Builder::validate_toml(&source_file.path, contents_toml.clone())
             .with_context(|| SOURCE_PARSE_ERROR)?;
@@ -143,7 +143,7 @@ pub trait Source: SourceFetch {
         Ok(())
     }
 
-    fn add_context_to_exported_config_files(
+    fn add_context_to_exported_config_paths(
         &self,
         toml: &mut toml::Value,
         source_file: &SourceFile,
@@ -157,7 +157,7 @@ pub trait Source: SourceFetch {
             .iter_mut()
         {
             plugin
-                .get_mut("exported_config_files")?
+                .get_mut("exported_config_paths")?
                 .as_array_mut()
                 .map(|values| {
                     for value in values.iter_mut() {
@@ -210,9 +210,9 @@ mod test {
             path: tempdir.join("plugin.toml"),
             contents: r#"
                 [plugins.definitions.myplugin]
-                exported_config_files = ["config.yml"]
+                exported_config_paths = ["config.yml"]
                 [plugins.definitions.my_other_plugin]
-                exported_config_files = ["config.yml", "subdir/config.yml"]
+                exported_config_paths = ["config.yml", "subdir/config.yml"]
             "#
             .into(),
         };
@@ -226,12 +226,12 @@ mod test {
         let config: QltyConfig = builder.build()?.try_deserialize()?;
 
         assert_eq!(
-            config.plugins.definitions["myplugin"].exported_config_files,
+            config.plugins.definitions["myplugin"].exported_config_paths,
             vec![tempdir.join("config.yml")]
         );
 
         assert_eq!(
-            config.plugins.definitions["my_other_plugin"].exported_config_files,
+            config.plugins.definitions["my_other_plugin"].exported_config_paths,
             vec![
                 tempdir.join("config.yml"),
                 tempdir.join("subdir").join("config.yml")


### PR DESCRIPTION
This change allows plugins to package and declare exported configuration files using the syntax below:

```toml
[plugins.definitions.some-plugin]
# Paths are relative to this TOML file location (plugin.toml, source.toml, etc)
exported_config_paths = ["relative/path/to/config.yml", "other/config.alternate.yml"]

# ...
```

Declaring an exported configuration allows a configuration file to be automatically included at runtime as a fallback default if no other configuration files are present or detected by the workspace (including `.qlty/configs` directory). The configuration file will be symlinked just like any other configuration. 

### Disabling Export Behavior from a Downstream Consumer

Users who want to opt out of automatic importing of configuration files can either:

1. Define a default configuration file in their workspace source tree (or `.qlty/configs`), or,
2. Override the `plugins.definitions.<plugin>.exported_config_paths` as:

```toml
[plugins.definitions.some-plugin]
exported_config_paths = []
```

### Using with Sources

This behavior is can used with custom sources to automatically include custom configuration from a given layered source:

#### \> .qlty/qlty.toml

```toml
[[source]]
name = "default"
default = true

[[source]]
name = "configs"
directory = "./configuration" # this can also be a repository
```

#### \> configuration/source.toml

```toml
[plugins.definitions.rubocop]
exported_config_paths = ["rubocop/.rubocop.yml"]
```

#### \> configuration/rubocop/.rubocop.yml

```yaml
AllCops:
  Enable: true
# ...
```

Any project including the above source will automatically receive custom rubocop configuration that will automatically be applied when running `qlty check`.