### PR TITLE
rust: skip version check when using a version channel

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -47,9 +47,11 @@ name = "actionlint"
 
 [[plugin]]
 name = "clippy"
+version = "1.89.0" # Note: Clippy version is controlled by the rust version above
 
 [[plugin]]
 name = "rustfmt"
+version = "1.89.0" # Note: rustfmt version is controlled by the rust version above
 
 [[plugin]]
 name = "eslint"

--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -47,11 +47,9 @@ name = "actionlint"
 
 [[plugin]]
 name = "clippy"
-version = "1.89.0" # Note: Clippy version is controlled by the rust version above
 
 [[plugin]]
 name = "rustfmt"
-version = "1.89.0" # Note: rustfmt version is controlled by the rust version above
 
 [[plugin]]
 name = "eslint"


### PR DESCRIPTION
The version will not reliably match a specific numeric when using channels (since versions can change arbitrarily).

There's an open question about how cache keys should be handled in this situation (how do we detect that "nightly" is out of date?), but I think the existing behavior will also keep cache around and only fail once the tool cache is cleared, so technically this does not change existing caching behavior.