### PR TITLE
Only enable RadarLint for Ruby when a RadarLint config is found

### DIFF
--- a/qlty-plugins/plugins/linters/radarlint-php/plugin.toml
+++ b/qlty-plugins/plugins/linters/radarlint-php/plugin.toml
@@ -10,7 +10,7 @@ known_good_version = "2.0.0"
 description = "Php linter"
 file_types = ["php"]
 config_files = ["radarlint.properties"]
-suggeste_mode = "comment"
+suggested_mode = "comment"
 
 [[plugins.definitions.radarlint-php.drivers.lint.version]]
 version_matcher = "<2.0.0"

--- a/qlty-plugins/plugins/linters/radarlint-python/plugin.toml
+++ b/qlty-plugins/plugins/linters/radarlint-python/plugin.toml
@@ -10,7 +10,7 @@ known_good_version = "2.0.0"
 description = "Python linter"
 file_types = ["python"]
 config_files = ["radarlint.properties"]
-suggeste_mode = "comment"
+suggested_mode = "comment"
 
 [[plugins.definitions.radarlint-python.drivers.lint.version]]
 version_matcher = "<2.0.0"

--- a/qlty-plugins/plugins/linters/radarlint-ruby/plugin.toml
+++ b/qlty-plugins/plugins/linters/radarlint-ruby/plugin.toml
@@ -10,7 +10,7 @@ known_good_version = "2.0.0"
 description = "Ruby linter"
 file_types = ["ruby"]
 config_files = ["radarlint.properties"]
-suggeste_mode = "monitor"
+suggested_mode = "monitor"
 
 [[plugins.definitions.radarlint-ruby.drivers.lint.version]]
 version_matcher = "<2.0.0"
@@ -21,7 +21,7 @@ output_format = "radarlint"
 output_missing = "parse"
 batch = true
 cache_results = true
-suggested = "targets"
+suggested = "config"
 
 [[plugins.definitions.radarlint-ruby.drivers.lint.version]]
 version_matcher = ">=2.0.0"
@@ -32,4 +32,4 @@ output_format = "sarif"
 output_missing = "error"
 batch = true
 cache_results = true
-suggested = "targets"
+suggested = "config"

--- a/qlty-plugins/plugins/linters/radarlint-scala/plugin.toml
+++ b/qlty-plugins/plugins/linters/radarlint-scala/plugin.toml
@@ -10,7 +10,7 @@ known_good_version = "2.0.0"
 description = "Scala linter"
 file_types = ["scala"]
 config_files = ["radarlint.properties"]
-suggeste_mode = "comment"
+suggested_mode = "comment"
 
 [[plugins.definitions.radarlint-scala.drivers.lint.version]]
 version_matcher = "<2.0.0"


### PR DESCRIPTION
- Only enable RadarLint for Ruby when a RadarLint config is found
- Fix bug where we did not correctly set `suggested_mode = "comment"` for RadarLint