### PR TITLE
Better error messages for downloads

### DIFF
--- a/qlty-check/src/tool/download.rs
+++ b/qlty-check/src/tool/download.rs
@@ -213,7 +213,7 @@ impl Download {
         let tar = GzDecoder::new(reader);
         let mut archive = Archive::new(tar);
         self.extract_archive(&mut archive, directory)
-            .with_context(|| format!("Error extracting tar.gz archive from {}", url))?;
+            .with_context(|| format!("Error extracting tar.gz archive from {url}"))?;
         Ok(())
     }
 
@@ -222,20 +222,20 @@ impl Download {
         let url = self.url()?;
         let response = ureq::get(&url)
             .call()
-            .with_context(|| format!("Error downloading file from {}", url))?;
+            .with_context(|| format!("Error downloading file from {url}"))?;
 
         let response_reader = response.into_reader();
         let mut reader = BufReader::new(response_reader);
         let mut tar: Vec<u8> = Vec::new();
 
         lzma_rs::xz_decompress(&mut reader, &mut tar)
-            .with_context(|| format!("Failed to decompress xz file"))?;
+            .with_context(|| "Failed to decompress xz file".to_string())?;
 
         let cursor = Cursor::new(tar);
         let mut archive = Archive::new(cursor);
 
         self.extract_archive(&mut archive, directory)
-            .with_context(|| format!("Failed to extract tar archive"))
+            .with_context(|| "Failed to extract tar archive".to_string())
     }
 
     fn extract_archive<R: std::io::Read>(

--- a/qlty-check/src/tool/download.rs
+++ b/qlty-check/src/tool/download.rs
@@ -130,7 +130,7 @@ impl Download {
 
         let response = ureq::get(&url)
             .call()
-            .with_context(|| format!("Error downloading file from {}", url))?;
+            .with_context(|| format!("Error downloading file from {url}"))?;
 
         let mut reader = response.into_reader();
         let mut file = File::create(&binary_path)

--- a/qlty-check/src/tool/download.rs
+++ b/qlty-check/src/tool/download.rs
@@ -208,7 +208,7 @@ impl Download {
         let url = self.url()?;
         let response = ureq::get(&url)
             .call()
-            .with_context(|| format!("Error downloading file from {}", url))?;
+            .with_context(|| format!("Error downloading file from {url}"))?;
         let reader = response.into_reader();
         let tar = GzDecoder::new(reader);
         let mut archive = Archive::new(tar);

--- a/qlty-check/src/tool/download.rs
+++ b/qlty-check/src/tool/download.rs
@@ -172,7 +172,7 @@ impl Download {
 
         let response = ureq::get(&url)
             .call()
-            .with_context(|| format!("Error downloading file from {}", url))?;
+            .with_context(|| format!("Error downloading file from {url}"))?;
 
         let reader = response.into_reader();
         let mut decoder = GzDecoder::new(reader);


### PR DESCRIPTION
This pull request refactors the `Download` implementation in `qlty-check/src/tool/download.rs` to improve error handling by using the `anyhow::Context` trait. The changes enhance the clarity and specificity of error messages throughout the file download, decompression, and extraction processes.

### Error handling improvements:
* Replaced generic error handling with `anyhow::Context` to provide detailed error messages for failures in operations such as downloading files, creating files, copying data, and setting permissions. [[1]](diffhunk://#diff-c0681f617e1bcbddc5e9a53b56fc70b035cdf67e0fe73b69089ab65d749191e8L127-R158) [[2]](diffhunk://#diff-c0681f617e1bcbddc5e9a53b56fc70b035cdf67e0fe73b69089ab65d749191e8L155-R238) [[3]](diffhunk://#diff-c0681f617e1bcbddc5e9a53b56fc70b035cdf67e0fe73b69089ab65d749191e8L247-L257)
* Updated the `install_zip` method to use `anyhow::Context` for temporary file creation, copying response data, and extracting ZIP archives.

### Code readability improvements:
* Simplified the error handling logic by removing the `match` statements and replacing them with direct calls to `with_context`. [[1]](diffhunk://#diff-c0681f617e1bcbddc5e9a53b56fc70b035cdf67e0fe73b69089ab65d749191e8L127-R158) [[2]](diffhunk://#diff-c0681f617e1bcbddc5e9a53b56fc70b035cdf67e0fe73b69089ab65d749191e8L155-R238) [[3]](diffhunk://#diff-c0681f617e1bcbddc5e9a53b56fc70b035cdf67e0fe73b69089ab65d749191e8L247-L257)
* Removed the `bail!` macro in favor of more descriptive error propagation using `with_context`. [[1]](diffhunk://#diff-c0681f617e1bcbddc5e9a53b56fc70b035cdf67e0fe73b69089ab65d749191e8L155-R238) [[2]](diffhunk://#diff-c0681f617e1bcbddc5e9a53b56fc70b035cdf67e0fe73b69089ab65d749191e8L247-L257)

### Dependency updates:
* Added `anyhow::Context` to the imports for enhanced error handling functionality.