### PR TITLE
Make qlty install more context aware and inline with check

### DIFF
--- a/qlty-check/src/planner.rs
+++ b/qlty-check/src/planner.rs
@@ -63,7 +63,7 @@ pub struct Planner {
     target_mode: Option<TargetMode>,
     workspace_entry_finder_builder: Option<PluginWorkspaceEntryFinderBuilder>,
     cache_hits: Vec<IssuesCacheHit>,
-    active_plugins: Vec<ActivePlugin>,
+    pub active_plugins: Vec<ActivePlugin>,
     plugin_configs: HashMap<String, Vec<PluginConfigFile>>,
     invocations: Vec<InvocationPlan>,
     transformers: Vec<Box<dyn IssueTransformer>>,
@@ -130,7 +130,7 @@ impl Planner {
         Ok(())
     }
 
-    fn compute_workspace_entries_strategy(&mut self) -> Result<()> {
+    pub fn compute_workspace_entries_strategy(&mut self) -> Result<()> {
         self.target_mode = Some(self.compute_target_mode());
 
         let mut builder = PluginWorkspaceEntryFinderBuilder {
@@ -149,9 +149,10 @@ impl Planner {
         Ok(())
     }
 
-    fn compute_enabled_plugins(&mut self) -> Result<()> {
+    pub fn compute_enabled_plugins(&mut self) -> Result<()> {
         self.active_plugins = enabled_plugins(self)?;
         self.plugin_configs = plugin_configs(self)?;
+
         Ok(())
     }
 

--- a/qlty-check/src/planner.rs
+++ b/qlty-check/src/planner.rs
@@ -1,4 +1,3 @@
-use self::config::enabled_plugins; //, enabled_runtime_template};
 use self::level_filter::LevelFilter;
 use self::plugin::PluginPlanner;
 use self::plugin_mode_transformer::PluginModeTransformer;
@@ -41,7 +40,7 @@ pub mod source_extractor;
 pub mod target;
 mod target_batcher;
 
-pub use config::plugin_supported_on_platform;
+pub use config::{enabled_plugins, plugin_supported_on_platform};
 pub use invocation_plan::InvocationPlan;
 pub use plan::Plan;
 pub use plugin_workspace_entry_finder_builder::PluginWorkspaceEntryFinderBuilder;
@@ -63,7 +62,7 @@ pub struct Planner {
     target_mode: Option<TargetMode>,
     workspace_entry_finder_builder: Option<PluginWorkspaceEntryFinderBuilder>,
     cache_hits: Vec<IssuesCacheHit>,
-    pub active_plugins: Vec<ActivePlugin>,
+    active_plugins: Vec<ActivePlugin>,
     plugin_configs: HashMap<String, Vec<PluginConfigFile>>,
     invocations: Vec<InvocationPlan>,
     transformers: Vec<Box<dyn IssueTransformer>>,
@@ -90,6 +89,10 @@ impl Planner {
             invocations: vec![],
             transformers: vec![],
         })
+    }
+
+    pub fn set_target_mode(&mut self, target_mode: TargetMode) {
+        self.target_mode = Some(target_mode);
     }
 
     pub fn compute(&mut self) -> Result<Plan, Error> {

--- a/qlty-check/src/planner.rs
+++ b/qlty-check/src/planner.rs
@@ -133,7 +133,7 @@ impl Planner {
         Ok(())
     }
 
-    pub fn compute_workspace_entries_strategy(&mut self) -> Result<()> {
+    fn compute_workspace_entries_strategy(&mut self) -> Result<()> {
         self.target_mode = Some(self.compute_target_mode());
 
         let mut builder = PluginWorkspaceEntryFinderBuilder {
@@ -152,10 +152,9 @@ impl Planner {
         Ok(())
     }
 
-    pub fn compute_enabled_plugins(&mut self) -> Result<()> {
+    fn compute_enabled_plugins(&mut self) -> Result<()> {
         self.active_plugins = enabled_plugins(self)?;
         self.plugin_configs = plugin_configs(self)?;
-
         Ok(())
     }
 

--- a/qlty-cli/src/commands/install.rs
+++ b/qlty-cli/src/commands/install.rs
@@ -2,7 +2,7 @@ use crate::{Arguments, CommandError, CommandSuccess};
 use anyhow::{Context, Result};
 use clap::Args;
 use qlty_analysis::workspace_entries::TargetMode;
-use qlty_check::planner::Plan;
+use qlty_check::planner::{enabled_plugins, Plan};
 use qlty_check::tool::tool_builder::ToolBuilder;
 use qlty_check::{CheckFilter, Executor, Planner, Progress, Settings, Tool};
 use qlty_config::Workspace;
@@ -46,10 +46,8 @@ impl Install {
 
         let mut planner = Planner::new(ExecutionVerb::Install, &settings)?;
 
-        planner.compute_workspace_entries_strategy()?;
-        planner.compute_enabled_plugins()?;
-
-        let active_plugins = planner.active_plugins.clone();
+        planner.set_target_mode(TargetMode::All);
+        let active_plugins = enabled_plugins(&planner)?;
 
         let mut tools = vec![];
         for active_plugin in active_plugins {

--- a/qlty-cli/src/commands/install.rs
+++ b/qlty-cli/src/commands/install.rs
@@ -1,6 +1,7 @@
 use crate::{Arguments, CommandError, CommandSuccess};
 use anyhow::{Context, Result};
 use clap::Args;
+use qlty_analysis::workspace_entries::TargetMode;
 use qlty_check::planner::Plan;
 use qlty_check::tool::tool_builder::ToolBuilder;
 use qlty_check::{CheckFilter, Executor, Planner, Progress, Settings, Tool};
@@ -43,7 +44,7 @@ impl Install {
             }];
         }
 
-        let mut planner = Planner::new(ExecutionVerb::Unspecified, &settings)?;
+        let mut planner = Planner::new(ExecutionVerb::Install, &settings)?;
 
         planner.compute_workspace_entries_strategy()?;
         planner.compute_enabled_plugins()?;

--- a/qlty-cli/src/commands/install.rs
+++ b/qlty-cli/src/commands/install.rs
@@ -33,8 +33,10 @@ impl Install {
         workspace.fetch_sources()?;
         let config = workspace.config()?;
 
-        let mut settings = Settings::default();
-        settings.root = workspace.root.clone();
+        let mut settings = Settings {
+            root: workspace.root.clone(),
+            ..Default::default()
+        };
 
         if let Some(filter) = &self.filter {
             warn!("Filtering plugins: {}", filter);

--- a/qlty-types/src/protos/qlty.analysis.v1.rs
+++ b/qlty-types/src/protos/qlty.analysis.v1.rs
@@ -370,6 +370,7 @@ pub enum ExecutionVerb {
     Check = 1,
     Fmt = 2,
     Validate = 3,
+    Install = 4,
 }
 impl ExecutionVerb {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -378,10 +379,11 @@ impl ExecutionVerb {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            Self::Unspecified => "EXECUTION_VERB_UNSPECIFIED",
-            Self::Check => "EXECUTION_VERB_CHECK",
-            Self::Fmt => "EXECUTION_VERB_FMT",
-            Self::Validate => "EXECUTION_VERB_VALIDATE",
+            ExecutionVerb::Unspecified => "EXECUTION_VERB_UNSPECIFIED",
+            ExecutionVerb::Check => "EXECUTION_VERB_CHECK",
+            ExecutionVerb::Fmt => "EXECUTION_VERB_FMT",
+            ExecutionVerb::Validate => "EXECUTION_VERB_VALIDATE",
+            ExecutionVerb::Install => "EXECUTION_VERB_INSTALL",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -391,6 +393,7 @@ impl ExecutionVerb {
             "EXECUTION_VERB_CHECK" => Some(Self::Check),
             "EXECUTION_VERB_FMT" => Some(Self::Fmt),
             "EXECUTION_VERB_VALIDATE" => Some(Self::Validate),
+            "EXECUTION_VERB_INSTALL" => Some(Self::Install),
             _ => None,
         }
     }

--- a/qlty-types/src/protos/qlty.analysis.v1.serde.rs
+++ b/qlty-types/src/protos/qlty.analysis.v1.serde.rs
@@ -283,6 +283,7 @@ impl serde::Serialize for ExecutionVerb {
             Self::Check => "EXECUTION_VERB_CHECK",
             Self::Fmt => "EXECUTION_VERB_FMT",
             Self::Validate => "EXECUTION_VERB_VALIDATE",
+            Self::Install => "EXECUTION_VERB_INSTALL",
         };
         serializer.serialize_str(variant)
     }
@@ -298,6 +299,7 @@ impl<'de> serde::Deserialize<'de> for ExecutionVerb {
             "EXECUTION_VERB_CHECK",
             "EXECUTION_VERB_FMT",
             "EXECUTION_VERB_VALIDATE",
+            "EXECUTION_VERB_INSTALL",
         ];
 
         struct GeneratedVisitor;
@@ -342,6 +344,7 @@ impl<'de> serde::Deserialize<'de> for ExecutionVerb {
                     "EXECUTION_VERB_CHECK" => Ok(ExecutionVerb::Check),
                     "EXECUTION_VERB_FMT" => Ok(ExecutionVerb::Fmt),
                     "EXECUTION_VERB_VALIDATE" => Ok(ExecutionVerb::Validate),
+                    "EXECUTION_VERB_INSTALL" => Ok(ExecutionVerb::Install),
                     _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
                 }
             }


### PR DESCRIPTION
There were more than a few things different between the tool installation process in qlty install (which was more barebones) and qlty check which was more comprehensive. 

One of which was managing package_files and filters properly causing qlty install to not work as intended in many instances.

This PR aims to make them behave similar as possible while minimizing avoidable duplication.