### PR TITLE
GitSource: use auth-git2 during fetch to use credential configuration from gitconfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "auth-git2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55eead120c93036f531829cf9b85830a474e75ce71169680879d28078321ddc"
+dependencies = [
+ "dirs",
+ "git2",
+ "terminal-prompt",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +801,27 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2045,6 +2077,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,6 +2600,7 @@ name = "qlty-config"
 version = "0.532.0"
 dependencies = [
  "anyhow",
+ "auth-git2",
  "chrono",
  "config",
  "console",
@@ -2757,6 +2796,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3570,6 +3620,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal-prompt"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "572818b3472910acbd5dff46a3413715c18e934b071ab2ba464a7b2c2af16376"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ actix-web = "4.9.0"
 anyhow = { version = "1.0.98", features = ["backtrace"] }
 ar = "0.9.0"
 assert-json-diff = "2.0.2"
+auth-git2 = "0.5.7"
 base64 = "0.22.1"
 bencher = "0.1.5"
 bytesize = "1.3.0"

--- a/qlty-config/Cargo.toml
+++ b/qlty-config/Cargo.toml
@@ -22,6 +22,7 @@ chrono.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+auth-git2.workspace = true
 config.workspace = true
 console.workspace = true
 git2.workspace = true


### PR DESCRIPTION
This allows `qlty install` to respect the global (or repo specific) credential manager / redirect rules that may be needed when fetching.

Fixes the following bug:

```
▶ qlty install

   ERROR   

 > Failed to fetch base refspecs from remote origin https://github.com/some/private_repo
 > 
 > Caused by:
 >     remote authentication required but no callback set; class=Http (34); code=Auth (-16)
```

When using a source:

```toml
[[source]]
name = "custom"
repository = "https://github.com/some/private_repo"
branch = "main"
```