### PR TITLE
fix: Use system certificate roots for downloads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ tree-sitter-rust = "0.21.2"
 tree-sitter-swift = "0.5.0"
 tree-sitter-typescript = "0.21.2"
 trycmd = "0.15.8"
-ureq = { version = "2.12.1", features = ["json", "proxy-from-env"] }
+ureq = { version = "2.12.1", features = ["json", "proxy-from-env", "platform-verifier"] }
 url = "2.5.4"
 uuid = { version = "1.14.0", features = ["v4"] }
 walkdir = "2.5.0"

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -2,6 +2,7 @@ pub mod command_builder;
 mod download;
 mod github;
 pub mod go;
+mod http;
 mod installations;
 pub mod java;
 pub mod node;

--- a/qlty-check/src/tool/download.rs
+++ b/qlty-check/src/tool/download.rs
@@ -1,3 +1,4 @@
+use super::http;
 use super::installations::initialize_installation;
 use super::installations::write_to_file;
 use super::Tool;
@@ -128,7 +129,7 @@ impl Download {
 
         let url = self.url().with_context(|| "Failed to get download URL")?;
 
-        let response = ureq::get(&url)
+        let response = http::get(&url)
             .call()
             .with_context(|| format!("Error downloading file from {url}"))?;
 
@@ -170,7 +171,7 @@ impl Download {
 
         let url = self.url().with_context(|| "Failed to get download URL")?;
 
-        let response = ureq::get(&url)
+        let response = http::get(&url)
             .call()
             .with_context(|| format!("Error downloading file from {url}"))?;
 
@@ -206,7 +207,7 @@ impl Download {
     fn install_targz(&self, directory: &Path) -> Result<()> {
         info!("Downloading (tar.gz) {}", self.url()?);
         let url = self.url()?;
-        let response = ureq::get(&url)
+        let response = http::get(&url)
             .call()
             .with_context(|| format!("Error downloading file from {url}"))?;
         let reader = response.into_reader();
@@ -220,7 +221,7 @@ impl Download {
     fn install_tarxz(&self, directory: &Path) -> Result<()> {
         info!("Downloading (tar.xz) {}", self.url()?);
         let url = self.url()?;
-        let response = ureq::get(&url)
+        let response = http::get(&url)
             .call()
             .with_context(|| format!("Error downloading file from {url}"))?;
 
@@ -277,7 +278,7 @@ impl Download {
     }
 
     fn install_zip(&self, directory: &Path) -> Result<()> {
-        let response = ureq::get(&self.url()?)
+        let response = http::get(&self.url()?)
             .call()
             .with_context(|| format!("Error downloading file from {}", self.url().unwrap()))?;
 

--- a/qlty-check/src/tool/github.rs
+++ b/qlty-check/src/tool/github.rs
@@ -1,3 +1,4 @@
+use super::http;
 use super::installations::{initialize_installation, write_to_file};
 use super::ToolType;
 use crate::tool::Download;
@@ -398,7 +399,7 @@ impl GitHubReleaseTool {
     }
 
     fn get_release_assets(&self, url: &str) -> Result<Vec<serde_json::Value>> {
-        let mut request = ureq::get(url)
+        let mut request = http::get(url)
             .set(
                 "User-Agent",
                 &format!("{}/{}", USER_AGENT_PREFIX, QLTY_VERSION),

--- a/qlty-check/src/tool/http.rs
+++ b/qlty-check/src/tool/http.rs
@@ -1,0 +1,34 @@
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+
+static AGENT: Lazy<ureq::Agent> = Lazy::new(|| {
+    let mut config_builder = rustls::ClientConfig::builder();
+    
+    // Use platform-verifier to get system certificate roots
+    config_builder = config_builder.with_root_certs(
+        rustls_platform_verifier::tls_config_with_native_roots()
+            .expect("Failed to get platform certificate roots")
+            .root_store
+    );
+    
+    let config = config_builder.with_no_client_auth();
+    
+    ureq::AgentBuilder::new()
+        .tls_config(Arc::new(config))
+        .build()
+});
+
+pub fn get(url: &str) -> ureq::Request {
+    AGENT.get(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_creates_request() {
+        let request = get("https://example.com");
+        assert_eq!(request.url(), "https://example.com");
+    }
+}

--- a/qlty-check/src/tool/ruby/sys/linux.rs
+++ b/qlty-check/src/tool/ruby/sys/linux.rs
@@ -1,5 +1,6 @@
 use crate::{
     tool::{
+        http,
         installations::{initialize_installation, write_to_file},
         ruby::PlatformRuby,
     },
@@ -129,7 +130,7 @@ impl RubyLinux {
         installation.download_file_type = Some(".deb".to_string());
         installation.download_binary_name = Some(package.to_string());
 
-        let result = ureq::get(url.as_str()).call();
+        let result = http::get(url.as_str()).call();
         Self::finalize_installation(&mut installation, &result);
 
         match result {

--- a/qlty-cli/src/auth/mod.rs
+++ b/qlty-cli/src/auth/mod.rs
@@ -1,6 +1,7 @@
 mod auth_flow;
 mod credentials;
 
+use crate::http;
 use anyhow::Result;
 use auth_flow::{launch_login_server, AppState};
 use console::style;
@@ -65,7 +66,7 @@ fn auth_via_browser() -> Result<String> {
     );
     thread::sleep(Duration::from_millis(500));
 
-    let open_url = ureq::get(&state.login_url)
+    let open_url = http::get(&state.login_url)
         .query("state", original_state)
         .query("response_type", "token")
         .query("redirect_uri", &server.base_url)

--- a/qlty-cli/src/http.rs
+++ b/qlty-cli/src/http.rs
@@ -1,0 +1,44 @@
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+
+static AGENT: Lazy<ureq::Agent> = Lazy::new(|| {
+    let mut config_builder = rustls::ClientConfig::builder();
+    
+    // Use platform-verifier to get system certificate roots
+    config_builder = config_builder.with_root_certs(
+        rustls_platform_verifier::tls_config_with_native_roots()
+            .expect("Failed to get platform certificate roots")
+            .root_store
+    );
+    
+    let config = config_builder.with_no_client_auth();
+    
+    ureq::AgentBuilder::new()
+        .tls_config(Arc::new(config))
+        .build()
+});
+
+pub fn get(url: &str) -> ureq::Request {
+    AGENT.get(url)
+}
+
+pub fn post(url: &str) -> ureq::Request {
+    AGENT.post(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_creates_request() {
+        let request = get("https://example.com");
+        assert_eq!(request.url(), "https://example.com");
+    }
+
+    #[test]
+    fn test_post_creates_request() {
+        let request = post("https://example.com");
+        assert_eq!(request.url(), "https://example.com");
+    }
+}

--- a/qlty-cli/src/lib.rs
+++ b/qlty-cli/src/lib.rs
@@ -6,6 +6,7 @@ mod errors;
 pub mod exe_name;
 pub mod export;
 pub mod format;
+mod http;
 mod initializer;
 mod logging;
 pub mod shell;

--- a/qlty-cli/src/telemetry/analytics.rs
+++ b/qlty-cli/src/telemetry/analytics.rs
@@ -1,5 +1,6 @@
 // Portions of this code are from https://github.com/meilisearch/segment
 // MIT License: https://github.com/meilisearch/segment/blob/main/LICENSE
+use crate::http;
 use crate::telemetry::locale::current_locale;
 use anyhow::{Context, Result};
 use base64::Engine as _;
@@ -44,7 +45,7 @@ impl AnalyticsClient {
             TRACK_URL, http_basic_authorization, data
         );
 
-        ureq::post(TRACK_URL)
+        http::post(TRACK_URL)
             .set("Authorization", &http_basic_authorization)
             .send_json(data)
             .map(|_| ())

--- a/qlty-cli/src/upgrade.rs
+++ b/qlty-cli/src/upgrade.rs
@@ -1,4 +1,5 @@
 use crate::get_exe_name;
+use crate::http;
 use anyhow::{bail, Context, Result};
 use dialoguer::{theme::ColorfulTheme, Confirm};
 use duct::cmd;
@@ -98,7 +99,7 @@ impl QltyRelease {
             DEFAULT_MANIFEST_LOCATION_URL.to_string()
         };
 
-        let response = ureq::get(&url)
+        let response = http::get(&url)
             .set(
                 "User-Agent",
                 &format!("{}/{}", USER_AGENT_PREFIX, QLTY_VERSION),

--- a/qlty-cloud/src/http.rs
+++ b/qlty-cloud/src/http.rs
@@ -1,0 +1,44 @@
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+
+static AGENT: Lazy<ureq::Agent> = Lazy::new(|| {
+    let mut config_builder = rustls::ClientConfig::builder();
+    
+    // Use platform-verifier to get system certificate roots
+    config_builder = config_builder.with_root_certs(
+        rustls_platform_verifier::tls_config_with_native_roots()
+            .expect("Failed to get platform certificate roots")
+            .root_store
+    );
+    
+    let config = config_builder.with_no_client_auth();
+    
+    ureq::AgentBuilder::new()
+        .tls_config(Arc::new(config))
+        .build()
+});
+
+pub fn get(url: &str) -> ureq::Request {
+    AGENT.get(url)
+}
+
+pub fn post(url: &str) -> ureq::Request {
+    AGENT.post(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_creates_request() {
+        let request = get("https://example.com");
+        assert_eq!(request.url(), "https://example.com");
+    }
+
+    #[test]
+    fn test_post_creates_request() {
+        let request = post("https://example.com");
+        assert_eq!(request.url(), "https://example.com");
+    }
+}

--- a/qlty-cloud/src/lib.rs
+++ b/qlty-cloud/src/lib.rs
@@ -1,3 +1,5 @@
+mod http;
+
 use anyhow::{anyhow, bail, Result};
 use qlty_config::version::QLTY_VERSION;
 use qlty_types::tests::v1::CoverageMetadata;
@@ -43,12 +45,12 @@ impl Client {
 
     pub fn post(&self, path: &str) -> Request {
         let url = self.build_url(path);
-        self.build_request(ureq::post(&url))
+        self.build_request(http::post(&url))
     }
 
     pub fn get(&self, path: &str) -> Request {
         let url = self.build_url(path);
-        self.build_request(ureq::get(&url))
+        self.build_request(http::get(&url))
     }
 
     fn build_url(&self, path: &str) -> String {

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -1,5 +1,6 @@
 use super::{Language, ReleaseDef};
 use crate::config::DownloadDef;
+use crate::http;
 use crate::QltyConfig;
 use anyhow::{Context, Result};
 use qlty_types::analysis::v1::{Category, Level};
@@ -695,7 +696,7 @@ pub struct PluginFetch {
 
 impl PluginFetch {
     pub fn download_file_to(&self, directories: &[PathBuf]) -> Result<()> {
-        let response = ureq::get(&self.url)
+        let response = http::get(&self.url)
             .call()
             .with_context(|| format!("Failed to get url: {}", &self.url))?;
 

--- a/qlty-config/src/http.rs
+++ b/qlty-config/src/http.rs
@@ -1,0 +1,34 @@
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+
+static AGENT: Lazy<ureq::Agent> = Lazy::new(|| {
+    let mut config_builder = rustls::ClientConfig::builder();
+    
+    // Use platform-verifier to get system certificate roots
+    config_builder = config_builder.with_root_certs(
+        rustls_platform_verifier::tls_config_with_native_roots()
+            .expect("Failed to get platform certificate roots")
+            .root_store
+    );
+    
+    let config = config_builder.with_no_client_auth();
+    
+    ureq::AgentBuilder::new()
+        .tls_config(Arc::new(config))
+        .build()
+});
+
+pub fn get(url: &str) -> ureq::Request {
+    AGENT.get(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_creates_request() {
+        let request = get("https://example.com");
+        assert_eq!(request.url(), "https://example.com");
+    }
+}

--- a/qlty-config/src/lib.rs
+++ b/qlty-config/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+mod http;
 mod library;
 mod migration;
 pub mod sources;

--- a/qlty-coverage/src/http.rs
+++ b/qlty-coverage/src/http.rs
@@ -1,0 +1,54 @@
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+
+static AGENT: Lazy<ureq::Agent> = Lazy::new(|| {
+    let mut config_builder = rustls::ClientConfig::builder();
+    
+    // Use platform-verifier to get system certificate roots
+    config_builder = config_builder.with_root_certs(
+        rustls_platform_verifier::tls_config_with_native_roots()
+            .expect("Failed to get platform certificate roots")
+            .root_store
+    );
+    
+    let config = config_builder.with_no_client_auth();
+    
+    ureq::AgentBuilder::new()
+        .tls_config(Arc::new(config))
+        .build()
+});
+
+pub fn get(url: &str) -> ureq::Request {
+    AGENT.get(url)
+}
+
+pub fn post(url: &str) -> ureq::Request {
+    AGENT.post(url)
+}
+
+pub fn put(url: &str) -> ureq::Request {
+    AGENT.put(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_creates_request() {
+        let request = get("https://example.com");
+        assert_eq!(request.url(), "https://example.com");
+    }
+
+    #[test]
+    fn test_post_creates_request() {
+        let request = post("https://example.com");
+        assert_eq!(request.url(), "https://example.com");
+    }
+
+    #[test]
+    fn test_put_creates_request() {
+        let request = put("https://example.com");
+        assert_eq!(request.url(), "https://example.com");
+    }
+}

--- a/qlty-coverage/src/lib.rs
+++ b/qlty-coverage/src/lib.rs
@@ -3,6 +3,7 @@ mod env;
 pub mod export;
 pub mod formats;
 pub mod git;
+mod http;
 pub mod parser;
 pub mod print;
 pub mod publish;

--- a/qlty-coverage/src/publish/upload.rs
+++ b/qlty-coverage/src/publish/upload.rs
@@ -1,4 +1,5 @@
 use crate::export::CoverageExport;
+use crate::http;
 use crate::publish::Report;
 use anyhow::{anyhow, bail};
 use anyhow::{Context, Result};
@@ -78,7 +79,7 @@ impl Upload {
         content_type: &str,
         data: Vec<u8>,
     ) -> Result<(), anyhow::Error> {
-        let response = ureq::put(url)
+        let response = http::put(url)
             .set("Content-Type", content_type)
             .send_bytes(&data)
             .map_err(|err| {


### PR DESCRIPTION
Enable platform-verifier feature for ureq and create HTTP helper modules that use rustls_platform_verifier to respect system certificate stores.

This fixes downloads failing on OpenAI ChatGPT Codex and other environments that use TLS proxies with custom certificate authorities.

Changes:
- Added platform-verifier feature to ureq in workspace Cargo.toml  
- Created HTTP helper modules in all crates that use ureq
- Updated all ureq::get(), ureq::post(), and ureq::put() calls
- System certificate roots now used instead of Mozilla's built-in ones

Fixes #2072

🤖 Generated with [Claude Code](https://claude.ai/code)