### PR TITLE
feat(config): Reject invalid configuration combinations

### DIFF
--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -206,7 +206,7 @@ impl Builder {
 
         for enabled_plugin in &mut config.plugin {
             enabled_plugin.validate().with_context(|| {
-                format!("Invalid configuration for plugin '{}'", enabled_plugin.name)
+                format!("Configuration error for plugin '{}'", enabled_plugin.name)
             })?;
             let plugin_definition =
                 config
@@ -338,11 +338,17 @@ mod test {
         let result = Builder::toml_to_config(Table(invalid_config));
         assert!(result.is_err());
 
-        let error_message = result.unwrap_err().to_string();
-        assert!(error_message.contains("rubocop"));
-        assert!(error_message.contains("package_file"));
-        assert!(error_message.contains("extra_packages"));
-        assert!(error_message.contains("mutually exclusive"));
+        let error = result.unwrap_err();
+        let error_chain = error
+            .chain()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(error_chain.contains("rubocop"));
+        assert!(error_chain.contains("package_file"));
+        assert!(error_chain.contains("extra_packages"));
+        assert!(error_chain.contains("mutually exclusive"));
     }
 
     #[test]

--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -386,4 +386,53 @@ mod test {
         let result = Builder::toml_to_config(Table(valid_config));
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_validate_plugin_with_package_filters_but_no_package_file() {
+        let invalid_config = toml! {
+            config_version = "0"
+
+            [[plugin]]
+            name = "rubocop"
+            version = "1.56.3"
+            package_filters = ["some-filter"]
+
+            [plugins.definitions.rubocop]
+            runtime = "ruby"
+        };
+
+        let result = Builder::toml_to_config(Table(invalid_config));
+        assert!(result.is_err());
+
+        let error = result.unwrap_err();
+        let error_chain = error
+            .chain()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(error_chain.contains("rubocop"));
+        assert!(error_chain.contains("package_filters"));
+        assert!(error_chain.contains("package_file"));
+        assert!(error_chain.contains("requires"));
+    }
+
+    #[test]
+    fn test_validate_plugin_with_package_filters_and_package_file() {
+        let valid_config = toml! {
+            config_version = "0"
+
+            [[plugin]]
+            name = "rubocop"
+            version = "1.56.3"
+            package_file = "Gemfile"
+            package_filters = ["some-filter"]
+
+            [plugins.definitions.rubocop]
+            runtime = "ruby"
+        };
+
+        let result = Builder::toml_to_config(Table(valid_config));
+        assert!(result.is_ok());
+    }
 }

--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -324,20 +324,20 @@ mod test {
     fn test_validate_plugin_with_mutually_exclusive_options() {
         let invalid_config = toml! {
             config_version = "0"
-            
+
             [[plugin]]
             name = "rubocop"
             version = "1.56.3"
             extra_packages = ["rubocop-factory_bot@2.25.1"]
             package_file = "Gemfile"
-            
+
             [plugins.definitions.rubocop]
             runtime = "ruby"
         };
 
         let result = Builder::toml_to_config(Table(invalid_config));
         assert!(result.is_err());
-        
+
         let error_message = result.unwrap_err().to_string();
         assert!(error_message.contains("rubocop"));
         assert!(error_message.contains("package_file"));
@@ -349,12 +349,12 @@ mod test {
     fn test_validate_plugin_with_package_file_only() {
         let valid_config = toml! {
             config_version = "0"
-            
+
             [[plugin]]
             name = "rubocop"
             version = "1.56.3"
             package_file = "Gemfile"
-            
+
             [plugins.definitions.rubocop]
             runtime = "ruby"
         };
@@ -367,12 +367,12 @@ mod test {
     fn test_validate_plugin_with_extra_packages_only() {
         let valid_config = toml! {
             config_version = "0"
-            
+
             [[plugin]]
             name = "rubocop"
             version = "1.56.3"
             extra_packages = ["rubocop-factory_bot@2.25.1"]
-            
+
             [plugins.definitions.rubocop]
             runtime = "ruby"
         };

--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -182,7 +182,7 @@ impl Builder {
         }
     }
 
-    fn toml_to_config(toml: Value) -> Result<QltyConfig> {
+    pub fn toml_to_config(toml: Value) -> Result<QltyConfig> {
         let mut config: QltyConfig = Self::parse_toml_as_config(toml)?;
         Self::insert_ignores_from_exclude_patterns(&mut config);
         let config = Self::post_process_config(config);
@@ -335,7 +335,7 @@ mod test {
             runtime = "ruby"
         };
 
-        let result = Builder::parse_toml_as_config(Table(invalid_config));
+        let result = Builder::toml_to_config(Table(invalid_config));
         assert!(result.is_err());
         
         let error_message = result.unwrap_err().to_string();
@@ -359,7 +359,7 @@ mod test {
             runtime = "ruby"
         };
 
-        let result = Builder::parse_toml_as_config(Table(valid_config));
+        let result = Builder::toml_to_config(Table(valid_config));
         assert!(result.is_ok());
     }
 
@@ -377,7 +377,7 @@ mod test {
             runtime = "ruby"
         };
 
-        let result = Builder::parse_toml_as_config(Table(valid_config));
+        let result = Builder::toml_to_config(Table(valid_config));
         assert!(result.is_ok());
     }
 }

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -945,7 +945,7 @@ mod tests {
 
         let result = plugin.validate();
         assert!(result.is_err());
-        
+
         let error_message = result.unwrap_err().to_string();
         assert!(error_message.contains("test-plugin"));
         assert!(error_message.contains("package_file"));


### PR DESCRIPTION
Fixes #1946

This PR implements validation to reject invalid configuration combinations in qlty.toml files.

## Changes

- Add validation to `EnabledPlugin` to detect mutually exclusive options
- `package_file` and `extra_packages` cannot be used together
- Provide clear error message when both options are specified
- Add comprehensive unit tests and integration tests
- Validation occurs during configuration parsing/post-processing

## Testing

The implementation includes tests that verify:
- Valid configurations with only `package_file`
- Valid configurations with only `extra_packages`
- Valid configurations with neither option
- Error handling when both options are specified

Generated with [Claude Code](https://claude.ai/code)