### PR TITLE
Add log for ignored coverage paths

### DIFF
--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -381,6 +381,18 @@ impl Publish {
             }
         );
 
+        if report.ignored_paths_count > 0 {
+            eprintln!(
+                "    {} {} ignored",
+                report.ignored_paths_count.to_formatted_string(&Locale::en),
+                if report.ignored_paths_count == 1 {
+                    "path"
+                } else {
+                    "paths"
+                }
+            );
+        }
+
         let mut missing_files = report.missing_files.iter().collect::<Vec<_>>();
         missing_files.sort();
 

--- a/qlty-cli/tests/cmd/coverage/files_exist.stderr
+++ b/qlty-cli/tests/cmd/coverage/files_exist.stderr
@@ -24,6 +24,7 @@ https://qlty.sh/d/coverage
  COVERAGE DATA 
 
     2 unique code file paths
+    1 path ignored
     1 path is missing on disk (50.0%)
 
     Missing code files:

--- a/qlty-cli/tests/cmd/coverage/files_exist.stdout
+++ b/qlty-cli/tests/cmd/coverage/files_exist.stdout
@@ -96,5 +96,6 @@
     "omitted_lines": 26,
     "total_lines": 52,
     "coverage_percentage": 92.3076923076923
-  }
+  },
+  "ignored_paths_count": 1
 }

--- a/qlty-cli/tests/cmd/coverage/json.stdout
+++ b/qlty-cli/tests/cmd/coverage/json.stdout
@@ -102,5 +102,6 @@
     "omitted_lines": 26,
     "total_lines": 52,
     "coverage_percentage": 92.3076923076923
-  }
+  },
+  "ignored_paths_count": 0
 }

--- a/qlty-cli/tests/cmd/coverage/overrides.stdout
+++ b/qlty-cli/tests/cmd/coverage/overrides.stdout
@@ -102,5 +102,6 @@
     "omitted_lines": 26,
     "total_lines": 52,
     "coverage_percentage": 92.3076923076923
-  }
+  },
+  "ignored_paths_count": 0
 }

--- a/qlty-coverage/src/publish/processor.rs
+++ b/qlty-coverage/src/publish/processor.rs
@@ -25,6 +25,8 @@ impl Processor {
             f.tag = self.plan.metadata.tag.clone();
         });
 
+        let pre_transform_file_coverages_count = self.results.file_coverages.len();
+
         let mut transformed_file_coverages = self
             .results
             .file_coverages
@@ -62,6 +64,8 @@ impl Processor {
         }
 
         let totals = CoverageMetrics::calculate(&transformed_file_coverages);
+        let ignored_paths_count =
+            pre_transform_file_coverages_count - transformed_file_coverages.len();
 
         Ok(Report {
             metadata: self.plan.metadata.clone(),
@@ -70,6 +74,7 @@ impl Processor {
             totals,
             missing_files,
             found_files,
+            ignored_paths_count,
         })
     }
 

--- a/qlty-coverage/src/publish/report.rs
+++ b/qlty-coverage/src/publish/report.rs
@@ -19,6 +19,7 @@ pub struct Report {
     pub missing_files: HashSet<String>,
 
     pub totals: CoverageMetrics,
+    pub ignored_paths_count: usize,
 }
 
 impl Report {

--- a/qlty-coverage/src/validate.rs
+++ b/qlty-coverage/src/validate.rs
@@ -104,6 +104,7 @@ mod tests {
             found_files: HashSet::new(),
             missing_files: HashSet::new(),
             totals: Default::default(),
+            ignored_paths_count: 0,
         }
     }
 


### PR DESCRIPTION
Currently if any file coverages are ignored there is no way to communicate that leading to confusion among customers and support alike. 

This PR adds log line when coverage files are ignored.