### PR TITLE
feat: Support Git fetches through HTTPS proxies

### DIFF
--- a/qlty-config/src/sources/git_source.rs
+++ b/qlty-config/src/sources/git_source.rs
@@ -297,7 +297,7 @@ impl GitSource {
 
         callbacks.credentials(|url, username, allowed| {
             let config = git2::Config::open_default()
-                .map_err(|e| git2::Error::from_str(&format!("Failed to open Git configuration: {}", e)))?;
+                .map_err(|e| git2::Error::from_str(&format!("Failed to open Git configuration: {e}")))?;
             let authenticator = GitAuthenticator::default();
             let mut credential_fn = authenticator.credentials(&config);
             credential_fn(url, username, allowed)

--- a/qlty-config/src/sources/git_source.rs
+++ b/qlty-config/src/sources/git_source.rs
@@ -1,4 +1,5 @@
 use super::{source::SourceFetch, LocalSource, Source, SourceFile};
+use crate::configure_proxy_options;
 use crate::Library;
 use anyhow::{Context, Result};
 use auth_git2::GitAuthenticator;
@@ -278,16 +279,7 @@ impl GitSource {
         let mut fetch_options = FetchOptions::new();
 
         let mut proxy_options = git2::ProxyOptions::new();
-
-        if let Ok(https_proxy) = std::env::var("HTTPS_PROXY") {
-            debug!("Using HTTPS proxy: {}", https_proxy);
-            proxy_options.url(&https_proxy);
-        } else if let Ok(http_proxy) = std::env::var("HTTP_PROXY") {
-            debug!("Using HTTP proxy: {}", http_proxy);
-            proxy_options.url(&http_proxy);
-        }
-
-        proxy_options.auto();
+        configure_proxy_options!(proxy_options);
         fetch_options.proxy_options(proxy_options);
 
         let mut callbacks = RemoteCallbacks::new();

--- a/qlty-config/src/sources/git_source.rs
+++ b/qlty-config/src/sources/git_source.rs
@@ -1,5 +1,4 @@
 use super::{source::SourceFetch, LocalSource, Source, SourceFile};
-use crate::configure_proxy_options;
 use crate::Library;
 use anyhow::{Context, Result};
 use auth_git2::GitAuthenticator;
@@ -279,7 +278,7 @@ impl GitSource {
         let mut fetch_options = FetchOptions::new();
 
         let mut proxy_options = git2::ProxyOptions::new();
-        configure_proxy_options!(proxy_options);
+        crate::sources::source::configure_proxy_options(&mut proxy_options);
         fetch_options.proxy_options(proxy_options);
 
         let mut callbacks = RemoteCallbacks::new();

--- a/qlty-config/src/sources/git_source.rs
+++ b/qlty-config/src/sources/git_source.rs
@@ -213,7 +213,7 @@ impl GitSource {
 
     fn fetch(&self, _repository: &Repository, origin: &mut Remote, branches: &[&str]) -> Result<()> {
         let mut fetch_options = self.create_fetch_options()?;
-        
+
         // Per libgit2, passing an empty array of refspecs fetches base refspecs
         origin
             .fetch(branches, Some(&mut fetch_options), None)
@@ -277,7 +277,7 @@ impl GitSource {
     fn create_fetch_options(&self) -> Result<FetchOptions> {
         let mut fetch_options = FetchOptions::new();
         let mut proxy_options = ProxyOptions::new();
-        
+
         // Configure proxy from environment variables
         if let Ok(https_proxy) = std::env::var("HTTPS_PROXY") {
             debug!("Using HTTPS proxy: {}", https_proxy);
@@ -286,14 +286,14 @@ impl GitSource {
             debug!("Using HTTP proxy: {}", http_proxy);
             proxy_options.url(&http_proxy);
         }
-        
+
         // Set proxy auto-detect to use system configuration
         proxy_options.auto();
         fetch_options.proxy_options(proxy_options);
-        
+
         // Configure remote callbacks for authentication
         let mut callbacks = RemoteCallbacks::new();
-        
+
         // Use GitAuthenticator::default() in the closure to avoid lifetime issues
         callbacks.credentials(|url, username, allowed| {
             let config = git2::Config::open_default().unwrap_or_else(|_| git2::Config::new().unwrap());
@@ -301,13 +301,13 @@ impl GitSource {
             let mut credential_fn = authenticator.credentials(&config);
             credential_fn(url, username, allowed)
         });
-        
-        // Configure certificate checking to validate against system certificate roots  
+
+        // Configure certificate checking to validate against system certificate roots
         // Use default certificate validation behavior (validates against system certificate store)
         // By not setting a certificate_check callback, git2 will use the default validation
-        
+
         fetch_options.remote_callbacks(callbacks);
-        
+
         Ok(fetch_options)
     }
 }

--- a/qlty-config/src/sources/git_source.rs
+++ b/qlty-config/src/sources/git_source.rs
@@ -1,4 +1,5 @@
 use super::{source::SourceFetch, LocalSource, Source, SourceFile};
+use crate::sources::source::configure_proxy_options;
 use crate::Library;
 use anyhow::{Context, Result};
 use auth_git2::GitAuthenticator;
@@ -278,7 +279,7 @@ impl GitSource {
         let mut fetch_options = FetchOptions::new();
 
         let mut proxy_options = git2::ProxyOptions::new();
-        crate::sources::source::configure_proxy_options(&mut proxy_options);
+        configure_proxy_options(&mut proxy_options);
         fetch_options.proxy_options(proxy_options);
 
         let mut callbacks = RemoteCallbacks::new();

--- a/qlty-config/src/sources/source.rs
+++ b/qlty-config/src/sources/source.rs
@@ -7,7 +7,7 @@ use globset::{Glob, GlobSetBuilder};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use toml::Value;
-use tracing::{debug, trace};
+use tracing::trace;
 
 const SOURCE_PARSE_ERROR: &str = r#"There was an error reading configuration from one of your declared Sources.
 

--- a/qlty-config/src/sources/source.rs
+++ b/qlty-config/src/sources/source.rs
@@ -7,7 +7,7 @@ use globset::{Glob, GlobSetBuilder};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use toml::Value;
-use tracing::trace;
+use tracing::{debug, trace};
 
 const SOURCE_PARSE_ERROR: &str = r#"There was an error reading configuration from one of your declared Sources.
 
@@ -16,6 +16,32 @@ Please make sure you are using the latest version of the CLI with `qlty upgrade`
 Also, please make sure you are specifying the latest source tag in your qlty.toml file.
 
 For more information, please visit: https://qlty.io/docs/troubleshooting/source-parse-error"#;
+
+/// Macro to configure proxy options for git operations
+///
+/// This macro sets up proxy configuration by:
+/// 1. Checking for lowercase environment variables first (https_proxy, http_proxy)
+/// 2. Falling back to uppercase versions (HTTPS_PROXY, HTTP_PROXY)
+/// 3. Enabling auto-detection for system proxy configuration
+#[macro_export]
+macro_rules! configure_proxy_options {
+    ($proxy_options:ident) => {
+        // Check for lowercase first, then uppercase (prefer lowercase)
+        if let Ok(https_proxy) =
+            std::env::var("https_proxy").or_else(|_| std::env::var("HTTPS_PROXY"))
+        {
+            tracing::debug!("Using HTTPS proxy: {}", https_proxy);
+            $proxy_options.url(&https_proxy);
+        } else if let Ok(http_proxy) =
+            std::env::var("http_proxy").or_else(|_| std::env::var("HTTP_PROXY"))
+        {
+            tracing::debug!("Using HTTP proxy: {}", http_proxy);
+            $proxy_options.url(&http_proxy);
+        }
+
+        $proxy_options.auto();
+    };
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceFile {

--- a/qlty-config/src/sources/source.rs
+++ b/qlty-config/src/sources/source.rs
@@ -17,20 +17,6 @@ Also, please make sure you are specifying the latest source tag in your qlty.tom
 
 For more information, please visit: https://qlty.io/docs/troubleshooting/source-parse-error"#;
 
-pub fn configure_proxy_options() -> git2::ProxyOptions {
-    let mut proxy_options = git2::ProxyOptions::new();
-
-    if let Ok(https_proxy) = std::env::var("HTTPS_PROXY") {
-        debug!("Using HTTPS proxy: {}", https_proxy);
-        proxy_options.url(&https_proxy);
-    } else if let Ok(http_proxy) = std::env::var("HTTP_PROXY") {
-        debug!("Using HTTP proxy: {}", http_proxy);
-        proxy_options.url(&http_proxy);
-    }
-
-    proxy_options.auto();
-    proxy_options
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceFile {

--- a/qlty-config/src/sources/source.rs
+++ b/qlty-config/src/sources/source.rs
@@ -4,10 +4,11 @@ use crate::{QltyConfig, TomlMerge};
 use anyhow::{Context, Result};
 use config::File;
 use globset::{Glob, GlobSetBuilder};
+use std::env;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use toml::Value;
-use tracing::trace;
+use tracing::{debug, trace};
 
 const SOURCE_PARSE_ERROR: &str = r#"There was an error reading configuration from one of your declared Sources.
 
@@ -25,14 +26,11 @@ For more information, please visit: https://qlty.io/docs/troubleshooting/source-
 /// 3. Enabling auto-detection for system proxy configuration
 pub fn configure_proxy_options(proxy_options: &mut git2::ProxyOptions) {
     // Check for lowercase first, then uppercase (prefer lowercase)
-    if let Ok(https_proxy) = std::env::var("https_proxy").or_else(|_| std::env::var("HTTPS_PROXY"))
-    {
-        trace!("Using HTTPS proxy: {}", https_proxy);
+    if let Ok(https_proxy) = env::var("https_proxy").or_else(|_| env::var("HTTPS_PROXY")) {
+        debug!("Using HTTPS proxy: {}", https_proxy);
         proxy_options.url(&https_proxy);
-    } else if let Ok(http_proxy) =
-        std::env::var("http_proxy").or_else(|_| std::env::var("HTTP_PROXY"))
-    {
-        trace!("Using HTTP proxy: {}", http_proxy);
+    } else if let Ok(http_proxy) = env::var("http_proxy").or_else(|_| env::var("HTTP_PROXY")) {
+        debug!("Using HTTP proxy: {}", http_proxy);
         proxy_options.url(&http_proxy);
     }
 

--- a/qlty-config/src/sources/source.rs
+++ b/qlty-config/src/sources/source.rs
@@ -7,7 +7,7 @@ use globset::{Glob, GlobSetBuilder};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use toml::Value;
-use tracing::trace;
+use tracing::{debug, trace};
 
 const SOURCE_PARSE_ERROR: &str = r#"There was an error reading configuration from one of your declared Sources.
 
@@ -16,6 +16,21 @@ Please make sure you are using the latest version of the CLI with `qlty upgrade`
 Also, please make sure you are specifying the latest source tag in your qlty.toml file.
 
 For more information, please visit: https://qlty.io/docs/troubleshooting/source-parse-error"#;
+
+pub fn configure_proxy_options() -> git2::ProxyOptions {
+    let mut proxy_options = git2::ProxyOptions::new();
+
+    if let Ok(https_proxy) = std::env::var("HTTPS_PROXY") {
+        debug!("Using HTTPS proxy: {}", https_proxy);
+        proxy_options.url(&https_proxy);
+    } else if let Ok(http_proxy) = std::env::var("HTTP_PROXY") {
+        debug!("Using HTTP proxy: {}", http_proxy);
+        proxy_options.url(&http_proxy);
+    }
+
+    proxy_options.auto();
+    proxy_options
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceFile {

--- a/qlty-config/src/sources/source.rs
+++ b/qlty-config/src/sources/source.rs
@@ -17,7 +17,6 @@ Also, please make sure you are specifying the latest source tag in your qlty.tom
 
 For more information, please visit: https://qlty.io/docs/troubleshooting/source-parse-error"#;
 
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceFile {
     pub path: PathBuf,

--- a/qlty-config/src/sources/source.rs
+++ b/qlty-config/src/sources/source.rs
@@ -17,30 +17,26 @@ Also, please make sure you are specifying the latest source tag in your qlty.tom
 
 For more information, please visit: https://qlty.io/docs/troubleshooting/source-parse-error"#;
 
-/// Macro to configure proxy options for git operations
+/// Configure proxy options for git operations
 ///
-/// This macro sets up proxy configuration by:
+/// This function sets up proxy configuration by:
 /// 1. Checking for lowercase environment variables first (https_proxy, http_proxy)
 /// 2. Falling back to uppercase versions (HTTPS_PROXY, HTTP_PROXY)
 /// 3. Enabling auto-detection for system proxy configuration
-#[macro_export]
-macro_rules! configure_proxy_options {
-    ($proxy_options:ident) => {
-        // Check for lowercase first, then uppercase (prefer lowercase)
-        if let Ok(https_proxy) =
-            std::env::var("https_proxy").or_else(|_| std::env::var("HTTPS_PROXY"))
-        {
-            tracing::debug!("Using HTTPS proxy: {}", https_proxy);
-            $proxy_options.url(&https_proxy);
-        } else if let Ok(http_proxy) =
-            std::env::var("http_proxy").or_else(|_| std::env::var("HTTP_PROXY"))
-        {
-            tracing::debug!("Using HTTP proxy: {}", http_proxy);
-            $proxy_options.url(&http_proxy);
-        }
+pub fn configure_proxy_options(proxy_options: &mut git2::ProxyOptions) {
+    // Check for lowercase first, then uppercase (prefer lowercase)
+    if let Ok(https_proxy) = std::env::var("https_proxy").or_else(|_| std::env::var("HTTPS_PROXY"))
+    {
+        trace!("Using HTTPS proxy: {}", https_proxy);
+        proxy_options.url(&https_proxy);
+    } else if let Ok(http_proxy) =
+        std::env::var("http_proxy").or_else(|_| std::env::var("HTTP_PROXY"))
+    {
+        trace!("Using HTTP proxy: {}", http_proxy);
+        proxy_options.url(&http_proxy);
+    }
 
-        $proxy_options.auto();
-    };
+    proxy_options.auto();
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/qlty-config/src/sources/source_upgrade.rs
+++ b/qlty-config/src/sources/source_upgrade.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::{fmt::Debug, sync::Arc};
 use toml_edit::{value, DocumentMut, Item};
 
-use crate::Workspace;
+use crate::{configure_proxy_options, Workspace};
 
 #[derive(Debug, Default)]
 struct RemoteHeadRetriever;
@@ -19,19 +19,7 @@ impl HeadRetriever for RemoteHeadRetriever {
         let mut remote = git2::Remote::create_detached(source_url)?;
 
         let mut proxy_options = git2::ProxyOptions::new();
-
-        // Check for lowercase first, then uppercase (prefer lowercase)
-        if let Ok(https_proxy) =
-            std::env::var("https_proxy").or_else(|_| std::env::var("HTTPS_PROXY"))
-        {
-            proxy_options.url(&https_proxy);
-        } else if let Ok(http_proxy) =
-            std::env::var("http_proxy").or_else(|_| std::env::var("HTTP_PROXY"))
-        {
-            proxy_options.url(&http_proxy);
-        }
-
-        proxy_options.auto();
+        configure_proxy_options!(proxy_options);
         let callbacks = git2::RemoteCallbacks::new();
 
         remote.connect_auth(git2::Direction::Fetch, Some(callbacks), Some(proxy_options))?;

--- a/qlty-config/src/sources/source_upgrade.rs
+++ b/qlty-config/src/sources/source_upgrade.rs
@@ -4,7 +4,9 @@ use std::fs;
 use std::{fmt::Debug, sync::Arc};
 use toml_edit::{value, DocumentMut, Item};
 
+use crate::sources::source::configure_proxy_options;
 use crate::Workspace;
+
 
 #[derive(Debug, Default)]
 struct RemoteHeadRetriever;
@@ -18,19 +20,8 @@ impl HeadRetriever for RemoteHeadRetriever {
         let mut names = vec![];
         let mut remote = git2::Remote::create_detached(source_url)?;
 
-        // Configure proxy options for remote connection
-        let mut proxy_options = git2::ProxyOptions::new();
-        if let Ok(https_proxy) = std::env::var("HTTPS_PROXY") {
-            proxy_options.url(&https_proxy);
-        } else if let Ok(http_proxy) = std::env::var("HTTP_PROXY") {
-            proxy_options.url(&http_proxy);
-        }
-        proxy_options.auto();
-
-        // Create connection options with proxy support
+        let proxy_options = configure_proxy_options();
         let callbacks = git2::RemoteCallbacks::new();
-        // Use default certificate validation behavior (validates against system certificate store)
-        // By not setting a certificate_check callback, git2 will use the default validation
 
         remote.connect_auth(git2::Direction::Fetch, Some(callbacks), Some(proxy_options))?;
 

--- a/qlty-config/src/sources/source_upgrade.rs
+++ b/qlty-config/src/sources/source_upgrade.rs
@@ -6,7 +6,6 @@ use toml_edit::{value, DocumentMut, Item};
 
 use crate::Workspace;
 
-
 #[derive(Debug, Default)]
 struct RemoteHeadRetriever;
 
@@ -19,15 +18,19 @@ impl HeadRetriever for RemoteHeadRetriever {
         let mut names = vec![];
         let mut remote = git2::Remote::create_detached(source_url)?;
 
-        // Configure proxy options
         let mut proxy_options = git2::ProxyOptions::new();
-        
-        if let Ok(https_proxy) = std::env::var("HTTPS_PROXY") {
+
+        // Check for lowercase first, then uppercase (prefer lowercase)
+        if let Ok(https_proxy) =
+            std::env::var("https_proxy").or_else(|_| std::env::var("HTTPS_PROXY"))
+        {
             proxy_options.url(&https_proxy);
-        } else if let Ok(http_proxy) = std::env::var("HTTP_PROXY") {
+        } else if let Ok(http_proxy) =
+            std::env::var("http_proxy").or_else(|_| std::env::var("HTTP_PROXY"))
+        {
             proxy_options.url(&http_proxy);
         }
-        
+
         proxy_options.auto();
         let callbacks = git2::RemoteCallbacks::new();
 

--- a/qlty-config/src/sources/source_upgrade.rs
+++ b/qlty-config/src/sources/source_upgrade.rs
@@ -17,7 +17,7 @@ impl HeadRetriever for RemoteHeadRetriever {
     fn remote_fetch_heads(&self, source_url: &str) -> Result<Vec<String>> {
         let mut names = vec![];
         let mut remote = git2::Remote::create_detached(source_url)?;
-        
+
         // Configure proxy options for remote connection
         let mut proxy_options = git2::ProxyOptions::new();
         if let Ok(https_proxy) = std::env::var("HTTPS_PROXY") {
@@ -26,12 +26,12 @@ impl HeadRetriever for RemoteHeadRetriever {
             proxy_options.url(&http_proxy);
         }
         proxy_options.auto();
-        
+
         // Create connection options with proxy support
         let callbacks = git2::RemoteCallbacks::new();
         // Use default certificate validation behavior (validates against system certificate store)
         // By not setting a certificate_check callback, git2 will use the default validation
-        
+
         remote.connect_auth(git2::Direction::Fetch, Some(callbacks), Some(proxy_options))?;
 
         for head in remote.list()? {

--- a/qlty-config/src/sources/source_upgrade.rs
+++ b/qlty-config/src/sources/source_upgrade.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::{fmt::Debug, sync::Arc};
 use toml_edit::{value, DocumentMut, Item};
 
-use crate::{configure_proxy_options, Workspace};
+use crate::Workspace;
 
 #[derive(Debug, Default)]
 struct RemoteHeadRetriever;
@@ -19,7 +19,7 @@ impl HeadRetriever for RemoteHeadRetriever {
         let mut remote = git2::Remote::create_detached(source_url)?;
 
         let mut proxy_options = git2::ProxyOptions::new();
-        configure_proxy_options!(proxy_options);
+        crate::sources::source::configure_proxy_options(&mut proxy_options);
         let callbacks = git2::RemoteCallbacks::new();
 
         remote.connect_auth(git2::Direction::Fetch, Some(callbacks), Some(proxy_options))?;

--- a/qlty-config/src/sources/source_upgrade.rs
+++ b/qlty-config/src/sources/source_upgrade.rs
@@ -28,10 +28,9 @@ impl HeadRetriever for RemoteHeadRetriever {
         proxy_options.auto();
         
         // Create connection options with proxy support
-        let mut callbacks = git2::RemoteCallbacks::new();
-        callbacks.certificate_check(|_cert, _valid| {
-            Ok(git2::CertificateCheckStatus::CertificateOk) // Allow certificates for proxy scenarios
-        });
+        let callbacks = git2::RemoteCallbacks::new();
+        // Use default certificate validation behavior (validates against system certificate store)
+        // By not setting a certificate_check callback, git2 will use the default validation
         
         remote.connect_auth(git2::Direction::Fetch, Some(callbacks), Some(proxy_options))?;
 

--- a/qlty-config/src/sources/source_upgrade.rs
+++ b/qlty-config/src/sources/source_upgrade.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::{fmt::Debug, sync::Arc};
 use toml_edit::{value, DocumentMut, Item};
 
-use crate::Workspace;
+use crate::{sources::source::configure_proxy_options, Workspace};
 
 #[derive(Debug, Default)]
 struct RemoteHeadRetriever;
@@ -19,7 +19,7 @@ impl HeadRetriever for RemoteHeadRetriever {
         let mut remote = git2::Remote::create_detached(source_url)?;
 
         let mut proxy_options = git2::ProxyOptions::new();
-        crate::sources::source::configure_proxy_options(&mut proxy_options);
+        configure_proxy_options(&mut proxy_options);
         let callbacks = git2::RemoteCallbacks::new();
 
         remote.connect_auth(git2::Direction::Fetch, Some(callbacks), Some(proxy_options))?;


### PR DESCRIPTION
Fixes #2074

This PR addresses the issue where Git fetches of sources don't use HTTPS proxies, which was causing failures in environments like OpenAI ChatGPT Codex that require HTTPS proxying.

## Changes

- Replace `GitAuthenticator::default()` with custom `FetchOptions` configuration
- Add support for `HTTPS_PROXY` and `HTTP_PROXY` environment variables
- Enable proxy auto-detection for system configuration
- Maintain authentication compatibility with auth-git2
- Handle certificates appropriately for proxy scenarios
- Update both `git_source.rs` and `source_upgrade.rs`

The solution respects standard proxy environment variables and maintains compatibility with existing authentication while adding HTTPS proxy support.

Generated with [Claude Code](https://claude.ai/code)