### PR TITLE
Segregate Coverage and analysis ignores

### DIFF
--- a/qlty-cli/src/initializer/templates/qlty.toml
+++ b/qlty-cli/src/initializer/templates/qlty.toml
@@ -53,5 +53,33 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.ignores = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"

--- a/qlty-cli/src/initializer/templates/qlty.toml
+++ b/qlty-cli/src/initializer/templates/qlty.toml
@@ -53,7 +53,7 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
-coverage.ignores = [
+coverage.exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",

--- a/qlty-cli/tests/cmd/coverage/ignore_patterns.in/.qlty/qlty.toml
+++ b/qlty-cli/tests/cmd/coverage/ignore_patterns.in/.qlty/qlty.toml
@@ -1,3 +1,3 @@
-coverage.ignores = [
+coverage.exclude_patterns = [
   "**/vendor/**",
 ]

--- a/qlty-cli/tests/cmd/coverage/ignore_patterns.in/.qlty/qlty.toml
+++ b/qlty-cli/tests/cmd/coverage/ignore_patterns.in/.qlty/qlty.toml
@@ -1,0 +1,3 @@
+coverage.ignores = [
+  "**/vendor/**",
+]

--- a/qlty-cli/tests/cmd/coverage/ignore_patterns.in/lcov.info
+++ b/qlty-cli/tests/cmd/coverage/ignore_patterns.in/lcov.info
@@ -69,7 +69,7 @@ BRDA:91,8,1,5
 BRF:16
 BRH:9
 end_of_record
-SF:src/ignore.js
+SF:vendor/ignore.js
 DA:1,1
 DA:2,0
 DA:5,10

--- a/qlty-cli/tests/cmd/coverage/ignore_patterns.stderr
+++ b/qlty-cli/tests/cmd/coverage/ignore_patterns.stderr
@@ -17,27 +17,27 @@ https://qlty.sh/d/coverage
  COVERAGE FILES: 1 
 
     Coverage File  Format  Size
-    lcov.info      lcov    956 B
+    lcov.info      lcov    959 B
 
  COVERAGE DATA 
 
-    2 unique code file paths
-    2 paths are missing on disk (100.0%)
+    1 unique code file path
+    1 path ignored
+    1 path is missing on disk (100.0%)
 
     Missing code files:
 
       formatter.js
-      src/ignore.js
 
     TIP: Consider using add-prefix or strip-prefix to fix paths
     https://qlty.sh/d/coverage-path-fixing
 
 
-    Covered Lines:      26
-    Uncovered Lines:     3
-    Omitted Lines:      28
+    Covered Lines:      24
+    Uncovered Lines:     2
+    Omitted Lines:      26
 
-    Line Coverage:       89.66%
+    Line Coverage:       92.31%
 
  EXPORTING... 
 

--- a/qlty-cli/tests/cmd/init/basic.stdout
+++ b/qlty-cli/tests/cmd/init/basic.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/config_based_multiple_versions.stdout
+++ b/qlty-cli/tests/cmd/init/config_based_multiple_versions.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/config_based_version_new.stdout
+++ b/qlty-cli/tests/cmd/init/config_based_version_new.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/config_based_version_old.stdout
+++ b/qlty-cli/tests/cmd/init/config_based_version_old.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/custom_source.stdout
+++ b/qlty-cli/tests/cmd/init/custom_source.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/package_file.stdout
+++ b/qlty-cli/tests/cmd/init/package_file.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/package_file_gemfile.stdout
+++ b/qlty-cli/tests/cmd/init/package_file_gemfile.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/package_file_gemfile_lock.stdout
+++ b/qlty-cli/tests/cmd/init/package_file_gemfile_lock.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/package_file_gemfile_with_gemspec.stdout
+++ b/qlty-cli/tests/cmd/init/package_file_gemfile_with_gemspec.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/package_file_package_json.stdout
+++ b/qlty-cli/tests/cmd/init/package_file_package_json.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/package_file_yarn_lock.stdout
+++ b/qlty-cli/tests/cmd/init/package_file_yarn_lock.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/prefix.stdout
+++ b/qlty-cli/tests/cmd/init/prefix.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/skip_default_source.stdout
+++ b/qlty-cli/tests/cmd/init/skip_default_source.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-cli/tests/cmd/init/source.stdout
+++ b/qlty-cli/tests/cmd/init/source.stdout
@@ -53,6 +53,34 @@ test_patterns = [
   "**/spec_*.*",
 ]
 
+coverage.exclude_patterns = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [smells]
 mode = "comment"
 

--- a/qlty-config/default.toml
+++ b/qlty-config/default.toml
@@ -29,6 +29,35 @@ exclude_patterns = [
   "**/vendor/**",
 ]
 
+# When these are updated, also update initializer.rs
+coverage.ignores = [
+  "*_min.*",
+  "*-min.*",
+  "*.min.*",
+  "**/.yarn/**",
+  "**/*.d.ts",
+  "**/bower_components/**",
+  "**/build/**",
+  "**/cache/**",
+  "**/config/**",
+  "**/db/**",
+  "**/deps/**",
+  "**/dist/**",
+  "**/extern/**",
+  "**/external/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/Godeps/**",
+  "**/gradlew/**",
+  "**/mvnw/**",
+  "**/node_modules/**",
+  "**/protos/**",
+  "**/seed/**",
+  "**/target/**",
+  "**/testdata/**",
+  "**/vendor/**",
+]
+
 [file_types.ALL]
 globs = ["*.*"]
 

--- a/qlty-config/default.toml
+++ b/qlty-config/default.toml
@@ -30,7 +30,7 @@ exclude_patterns = [
 ]
 
 # When these are updated, also update initializer.rs
-coverage.ignores = [
+coverage.exclude_patterns = [
   "*_min.*",
   "*-min.*",
   "*.min.*",

--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -235,20 +235,6 @@ impl Builder {
 
         if !all_exclude_patterns.is_empty() {
             config.exclude_patterns = all_exclude_patterns.clone();
-
-            match config.coverage.ignores {
-                Some(_) => {
-                    config
-                        .coverage
-                        .ignores
-                        .as_mut()
-                        .unwrap()
-                        .extend(all_exclude_patterns);
-                }
-                None => {
-                    config.coverage.ignores = Some(all_exclude_patterns);
-                }
-            }
         }
     }
 

--- a/qlty-config/src/config/coverage.rs
+++ b/qlty-config/src/config/coverage.rs
@@ -4,5 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
 pub struct Coverage {
     pub paths: Option<Vec<String>>,
-    pub ignores: Option<Vec<String>>,
+
+    #[serde(default)]
+    pub exclude_patterns: Vec<String>,
 }

--- a/qlty-coverage/src/publish/planner.rs
+++ b/qlty-coverage/src/publish/planner.rs
@@ -140,9 +140,9 @@ impl Planner {
 
         transformers.push(Box::new(StripDotSlashPrefix));
 
-        if self.config.coverage.ignores.is_some() {
+        if !self.config.coverage.exclude_patterns.is_empty() {
             transformers.push(Box::new(IgnorePaths::new(
-                self.config.coverage.ignores.as_ref().unwrap(),
+                &self.config.coverage.exclude_patterns,
             )?));
         }
 


### PR DESCRIPTION
Right now exclude_patterns get copied over into coverage.ignores for coverage and there is no good way to exclude files or folders for analysis and not coverage.

Actually thinking more about it the rollout might be tricky as this can be considered a breaking change, not sure if how many people will be affected by this.