### PR TITLE
fix: shellcheck considers tabs as 8 columns in location ranges

### DIFF
--- a/qlty-check/src/patch_builder.rs
+++ b/qlty-check/src/patch_builder.rs
@@ -51,7 +51,7 @@ impl PatchBuilder {
 
     fn build_patch(
         &self,
-        replacements: &Vec<Replacement>,
+        replacements: &[Replacement],
         location: &Option<Location>,
         tool: &str,
     ) -> String {

--- a/qlty-check/src/patch_builder.rs
+++ b/qlty-check/src/patch_builder.rs
@@ -21,8 +21,7 @@ impl IssueTransformer for PatchBuilder {
             }
             let replacements = suggestion.replacements.clone();
             suggestion.replacements = self.sorted_replacements(replacements).collect();
-            suggestion.patch =
-                self.build_patch(&suggestion.replacements, &issue.location, &issue.tool);
+            suggestion.patch = self.build_patch(&suggestion.replacements, &issue.location);
         }
 
         Some(issue)
@@ -49,12 +48,7 @@ impl PatchBuilder {
             .sorted_by(|a, b| a.range().end_byte.cmp(&b.range().end_byte))
     }
 
-    fn build_patch(
-        &self,
-        replacements: &[Replacement],
-        location: &Option<Location>,
-        tool: &str,
-    ) -> String {
+    fn build_patch(&self, replacements: &[Replacement], location: &Option<Location>) -> String {
         let mut patch = String::from("");
         let file_path = if let Some(location) = location {
             &location.path
@@ -68,38 +62,7 @@ impl PatchBuilder {
         if let Ok(data) = &contents {
             let mut mdata = data.clone();
             let apply = replacements.iter().rev().all(|replacement| {
-                let mut range = replacement.range();
-
-                if tool == "shellcheck" {
-                    // Shellcheck adds 8 to columns for every tab (\t) char
-                    // So we need to adjust the start and end column
-                    if let Some(target_line) = data.split('\n').nth(range.start_line as usize - 1) {
-                        // Count tabs before the start column position
-                        let tabs_before_start = target_line
-                            .chars()
-                            .take((range.start_column as usize).saturating_sub(1))
-                            .filter(|&c| c == '\t')
-                            .count();
-
-                        let tabs_before_end = target_line
-                            .chars()
-                            .take((range.end_column as usize).saturating_sub(1))
-                            .filter(|&c| c == '\t')
-                            .count();
-
-                        // Adjust columns: shellcheck adds 7 extra positions per tab (8 total - 1 for the tab itself)
-                        if tabs_before_start > 0 {
-                            range.start_column = range
-                                .start_column
-                                .saturating_sub((tabs_before_start * 7) as u32);
-                        }
-                        if tabs_before_end > 0 {
-                            range.end_column = range
-                                .end_column
-                                .saturating_sub((tabs_before_end * 7) as u32);
-                        }
-                    }
-                }
+                let range = replacement.range();
 
                 let (start_byte, end_byte) = if let (Some(start_byte), Some(end_byte)) =
                     (range.start_byte, range.end_byte)
@@ -653,52 +616,6 @@ mod test {
                       startLine: 3
                       endLine: 4
                       endColumn: 13
-        "###);
-    }
-
-    #[test]
-    fn parse_shellcheck_tabs() {
-        let input = include_str!("../tests/fixtures/planner/patch_builder/parse.05.output.txt");
-        let patch_builder = new_from_cache([(
-            "/tmp/src/main.sh".into(),
-            include_str!("../tests/fixtures/planner/patch_builder/parse.05.input.sh").into(),
-        )]);
-
-        let issues = Shellcheck {}.parse("shellcheck", input).ok().unwrap();
-        let issues = transformed_issues(issues, &patch_builder);
-        insta::assert_yaml_snapshot!(issues, @r###"
-        - tool: shellcheck
-          ruleKey: "2086"
-          message: Double quote to prevent globbing and word splitting.
-          level: LEVEL_LOW
-          category: CATEGORY_LINT
-          location:
-            path: /tmp/src/main.sh
-            range:
-              startLine: 5
-              startColumn: 19
-              endLine: 5
-              endColumn: 30
-          suggestions:
-            - patch: "--- original\n+++ modified\n@@ -2,6 +2,6 @@\n\n if [[ $# != 3 ]]; then\n \tusername=$1\n-\tsudo su - ${username} -c whoami\n+\tsudo su - \"${username}\" -c whoami\n \texit 1\n fi\n"
-              source: SUGGESTION_SOURCE_TOOL
-              replacements:
-                - data: "\""
-                  location:
-                    path: /tmp/src/main.sh
-                    range:
-                      startLine: 5
-                      startColumn: 19
-                      endLine: 5
-                      endColumn: 19
-                - data: "\""
-                  location:
-                    path: /tmp/src/main.sh
-                    range:
-                      startLine: 5
-                      startColumn: 30
-                      endLine: 5
-                      endColumn: 30
         "###);
     }
 }

--- a/qlty-check/src/planner/plugin_tab_column_width_transformer.rs
+++ b/qlty-check/src/planner/plugin_tab_column_width_transformer.rs
@@ -1,0 +1,162 @@
+use crate::source_reader::SourceReader;
+use qlty_config::issue_transformer::IssueTransformer;
+use qlty_types::analysis::v1::Issue;
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct PluginTabColumnWidthTransformer {
+    pub source_reader: Arc<dyn SourceReader>,
+    pub tab_column_width: usize,
+    pub plugin_name: String,
+}
+
+impl IssueTransformer for PluginTabColumnWidthTransformer {
+    fn transform(&self, mut issue: Issue) -> Option<Issue> {
+        if issue.tool == self.plugin_name {
+            if let Some(location) = issue.location.as_mut() {
+                if let Some(range) = location.range.as_mut() {
+                    if let Some([start_column, end_column]) =
+                        self.get_correct_columns_for_path_and_range(&location.path, range.clone())
+                    {
+                        range.start_column = start_column;
+                        range.end_column = end_column;
+                    }
+                }
+            }
+
+            for suggestion in &mut issue.suggestions {
+                for replacement in &mut suggestion.replacements {
+                    if let Some(location) = replacement.location.as_mut() {
+                        if let Some(range) = location.range.as_mut() {
+                            if let Some([start_column, end_column]) = self
+                                .get_correct_columns_for_path_and_range(
+                                    &location.path,
+                                    range.clone(),
+                                )
+                            {
+                                range.start_column = start_column;
+                                range.end_column = end_column;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Some(issue)
+    }
+
+    fn clone_box(&self) -> Box<dyn IssueTransformer> {
+        Box::new(self.clone())
+    }
+}
+
+impl PluginTabColumnWidthTransformer {
+    fn get_correct_columns_for_path_and_range(
+        &self,
+        file_path: &str,
+        range: qlty_types::analysis::v1::Range,
+    ) -> Option<[u32; 2]> {
+        let contents = self.source_reader.read(file_path.into());
+        let (mut start_column, mut end_column) = (range.start_column, range.end_column);
+        if let Ok(data) = &contents {
+            if let Some(target_line) = data.split('\n').nth(range.start_line as usize - 1) {
+                let tabs_before_start = target_line
+                    .chars()
+                    .take((range.start_column as usize).saturating_sub(1))
+                    .filter(|&c| c == '\t')
+                    .count();
+                let tabs_before_end = target_line
+                    .chars()
+                    .take((range.end_column as usize).saturating_sub(1))
+                    .filter(|&c| c == '\t')
+                    .count();
+                if tabs_before_start > 0 {
+                    start_column = start_column
+                        .saturating_sub((tabs_before_start * self.tab_column_width) as u32);
+                }
+                if tabs_before_end > 0 {
+                    end_column =
+                        end_column.saturating_sub((tabs_before_end * self.tab_column_width) as u32);
+                }
+            }
+        }
+        Some([start_column, end_column])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        parser::{shellcheck::Shellcheck, Parser},
+        source_reader::SourceReaderFs,
+    };
+
+    fn transformed_issues(
+        issues: Vec<Issue>,
+        plugin_tab_column_width_transformer: &PluginTabColumnWidthTransformer,
+    ) -> Vec<Issue> {
+        issues
+            .iter()
+            .map(|issue| plugin_tab_column_width_transformer.transform(issue.clone()))
+            .filter(Option::is_some)
+            .map(Option::unwrap)
+            .collect()
+    }
+
+    #[test]
+    fn parse_shellcheck_tabs() {
+        let input = include_str!(
+            "../../tests/fixtures/planner/plugin_tab_column_width_transformer/parse.01.output.txt"
+        );
+
+        let plugin_tab_column_width_transformer = PluginTabColumnWidthTransformer {
+            source_reader: Arc::new(SourceReaderFs::with_cache(
+            [(
+                "/tmp/src/main.sh".into(),
+                include_str!("../../tests/fixtures/planner/plugin_tab_column_width_transformer/parse.01.input.sh").into(),
+            )]
+            .into(),
+        )),
+            tab_column_width: 7,
+            plugin_name: "shellcheck".to_string(),
+        };
+
+        let issues = Shellcheck {}.parse("shellcheck", input).ok().unwrap();
+        let issues = transformed_issues(issues, &plugin_tab_column_width_transformer);
+
+        insta::assert_yaml_snapshot!(issues, @r###"
+        - tool: shellcheck
+          ruleKey: "2086"
+          message: Double quote to prevent globbing and word splitting.
+          level: LEVEL_LOW
+          category: CATEGORY_LINT
+          location:
+            path: /tmp/src/main.sh
+            range:
+              startLine: 5
+              startColumn: 12
+              endLine: 5
+              endColumn: 23
+          suggestions:
+            - source: SUGGESTION_SOURCE_TOOL
+              replacements:
+                - data: "\""
+                  location:
+                    path: /tmp/src/main.sh
+                    range:
+                      startLine: 5
+                      startColumn: 12
+                      endLine: 5
+                      endColumn: 12
+                - data: "\""
+                  location:
+                    path: /tmp/src/main.sh
+                    range:
+                      startLine: 5
+                      startColumn: 23
+                      endLine: 5
+                      endColumn: 23
+        "###);
+    }
+}

--- a/qlty-check/src/planner/plugin_tab_column_width_transformer.rs
+++ b/qlty-check/src/planner/plugin_tab_column_width_transformer.rs
@@ -16,7 +16,7 @@ impl IssueTransformer for PluginTabColumnWidthTransformer {
             if let Some(location) = issue.location.as_mut() {
                 if let Some(range) = location.range.as_mut() {
                     if let Some([start_column, end_column]) =
-                        self.get_correct_columns_for_path_and_range(&location.path, range.clone())
+                        self.get_correct_columns_for_path_and_range(&location.path, *range)
                     {
                         range.start_column = start_column;
                         range.end_column = end_column;
@@ -28,11 +28,8 @@ impl IssueTransformer for PluginTabColumnWidthTransformer {
                 for replacement in &mut suggestion.replacements {
                     if let Some(location) = replacement.location.as_mut() {
                         if let Some(range) = location.range.as_mut() {
-                            if let Some([start_column, end_column]) = self
-                                .get_correct_columns_for_path_and_range(
-                                    &location.path,
-                                    range.clone(),
-                                )
+                            if let Some([start_column, end_column]) =
+                                self.get_correct_columns_for_path_and_range(&location.path, *range)
                             {
                                 range.start_column = start_column;
                                 range.end_column = end_column;

--- a/qlty-check/tests/fixtures/planner/patch_builder/parse.05.input.sh
+++ b/qlty-check/tests/fixtures/planner/patch_builder/parse.05.input.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ $# != 3 ]]; then
+	username=$1
+	sudo su - ${username} -c whoami
+	exit 1
+fi

--- a/qlty-check/tests/fixtures/planner/patch_builder/parse.05.output.txt
+++ b/qlty-check/tests/fixtures/planner/patch_builder/parse.05.output.txt
@@ -1,0 +1,34 @@
+[
+  {
+    "file": "/tmp/src/main.sh",
+    "line": 5,
+    "endLine": 5,
+    "column": 19,
+    "endColumn": 30,
+    "level": "info",
+    "code": 2086,
+    "message": "Double quote to prevent globbing and word splitting.",
+    "fix": {
+      "replacements": [
+        {
+          "column": 19,
+          "endColumn": 19,
+          "endLine": 5,
+          "insertionPoint": "afterEnd",
+          "line": 5,
+          "precedence": 10,
+          "replacement": "\""
+        },
+        {
+          "column": 30,
+          "endColumn": 30,
+          "endLine": 5,
+          "insertionPoint": "beforeStart",
+          "line": 5,
+          "precedence": 10,
+          "replacement": "\""
+        }
+      ]
+    }
+  }
+]

--- a/qlty-check/tests/fixtures/planner/plugin_tab_column_width_transformer/parse.01.input.sh
+++ b/qlty-check/tests/fixtures/planner/plugin_tab_column_width_transformer/parse.01.input.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ $# != 3 ]]; then
+	username=$1
+	sudo su - ${username} -c whoami
+	exit 1
+fi

--- a/qlty-check/tests/fixtures/planner/plugin_tab_column_width_transformer/parse.01.output.txt
+++ b/qlty-check/tests/fixtures/planner/plugin_tab_column_width_transformer/parse.01.output.txt
@@ -1,0 +1,34 @@
+[
+  {
+    "file": "/tmp/src/main.sh",
+    "line": 5,
+    "endLine": 5,
+    "column": 19,
+    "endColumn": 30,
+    "level": "info",
+    "code": 2086,
+    "message": "Double quote to prevent globbing and word splitting.",
+    "fix": {
+      "replacements": [
+        {
+          "column": 19,
+          "endColumn": 19,
+          "endLine": 5,
+          "insertionPoint": "afterEnd",
+          "line": 5,
+          "precedence": 10,
+          "replacement": "\""
+        },
+        {
+          "column": 30,
+          "endColumn": 30,
+          "endLine": 5,
+          "insertionPoint": "beforeStart",
+          "line": 5,
+          "precedence": 10,
+          "replacement": "\""
+        }
+      ]
+    }
+  }
+]

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -407,6 +407,9 @@ pub struct PluginDef {
 
     #[serde(default)]
     pub suggested_mode: IssueMode,
+
+    #[serde(default)]
+    pub tab_column_width: Option<usize>,
 }
 
 fn default_idempotent() -> bool {


### PR DESCRIPTION
https://github.com/qltysh/qlty/issues/2073

So it seems Shellcheck adds 8 to the column for every tab (\t) char which we need to adjust for. 
Unfortunately can't be done in parser since we don't have access to file contents at that point, so instead had to do this hackaround in the patch builder.

Fixes #2100