### PR TITLE
fix: Add ca-certificates to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN cargo build --release --bin qlty
 RUN mv ./target/release/qlty ./qlty
 
 FROM debian:bookworm-slim AS runtime
+RUN apt-get update -yqq && apt-get install -yqq ca-certificates
 WORKDIR /app
 COPY --from=builder /app/qlty /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/qlty"]


### PR DESCRIPTION
This resolves the connection error when reaching out to the API endpoint:
```
Transport Error: https://qlty.sh/api: Transport { kind: ConnectionFailed, message: Some("tls connection init failed"), url: Some(Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("qlty.sh")), port: None, path: "/api/coverage", query: None, fragment: None }), source: Some(Custom { kind: InvalidData, error: General("No CA certificates were loaded from the system") }) }
```