### PR TITLE
fix: prevent duplicate warnings for deprecated config fields

### DIFF
--- a/qlty-check/src/planner.rs
+++ b/qlty-check/src/planner.rs
@@ -19,7 +19,7 @@ use qlty_analysis::git::{compute_upstream, DiffLineFilter};
 use qlty_analysis::workspace_entries::TargetMode;
 use qlty_config::config::issue_transformer::IssueTransformer;
 use qlty_config::config::{DriverType, Match, PluginDef, Set, Triage};
-use qlty_config::{QltyConfig, Workspace};
+use qlty_config::{warn_once, QltyConfig, Workspace};
 use qlty_types::analysis::v1::ExecutionVerb;
 use qlty_types::{category_from_str, level_from_str};
 use rayon::prelude::*;
@@ -299,12 +299,12 @@ impl Planner {
         let mut triages = self.config.triage.clone();
 
         if !self.config.overrides.is_empty() {
-            eprintln!(
+            warn_once(&format!(
                 "{} The `{}` field in qlty.toml is deprecated. Please use `{}` instead.",
                 style("WARNING:").bold().yellow(),
                 style("[[override]]").bold(),
                 style("[[triage]]").bold()
-            );
+            ));
 
             for issue_override in &self.config.overrides {
                 triages.push(Triage {

--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -1,8 +1,8 @@
 use super::exclude::Exclude;
 use crate::config::{Match, Set, Triage};
 use crate::sources::SourcesList;
+use crate::{warn_once, Library, QltyConfig};
 use crate::{workspace::Workspace, TomlMerge};
-use crate::{Library, QltyConfig};
 use anyhow::{anyhow, bail, Context as _, Result};
 use config::{Config, File, FileFormat};
 use console::style;
@@ -152,32 +152,32 @@ impl Builder {
         let mut all_exclude_patterns = config.exclude_patterns.clone();
 
         if !config.ignore_patterns.is_empty() {
-            eprintln!(
+            warn_once(&format!(
                 "{} The `{}` field in qlty.toml is deprecated. Please use `{}` instead.",
                 style("WARNING:").bold().yellow(),
                 style("ignore_patterns").bold(),
                 style("exclude_patterns").bold()
-            );
+            ));
             all_exclude_patterns.extend(config.ignore_patterns.clone());
         }
 
         if !config.ignore.is_empty() {
-            eprintln!(
+            warn_once(&format!(
                 "{} The `{}` field in qlty.toml is deprecated. Please use `{}` or `{}` instead.",
                 style("WARNING:").bold().yellow(),
                 style("[[ignore]]").bold(),
                 style("[[exclude]]").bold(),
                 style("exclude_patterns").bold()
-            );
+            ));
 
             for ignore in &config.ignore {
                 if ignore.file_patterns.is_empty() {
-                    eprintln!(
+                    warn_once(&format!(
                         "{} The use of `{}` field in qlty.toml without {} is no longer supported. Skipping ignore without file_patterns.",
                         style("WARNING:").bold().yellow(),
                         style("[[ignore]]").bold(),
                         style("file_patterns").bold()
-                    );
+                    ));
                     continue;
                 }
 

--- a/qlty-config/src/lib.rs
+++ b/qlty-config/src/lib.rs
@@ -6,6 +6,7 @@ pub mod sources;
 mod toml_merge;
 mod user;
 pub mod version;
+mod warning_tracker;
 mod workspace;
 
 pub use crate::config::FileType;
@@ -15,4 +16,5 @@ pub use config::issue_transformer;
 pub use library::Library;
 pub use migration::{MigrateConfig, MigrationSettings};
 pub use user::UserData;
+pub use warning_tracker::warn_once;
 pub use workspace::Workspace;

--- a/qlty-config/src/warning_tracker.rs
+++ b/qlty-config/src/warning_tracker.rs
@@ -1,0 +1,14 @@
+use std::collections::HashSet;
+use std::sync::{LazyLock, Mutex};
+
+static WARNING_TRACKER: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+pub fn warn_once(warning_message: &str) {
+    let mut tracker = WARNING_TRACKER.lock().unwrap();
+
+    if !tracker.contains(warning_message) {
+        tracker.insert(warning_message.to_string());
+        eprintln!("{warning_message}");
+    }
+}


### PR DESCRIPTION
Implemented a warning deduplication system using a static `warn_once()` function to ensure deprecated field warnings are only shown once per execution.

- Added `warning_tracker.rs` with `warn_once()` function using LazyLock<Mutex<HashSet<String>>>
- Updated config builder to use `warn_once()` for `[[ignore]]` and `ignore_patterns` warnings
- Updated planner to use `warn_once()` for `[[override]]` warnings
- Fixes issue where warnings were duplicated during config processing

Resolves #2122

Generated with [Claude Code](https://claude.ai/code)