### PR TITLE
fix: ESLint plugin is missing support for TypeScript eslint configuration (eslint.config.ts)

### DIFF
--- a/qlty-plugins/plugins/linters/eslint/plugin.toml
+++ b/qlty-plugins/plugins/linters/eslint/plugin.toml
@@ -21,6 +21,7 @@ error_codes = [2]
 success_codes = [0, 1]
 config_files = [
   "eslint.config.js",
+  "eslint.config.ts",
   "eslint.config.mjs",
   "eslint.config.cjs",
 ]


### PR DESCRIPTION
ESLint fails when TypeScript config is used with: 
```
 Value for 'config' of type 'path::String' required.  You're using eslint.config.js, some command line flags are no longer available. Please see https://eslint.org/docs/latest/use/command-line-interface for details.eslint  Error  Exited with code 2 in 0.20s  .qlty/out/invoke-sEJm5a.yaml

```
Because it generates wrong command: 
```
script: sh -c "eslint --config  --output-file /tmp/invocation-out-sEJm5a.txt --format json src/'"

```

The config parameter is missing. 

Ideally If config is not found it should not include --config parameter at all. The current fix adds support for TypeScrtipt ESLint

Issue: https://github.com/qltysh/qlty/issues/1542