### PR TITLE
Add output after installing githooks

### DIFF
--- a/qlty-cli/src/commands/githooks/install.rs
+++ b/qlty-cli/src/commands/githooks/install.rs
@@ -106,5 +106,11 @@ fn install_hook(hook_name: &str, contents: &str) -> Result<()> {
         })?;
     }
 
+    println!(
+        "Installed git hook '{}' at {}",
+        hook_name,
+        hook_script_path.display()
+    );
+
     Ok(())
 }


### PR DESCRIPTION
Previously the lack of output for `qlty githooks install` was a bit disconcerting. I like seeing some form of output, if reasonable, to provide confidence that the command succeeded. And it seems reasonable to print out what it actually did.

<img width="916" height="102" alt="image" src="https://github.com/user-attachments/assets/19b9dbda-3d36-44fe-96c2-2cbef3c96acf" />
