### PR TITLE
update URLs for paths fixing doc

### DIFF
--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -459,7 +459,7 @@ impl Publish {
 
             eprintln!(
                 "    {}",
-                style("https://qlty.sh/d/coverage-path-fixing").dim()
+                style("https://docs.qlty.sh/coverage/path-fixing").dim()
             );
 
             eprintln!();

--- a/qlty-cli/tests/cmd/coverage/basic.stderr
+++ b/qlty-cli/tests/cmd/coverage/basic.stderr
@@ -33,7 +33,7 @@ https://qlty.sh/d/coverage
       formatter.js
 
     TIP: Consider using add-prefix or strip-prefix to fix paths
-    https://qlty.sh/d/coverage-path-fixing
+    https://docs.qlty.sh/coverage/path-fixing
 
 
     Covered Lines:      24

--- a/qlty-cli/tests/cmd/coverage/files_exist.stderr
+++ b/qlty-cli/tests/cmd/coverage/files_exist.stderr
@@ -36,7 +36,7 @@ https://qlty.sh/d/coverage
       src/doesnt_exist.js
 
     TIP: Consider using add-prefix or strip-prefix to fix paths
-    https://qlty.sh/d/coverage-path-fixing
+    https://docs.qlty.sh/coverage/path-fixing
 
 
     Covered Lines:      24

--- a/qlty-cli/tests/cmd/coverage/ignore_patterns.stderr
+++ b/qlty-cli/tests/cmd/coverage/ignore_patterns.stderr
@@ -34,7 +34,7 @@ https://qlty.sh/d/coverage
       src/ignore.js
 
     TIP: Consider using add-prefix or strip-prefix to fix paths
-    https://qlty.sh/d/coverage-path-fixing
+    https://docs.qlty.sh/coverage/path-fixing
 
 
     Covered Lines:      26

--- a/qlty-cli/tests/cmd/coverage/json.stderr
+++ b/qlty-cli/tests/cmd/coverage/json.stderr
@@ -33,7 +33,7 @@ https://qlty.sh/d/coverage
       rails/formatter.js
 
     TIP: Consider using add-prefix or strip-prefix to fix paths
-    https://qlty.sh/d/coverage-path-fixing
+    https://docs.qlty.sh/coverage/path-fixing
 
 
     Covered Lines:      24

--- a/qlty-cli/tests/cmd/coverage/override_commit_time.stderr
+++ b/qlty-cli/tests/cmd/coverage/override_commit_time.stderr
@@ -34,7 +34,7 @@ https://qlty.sh/d/coverage
       formatter.js
 
     TIP: Consider using add-prefix or strip-prefix to fix paths
-    https://qlty.sh/d/coverage-path-fixing
+    https://docs.qlty.sh/coverage/path-fixing
 
 
     Covered Lines:      24

--- a/qlty-cli/tests/cmd/coverage/overrides.stderr
+++ b/qlty-cli/tests/cmd/coverage/overrides.stderr
@@ -38,7 +38,7 @@ WARNING: --transform-add-prefix is deprecated, use --add-prefix instead
       rails/formatter.js
 
     TIP: Consider using add-prefix or strip-prefix to fix paths
-    https://qlty.sh/d/coverage-path-fixing
+    https://docs.qlty.sh/coverage/path-fixing
 
 
     Covered Lines:      24

--- a/qlty-cli/tests/cmd/coverage/publish_validate.stderr
+++ b/qlty-cli/tests/cmd/coverage/publish_validate.stderr
@@ -33,7 +33,7 @@ https://qlty.sh/d/coverage
       doesnt_exist.js
 
     TIP: Consider using add-prefix or strip-prefix to fix paths
-    https://qlty.sh/d/coverage-path-fixing
+    https://docs.qlty.sh/coverage/path-fixing
 
 
     Covered Lines:      26

--- a/qlty-cli/tests/cmd/without_git/basic_coverage.stderr
+++ b/qlty-cli/tests/cmd/without_git/basic_coverage.stderr
@@ -35,7 +35,7 @@ https://qlty.sh/d/coverage
       formatter.js
 
     TIP: Consider using add-prefix or strip-prefix to fix paths
-    https://qlty.sh/d/coverage-path-fixing
+    https://docs.qlty.sh/coverage/path-fixing
 
 
     Covered Lines:      24


### PR DESCRIPTION
This updates the outdates URLs in our error output to point to the correct docs page (https://docs.qlty.sh/coverage/path-fixing)