### PR TITLE
Run linter tests on update linter versions

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -15,6 +15,9 @@ on:
       - "qlty-config/**"
       - "qlty-check/src/tool/**"
       - ".github/workflows/plugins.yml"
+  workflow_run:
+    workflows: ["Update linter versions"]
+    types: [completed]
 
 permissions:
   actions: write


### PR DESCRIPTION
Since GITHUB_TOKEN is being used to create the update linter versions PR, it doesn't automatically trigger the plugins test action on its commits, so we need to explicitly tell it to.

https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run