### PR TITLE
Run plugins tests on update linter version PR

### DIFF
--- a/.github/workflows/update_linter_versions.yml
+++ b/.github/workflows/update_linter_versions.yml
@@ -12,6 +12,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  actions: write
 
 jobs:
   update-linter-versions:
@@ -102,5 +103,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'plugins.yml',   // file name of the second workflow
-              ref: 'update-linter-versions' // run it on the PR branch
+              ref: '${{ steps.cpr.outputs.pull-request-branch }}' // run it on the PR branch
             });

--- a/.github/workflows/update_linter_versions.yml
+++ b/.github/workflows/update_linter_versions.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 12 * * 2" # every Tuesday at 12:00
   pull_request:
     paths:
-      - ".github/workflows/plugins.yml"
+      - ".github/workflows/update_linter_versions.yml"
 
 permissions:
   contents: write

--- a/.github/workflows/update_linter_versions.yml
+++ b/.github/workflows/update_linter_versions.yml
@@ -58,6 +58,7 @@ jobs:
           title: "chore: Update linter versions"
           body: "This pull request was automatically created by GitHub Actions to update linter versions."
           branch: update-linter-versions
+          base: main
           signoff: true
           sign-commits: true
           delete-branch: true

--- a/.github/workflows/update_linter_versions.yml
+++ b/.github/workflows/update_linter_versions.yml
@@ -98,10 +98,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          debug: true
           script: |
-            await github.rest.actions.createWorkflowDispatch({
+            const result = await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'plugins.yml',   // file name of the second workflow
               ref: '${{ steps.cpr.outputs.pull-request-branch }}' // run it on the PR branch
             });
+            console.log("Workflow Dispatch Result: ", result);

--- a/.github/workflows/update_linter_versions.yml
+++ b/.github/workflows/update_linter_versions.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 12 * * 2" # every Tuesday at 12:00
+  pull_request:
+    paths:
+      - ".github/workflows/plugins.yml"
 
 permissions:
   contents: write
@@ -47,6 +50,7 @@ jobs:
         run: npm run update-linter-versions
 
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -86,3 +90,16 @@ jobs:
             //     assignees: assignees
             //   });
             }
+
+      - name: Kick off Plugin Tests on PR branch
+        if: steps.cpr.outputs.pull-request-number != '' # only if a PR was created/updated
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'plugins.yml',   // file name of the second workflow
+              ref: 'update-linter-versions' // run it on the PR branch
+            });


### PR DESCRIPTION
Since GITHUB_TOKEN is being used to create the update linter versions PR, it doesn't automatically trigger the plugins test action on its commits, so we need to explicitly tell it to.

https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs