### PR TITLE
chore: Extract metadata planner

### DIFF
--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -1,5 +1,5 @@
 use super::utils::{
-    load_config, print_authentication_info, print_initial_messages, print_metadata, print_settings,
+    print_authentication_info, print_initial_messages, print_metadata, print_settings,
     validate_metadata,
 };
 use crate::{CommandError, CommandSuccess};
@@ -7,10 +7,7 @@ use anyhow::{Context, Result};
 use clap::Args;
 use console::style;
 use qlty_cloud::{get_legacy_api_url, Client as QltyClient};
-use qlty_coverage::{
-    publish::{Planner, Settings},
-    token::load_auth_token,
-};
+use qlty_coverage::{publish::Settings, token::load_auth_token};
 use std::time::Instant;
 
 #[derive(Debug, Default, Clone)]
@@ -75,7 +72,9 @@ impl Complete {
         print_settings(&settings);
 
         let token = load_auth_token(&self.token, self.project.as_deref())?;
-        let metadata = Planner::new(&load_config(), &settings).compute_metadata()?;
+        let metadata_planner =
+            qlty_coverage::publish::MetadataPlanner::new(&settings, qlty_coverage::ci::current());
+        let metadata = metadata_planner.compute()?;
 
         validate_metadata(&metadata)?;
 

--- a/qlty-coverage/src/publish.rs
+++ b/qlty-coverage/src/publish.rs
@@ -10,7 +10,7 @@ mod upload;
 
 pub use metrics::CoverageMetrics;
 pub use plan::Plan;
-pub use planner::Planner;
+pub use planner::{MetadataPlanner, Planner};
 pub use processor::Processor;
 pub use reader::Reader;
 pub use report::Report;

--- a/qlty-coverage/src/publish/planner.rs
+++ b/qlty-coverage/src/publish/planner.rs
@@ -1,3 +1,4 @@
+use crate::ci::CI;
 use crate::git::retrieve_commit_metadata;
 use crate::publish::Plan;
 use crate::publish::Settings;
@@ -24,6 +25,20 @@ pub struct Planner {
     settings: Settings,
 }
 
+pub struct MetadataPlanner {
+    settings: Settings,
+    ci: Option<Box<dyn CI>>,
+}
+
+impl std::fmt::Debug for MetadataPlanner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetadataPlanner")
+            .field("settings", &self.settings)
+            .field("ci", &self.ci.as_ref().map(|c| c.ci_name()))
+            .finish()
+    }
+}
+
 impl Planner {
     pub fn new(config: &QltyConfig, settings: &Settings) -> Self {
         Self {
@@ -33,7 +48,8 @@ impl Planner {
     }
 
     pub fn compute(&self) -> Result<Plan> {
-        let metadata = self.compute_metadata()?;
+        let metadata_planner = MetadataPlanner::new(&self.settings, crate::ci::current());
+        let metadata = metadata_planner.compute()?;
 
         Ok(Plan {
             metadata: metadata.clone(),
@@ -43,10 +59,71 @@ impl Planner {
         })
     }
 
-    pub fn compute_metadata(&self) -> Result<CoverageMetadata> {
+    fn compute_report_files(&self) -> Result<Vec<ReportFile>> {
+        let paths = if self.settings.paths.is_empty() {
+            self.config.coverage.paths.clone().unwrap_or_default()
+        } else {
+            self.settings.paths.clone()
+        };
+
+        let mut report_files: Vec<ReportFile> = vec![];
+
+        for path in paths {
+            let (path, format) = extract_path_and_format(&path, self.settings.report_format)?;
+
+            report_files.push(ReportFile {
+                path: path.to_string_lossy().into_owned(),
+                format: format.to_string(),
+                ..Default::default()
+            })
+        }
+
+        Ok(report_files)
+    }
+
+    fn compute_transformers(
+        &self,
+        metadata: &CoverageMetadata,
+    ) -> Result<Vec<Box<dyn Transformer>>> {
+        let mut transformers: Vec<Box<dyn Transformer>> = vec![];
+
+        transformers.push(Box::new(ComputeSummary::new()));
+
+        if let Some(prefix) = self.settings.strip_prefix.clone() {
+            transformers.push(Box::new(StripPrefix::new(prefix)));
+        } else if let Ok(strip_prefix) = StripPrefix::new_from_git_root() {
+            transformers.push(Box::new(strip_prefix));
+        }
+
+        transformers.push(Box::new(StripDotSlashPrefix));
+
+        if self.config.coverage.ignores.is_some() {
+            transformers.push(Box::new(IgnorePaths::new(
+                self.config.coverage.ignores.as_ref().unwrap(),
+            )?));
+        }
+
+        if let Some(prefix) = self.settings.add_prefix.clone() {
+            transformers.push(Box::new(AddPrefix::new(&prefix)));
+        }
+
+        transformers.push(Box::new(AppendMetadata::new(metadata)));
+        Ok(transformers)
+    }
+}
+
+impl MetadataPlanner {
+    pub fn new(settings: &Settings, ci: Option<Box<dyn CI>>) -> Self {
+        Self {
+            settings: settings.clone(),
+            ci,
+        }
+    }
+
+    pub fn compute(&self) -> Result<CoverageMetadata> {
         let now = OffsetDateTime::now_utc();
 
-        let mut metadata = if let Some(ci) = crate::ci::current() {
+        let mut metadata = if let Some(ref ci) = self.ci {
             ci.metadata()
         } else {
             CoverageMetadata {
@@ -167,58 +244,6 @@ impl Planner {
             timestamp_str
         )
     }
-
-    fn compute_report_files(&self) -> Result<Vec<ReportFile>> {
-        let paths = if self.settings.paths.is_empty() {
-            self.config.coverage.paths.clone().unwrap_or_default()
-        } else {
-            self.settings.paths.clone()
-        };
-
-        let mut report_files: Vec<ReportFile> = vec![];
-
-        for path in paths {
-            let (path, format) = extract_path_and_format(&path, self.settings.report_format)?;
-
-            report_files.push(ReportFile {
-                path: path.to_string_lossy().into_owned(),
-                format: format.to_string(),
-                ..Default::default()
-            })
-        }
-
-        Ok(report_files)
-    }
-
-    fn compute_transformers(
-        &self,
-        metadata: &CoverageMetadata,
-    ) -> Result<Vec<Box<dyn Transformer>>> {
-        let mut transformers: Vec<Box<dyn Transformer>> = vec![];
-
-        transformers.push(Box::new(ComputeSummary::new()));
-
-        if let Some(prefix) = self.settings.strip_prefix.clone() {
-            transformers.push(Box::new(StripPrefix::new(prefix)));
-        } else if let Ok(strip_prefix) = StripPrefix::new_from_git_root() {
-            transformers.push(Box::new(strip_prefix));
-        }
-
-        transformers.push(Box::new(StripDotSlashPrefix));
-
-        if self.config.coverage.ignores.is_some() {
-            transformers.push(Box::new(IgnorePaths::new(
-                self.config.coverage.ignores.as_ref().unwrap(),
-            )?));
-        }
-
-        if let Some(prefix) = self.settings.add_prefix.clone() {
-            transformers.push(Box::new(AddPrefix::new(&prefix)));
-        }
-
-        transformers.push(Box::new(AppendMetadata::new(metadata)));
-        Ok(transformers)
-    }
 }
 
 #[cfg(test)]
@@ -227,13 +252,12 @@ mod tests {
 
     #[test]
     fn planner_override_commit_time_tests() {
-        let config = QltyConfig::default();
         let settings = Settings {
             override_commit_time: Some("2025-05-30T05:00:00+00:00".to_string()),
             ..Default::default()
         };
-        let planner = Planner::new(&config, &settings);
-        let metadata = planner.compute_metadata().unwrap();
+        let metadata_planner = MetadataPlanner::new(&settings, None);
+        let metadata = metadata_planner.compute().unwrap();
         assert_eq!(
             metadata.commit_time,
             Some(Timestamp {
@@ -246,34 +270,33 @@ mod tests {
     #[test]
     fn test_parse_unix_timestamp() {
         let input = "1729100000";
-        let parsed = Planner::parse_timestamp(input).unwrap();
+        let parsed = MetadataPlanner::parse_timestamp(input).unwrap();
         assert_eq!(parsed, 1729100000);
     }
 
     #[test]
     fn test_parse_rfc3339() {
         let input = "2023-01-01T12:00:00Z";
-        let parsed = Planner::parse_timestamp(input).unwrap();
+        let parsed = MetadataPlanner::parse_timestamp(input).unwrap();
         assert_eq!(parsed, 1672574400);
     }
 
     #[test]
     fn test_parse_iso8601_basic() {
         let input = "2023-01-01T12:00:00+00:00"; // valid ISO8601::DEFAULT format
-        let parsed = Planner::parse_timestamp(input).unwrap();
+        let parsed = MetadataPlanner::parse_timestamp(input).unwrap();
         assert_eq!(parsed, 1672574400);
     }
 
     #[test]
     fn test_parse_invalid_format() {
         let input = "not-a-valid-timestamp";
-        let result = Planner::parse_timestamp(input);
+        let result = MetadataPlanner::parse_timestamp(input);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_metadata_with_all_overrides() {
-        let config = QltyConfig::default();
         let settings = Settings {
             override_build_id: Some("build-123".to_string()),
             override_commit_sha: Some("sha-abc".to_string()),
@@ -287,8 +310,8 @@ mod tests {
             incomplete: true,
             ..Default::default()
         };
-        let planner = Planner::new(&config, &settings);
-        let metadata = planner.compute_metadata().unwrap();
+        let metadata_planner = MetadataPlanner::new(&settings, None);
+        let metadata = metadata_planner.compute().unwrap();
         assert_eq!(metadata.build_id, "build-123");
         assert_eq!(metadata.commit_sha, "sha-abc");
         assert_eq!(metadata.branch, "main");
@@ -309,13 +332,12 @@ mod tests {
 
     #[test]
     fn test_metadata_with_only_commit_time_override() {
-        let config = QltyConfig::default();
         let settings = Settings {
             override_commit_time: Some("1729100000".to_string()),
             ..Default::default()
         };
-        let planner = Planner::new(&config, &settings);
-        let metadata = planner.compute_metadata().unwrap();
+        let metadata_planner = MetadataPlanner::new(&settings, None);
+        let metadata = metadata_planner.compute().unwrap();
         assert_eq!(
             metadata.commit_time,
             Some(Timestamp {
@@ -327,13 +349,12 @@ mod tests {
 
     #[test]
     fn test_metadata_with_git_tag_override() {
-        let config = QltyConfig::default();
         let settings = Settings {
             override_git_tag: Some("v2.0.0".to_string()),
             ..Default::default()
         };
-        let planner = Planner::new(&config, &settings);
-        let metadata = planner.compute_metadata().unwrap();
+        let metadata_planner = MetadataPlanner::new(&settings, None);
+        let metadata = metadata_planner.compute().unwrap();
         assert_eq!(metadata.git_tag, Some("v2.0.0".to_string()));
     }
 }


### PR DESCRIPTION
Vanilla refactor to extract out a MetadataPlanner object to make unit testing it easier.