### PR TITLE
chore: Introduce no-validate option for safe deploy of GitHub Action

### DIFF
--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -128,7 +128,7 @@ pub struct Publish {
     /// This will check if the report is valid and minimum number of files are present.
     pub validate: bool,
 
-    #[arg(long, hide = true)]
+    #[arg(long, conflicts_with = "validate", hide = true)]
     pub no_validate: bool,
 
     #[arg(long)]

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -128,6 +128,9 @@ pub struct Publish {
     /// This will check if the report is valid and minimum number of files are present.
     pub validate: bool,
 
+    #[arg(long, hide = true)]
+    pub no_validate: bool,
+
     #[arg(long)]
     /// Custom threshold percentage for validation (0-100). Only applies when --validate is used.
     /// Default is 90.


### PR DESCRIPTION
Accepts (but for now does nothing) with a `--no-validate` option (current behavior is to not validate by default)