### PR TITLE
feat: enable validation by default for qlty coverage publish (#2220)

### DIFF
--- a/qlty-cli/tests/cmd/coverage/basic.toml
+++ b/qlty-cli/tests/cmd/coverage/basic.toml
@@ -8,6 +8,7 @@ args = [
   "123",
   "--override-branch",
   "main",
+  "--no-validate",
   "lcov.info"
 ]
 bin.name = "qlty"

--- a/qlty-cli/tests/cmd/coverage/ignore_patterns.toml
+++ b/qlty-cli/tests/cmd/coverage/ignore_patterns.toml
@@ -8,6 +8,7 @@ args = [
   "123",
   "--override-branch",
   "main",
+  "--no-validate",
   "lcov.info"
 ]
 bin.name = "qlty"

--- a/qlty-cli/tests/cmd/coverage/json.stdout
+++ b/qlty-cli/tests/cmd/coverage/json.stdout
@@ -15,7 +15,7 @@
     "uploadedAt": "[..]",
     "cliVersion": "[..]",
     "uploaderTool": "qltysh/qlty-action-coverage",
-    "publishCommand": "[..]qlty[..] coverage publish --dry-run --print --json --override-commit-sha 2ca1bc45a94e37c8dbae6fd9e19fc069ba64bd67 --add-prefix rails/ --tag rails lcov.info",
+    "publishCommand": "[..]qlty[..] coverage publish --dry-run --print --json --override-commit-sha 2ca1bc45a94e37c8dbae6fd9e19fc069ba64bd67 --add-prefix rails/ --tag rails --no-validate lcov.info",
     "uploaderToolVersion": "v1.0.0",
     "referenceType": "REFERENCE_TYPE_BRANCH"
   },

--- a/qlty-cli/tests/cmd/coverage/json.toml
+++ b/qlty-cli/tests/cmd/coverage/json.toml
@@ -10,6 +10,7 @@ args = [
   "rails/",
   "--tag",
   "rails",
+  "--no-validate",
   "lcov.info"
 ]
 bin.name = "qlty"

--- a/qlty-cli/tests/cmd/coverage/override_commit_time.toml
+++ b/qlty-cli/tests/cmd/coverage/override_commit_time.toml
@@ -10,6 +10,7 @@ args = [
   "main",
   "--override-commit-time",
   "2025-05-30T05:00:00+00:00",
+  "--no-validate",
   "lcov.info"
 ]
 bin.name = "qlty"

--- a/qlty-cli/tests/cmd/coverage/override_git_tag.toml
+++ b/qlty-cli/tests/cmd/coverage/override_git_tag.toml
@@ -10,6 +10,7 @@ args = [
   "2025-05-30T05:00:00+00:00",
   "--override-git-tag",
   "v2.0.0-override",
+  "--no-validate",
   "lcov.info"
 ]
 bin.name = "qlty"

--- a/qlty-cli/tests/cmd/coverage/overrides.stdout
+++ b/qlty-cli/tests/cmd/coverage/overrides.stdout
@@ -15,7 +15,7 @@
     "tag": "rails",
     "uploadedAt": "[..]",
     "cliVersion": "[..]",
-    "publishCommand": "[..]qlty[..] coverage publish --dry-run --print --json --override-branch test-branch-1 --override-commit-sha 2ca1bc45a94e37c8dbae6fd9e19fc069ba64bd67 --override-pr-number 99 --transform-add-prefix rails/ --tag rails lcov.info",
+    "publishCommand": "[..]qlty[..] coverage publish --dry-run --print --json --override-branch test-branch-1 --override-commit-sha 2ca1bc45a94e37c8dbae6fd9e19fc069ba64bd67 --override-pr-number 99 --transform-add-prefix rails/ --tag rails --no-validate lcov.info",
     "referenceType": "REFERENCE_TYPE_PULL_REQUEST"
   },
   "report_files": [

--- a/qlty-cli/tests/cmd/coverage/overrides.toml
+++ b/qlty-cli/tests/cmd/coverage/overrides.toml
@@ -14,6 +14,7 @@ args = [
   "rails/",
   "--tag",
   "rails",
+  "--no-validate",
   "lcov.info"
 ]
 bin.name = "qlty"

--- a/qlty-cli/tests/cmd/coverage/publish_validate.toml
+++ b/qlty-cli/tests/cmd/coverage/publish_validate.toml
@@ -8,7 +8,6 @@ args = [
   "123",
   "--override-branch",
   "main",
-  "--validate",
   "lcov.info"
 ]
 bin.name = "qlty"

--- a/qlty-cli/tests/cmd/without_git/basic_coverage.toml
+++ b/qlty-cli/tests/cmd/without_git/basic_coverage.toml
@@ -12,6 +12,7 @@ args = [
   "2025-05-30T05:00:00+00:00",
   "--strip-prefix",
   "/",
+  "--no-validate",
   "lcov.info"
 ]
 bin.name = "qlty"


### PR DESCRIPTION
Re-introduction of validation by default -- originally merged in #2220 and reverted in #2282 to ensure safe GHA deploy.