### PR TITLE
fix: fix compilation error on `main`

### DIFF
--- a/qlty-config/src/sources/git_source.rs
+++ b/qlty-config/src/sources/git_source.rs
@@ -321,7 +321,7 @@ impl GitSource {
         }
     }
 
-    fn create_fetch_options(&self) -> Result<FetchOptions> {
+    fn create_fetch_options(&self) -> Result<FetchOptions<'_>> {
         let mut fetch_options = FetchOptions::new();
 
         let mut proxy_options = git2::ProxyOptions::new();


### PR DESCRIPTION
closes #2297 

Claude, locally, said:

```
The issue was that FetchOptions from the git2 crate has a lifetime
  parameter that was being elided in the return type. By adding '_ explicitly, we're making the lifetime clear and
  following Rust's lifetime elision rules properly.
```