### PR TITLE
fix: never check rustc version

### DIFF
--- a/qlty-check/src/tool/rust.rs
+++ b/qlty-check/src/tool/rust.rs
@@ -46,15 +46,7 @@ impl Tool for Rust {
     }
 
     fn version_command(&self) -> Option<String> {
-        if self.version_is_numeric() {
-            Some("rustc --version".to_string())
-        } else {
-            info!(
-                "Using a {} version of Rust, skipping version check",
-                self.version
-            );
-            None
-        }
+        None
     }
 
     fn clone_box(&self) -> Box<dyn Tool> {
@@ -179,26 +171,5 @@ impl Tool for RustPackage {
 
     fn plugin(&self) -> Option<PluginDef> {
         Some(self.plugin.clone())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    #[test]
-    fn test_skip_version_command_on_nightly() {
-        use super::*;
-        let rust = Rust {
-            version: "nightly".to_string(),
-        };
-        assert_eq!(rust.version_command(), None);
-    }
-
-    #[test]
-    fn test_use_version_command_on_numeric() {
-        use super::*;
-        let rust = Rust {
-            version: "1.60.0".to_string(),
-        };
-        assert_eq!(rust.version_command(), Some("rustc --version".to_string()));
     }
 }


### PR DESCRIPTION
It's causing unneeded breakages