### PR TITLE
fix: escape special characters in file paths for glob matching

### DIFF
--- a/qlty-smells/src/duplication/transformers.rs
+++ b/qlty-smells/src/duplication/transformers.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use globset::{Glob, GlobSet, GlobSetBuilder};
+use globset::{escape, Glob, GlobSet, GlobSetBuilder};
 use qlty_config::config::issue_transformer::IssueTransformer;
 use qlty_types::analysis::v1::Issue;
 use std::path::PathBuf;
@@ -15,7 +15,7 @@ impl InclusionPathMatcher {
         for path in paths {
             if path.is_file() {
                 if let Some(file_path) = path.to_str() {
-                    builder.add(Glob::new(file_path)?);
+                    builder.add(Glob::new(&escape(file_path))?);
                 }
             } else if path.is_dir() {
                 if let Some(dir_path) = path.join("**").to_str() {


### PR DESCRIPTION
## Summary
- Fixed glob parsing error that occurred when file paths contained special glob characters like brackets
- Added proper escaping using `globset::escape()` to treat file paths as literal strings rather than glob patterns
- This resolves the error: "error parsing glob 'apps/webapps/src/app/product/chubb-vehicle-rental/[code]/[...not-found]/page.tsx': invalid range; 't' > 'f'"

## Changes
Modified `/Users/bhelmkamp/p/qltysh/qlty/qlty-smells/src/duplication/transformers.rs` to escape file paths before using them in glob matching operations.

## Test plan
- [x] Run `cargo check` - typechecks pass
- [x] Run `qlty fmt` - code is properly formatted
- [x] Run `qlty check --level=low --fix` - no linting issues
- [x] Run `cargo test` - all tests pass
- [ ] Test with file paths containing special characters like brackets to verify the fix works

🤖 Generated with [Claude Code](https://claude.ai/code)