### PR TITLE
Claude-based solution for path-based packages

### DIFF
--- a/qlty-check/src/tool/python.rs
+++ b/qlty-check/src/tool/python.rs
@@ -157,7 +157,16 @@ impl Tool for PipVenvPackage {
     }
 
     fn package_install(&self, task: &ProgressTask, name: &str, version: &str) -> Result<()> {
-        task.set_dim_message(&format!("pip install {}@{}", name, version));
+        // Check if this is a path-based package (when version is empty)
+        let package_spec = if version.is_empty() {
+            // It's a local path, use it directly
+            task.set_dim_message(&format!("pip install {}", name));
+            name.to_string()
+        } else {
+            // It's a regular package with version
+            task.set_dim_message(&format!("pip install {}@{}", name, version));
+            format!("{}=={}", name, version)
+        };
 
         self.run_command(self.cmd.build(
             PYTHON_COMMAND,
@@ -167,7 +176,7 @@ impl Tool for PipVenvPackage {
                 "install",
                 "--prefix",
                 &self.directory(),
-                &format!("{}=={}", name, version),
+                &package_spec,
             ],
         ))
     }

--- a/qlty-check/src/tool/ruby.rs
+++ b/qlty-check/src/tool/ruby.rs
@@ -350,21 +350,40 @@ impl Tool for RubygemsPackage {
             return Ok(()); // tool needs to be installed in Gemfile when bundler is used
         }
 
-        task.set_message(&format!("gem install {}@{}", name, version));
-        self.run_command(self.cmd.build(
-            "ruby",
-            vec![
-                "-S",
-                "gem",
-                "install",
-                name,
-                "--no-document",
-                "--version",
-                version,
-                "--install-dir",
-                &path_to_native_string(self.directory()),
-            ],
-        ))
+        // Check if this is a path-based package (when version is empty)
+        if version.is_empty() {
+            // It's a local path, use it directly without --version flag
+            task.set_message(&format!("gem install {}", name));
+            self.run_command(self.cmd.build(
+                "ruby",
+                vec![
+                    "-S",
+                    "gem",
+                    "install",
+                    name,
+                    "--no-document",
+                    "--install-dir",
+                    &path_to_native_string(self.directory()),
+                ],
+            ))
+        } else {
+            // It's a regular package with version
+            task.set_message(&format!("gem install {}@{}", name, version));
+            self.run_command(self.cmd.build(
+                "ruby",
+                vec![
+                    "-S",
+                    "gem",
+                    "install",
+                    name,
+                    "--no-document",
+                    "--version",
+                    version,
+                    "--install-dir",
+                    &path_to_native_string(self.directory()),
+                ],
+            ))
+        }
     }
 
     fn package_file_install(&self, task: &ProgressTask) -> Result<()> {

--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -632,6 +632,7 @@ mod test {
             extra_packages: vec![ExtraPackage {
                 name: "pkg1".to_string(),
                 version: "1.0.0".to_string(),
+                is_path: false,
             }],
             drivers: vec!["driver1".to_string()],
             config_files: vec![PathBuf::from("config1")],
@@ -654,6 +655,7 @@ mod test {
             extra_packages: vec![ExtraPackage {
                 name: "pkg2".to_string(),
                 version: "2.0.0".to_string(),
+                is_path: false,
             }],
             drivers: vec!["driver2".to_string()],
             config_files: vec![PathBuf::from("config2")],
@@ -904,6 +906,7 @@ mod test {
                 extra_packages: vec![ExtraPackage {
                     name: "pkg1".to_string(),
                     version: "1.0.0".to_string(),
+                    is_path: false,
                 }],
                 drivers: vec!["driver1".to_string()],
                 config_files: vec![PathBuf::from("config1")],
@@ -925,6 +928,7 @@ mod test {
                 extra_packages: vec![ExtraPackage {
                     name: "pkg2".to_string(),
                     version: "2.0.0".to_string(),
+                    is_path: false,
                 }],
                 drivers: vec!["driver2".to_string()],
                 config_files: vec![PathBuf::from("config2")],


### PR DESCRIPTION
I tested this approach on a repository that contained an `npm` package inside their monorepo in a subdirectory.

E.g. the monorepo has an npm module located at `/packages/npm_module_foo` This allows them to specify a package with:

```
[plugin]
name = "eslint"
extra_packages = ["eslint-plugin-import@2.32.0", "path:./packages/npm_module_foo"]
````