### PR TITLE
Revert "build(deps): bump actions-rust-lang/setup-rust-toolchain from 1.14.1 to 1.15.0"

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39
+        uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a
         with:
           toolchain: stable
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39
+        uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a
         with:
           toolchain: stable
 

--- a/.github/workflows/cli_integration.yml
+++ b/.github/workflows/cli_integration.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39
+        uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a
         with:
           toolchain: stable
 

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -72,7 +72,7 @@ jobs:
         if: contains(matrix.os, 'windows')
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39
+        uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a
         with:
           toolchain: stable
 


### PR DESCRIPTION
Reverts qltysh/qlty#2385

[Builds are failing](https://github.com/qltysh/qlty/actions/runs/17994187812). 

Error is below

```
Run cargo build --target x86_64-unknown-linux-musl --all-features --release
  cargo build --target x86_64-unknown-linux-musl --all-features --release
  cargo test --target x86_64-unknown-linux-musl --all-features --release
  shell: /usr/bin/bash -e {0}
  env:
    BINARY_NAME: qlty
    CACHE_ON_FAILURE: true
    CARGO_INCREMENTAL: 0
    SEGMENT_WRITE_KEY: ***
    Updating crates.io index
   Compiling quote v1.0.40
   Compiling libc v0.2.171
   Compiling serde_core v1.0.226
   Compiling serde v1.0.226
error[E0463]: can't find crate for `core`
  |
  = note: the `x86_64-unknown-linux-musl` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-linux-musl`

error[E0463]: can't find crate for `std`
  |
  = note: the `x86_64-unknown-linux-musl` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-linux-musl`

For more information about this error, try `rustc --explain E0463`.
error: could not compile `serde_core` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `libc` (lib) due to 1 previous error
```

This dependency bump seems suspicious but I don't have a smoking gun.