### PR TITLE
fix: plugin configs not to include affects cache

### DIFF
--- a/qlty-cli/tests/cmd/check/driver_script_config_file_interpolation.in/.qlty/qlty.toml
+++ b/qlty-cli/tests/cmd/check/driver_script_config_file_interpolation.in/.qlty/qlty.toml
@@ -3,17 +3,11 @@ config_version = "0"
 [plugins.definitions.exists]
 file_types = ["shell"]
 config_files = ["config_file.json"]
+affects_cache = ["affects_cache.json"]
 
 [plugins.definitions.exists.drivers.lint]
 prepare_script = "mkdir ${linter} && echo dir %2 > ${linter}/ls.cmd || echo dir %2 > ${linter}/ls.cmd"
 script = "ls -l ${config_file}"
-success_codes = [0]
-output = "pass_fail"
-
-[plugins.definitions.exists.drivers.second]
-prepare_script = "mkdir ${linter} && echo dir %2 > ${linter}/ls.cmd || echo dir %2 > ${linter}/ls.cmd"
-script = "ls -l ${config_file}"
-copy_configs_into_tool_install = true
 success_codes = [0]
 output = "pass_fail"
 


### PR DESCRIPTION
Fix regression from https://github.com/qltysh/qlty/pull/2416

Affects cache should not be part of plugin_configs as those are used for driver script interpolation. 

Serendipitously the release action failed and it did not affect any users, noticed it when my local fmt did not show issues. https://github.com/qltysh/qlty/actions/runs/18167950643