### PR TITLE
fix(trufflehog): tag outbound verification calls with qlty user-agent suffix

### DIFF
--- a/qlty-plugins/plugins/linters/trufflehog/plugin.toml
+++ b/qlty-plugins/plugins/linters/trufflehog/plugin.toml
@@ -14,8 +14,20 @@ version_command = "trufflehog --version"
 description = "Security tool that scans code to find secrets accidentally committed"
 security = true
 
-[plugins.definitions.trufflehog.drivers.lint]
+[[plugins.definitions.trufflehog.drivers.lint.version]]
+version_matcher = "<3.82.9"
 script = "trufflehog filesystem --json --fail --only-verified --no-update ${target}"
+success_codes = [0, 183]
+output = "stdout"
+output_format = "trufflehog"
+cache_results = true
+batch = true
+suggested = "targets"
+output_missing = "parse"
+
+[[plugins.definitions.trufflehog.drivers.lint.version]]
+version_matcher = ">=3.82.9"
+script = "trufflehog filesystem --json --fail --only-verified --no-update --user-agent-suffix=qlty ${target}"
 success_codes = [0, 183]
 output = "stdout"
 output_format = "trufflehog"


### PR DESCRIPTION
## Summary

- TruffleHog's `--only-verified` mode calls the issuing service (AWS STS, GitHub, etc.) to confirm detected credentials are live. A Qlty customer got AWS security alerts because those calls landed in their logs as bare `TruffleHog/<version>` — indistinguishable from attacker activity.
- Append `--user-agent-suffix=qlty` to the default driver script so verification requests carry `TruffleHog/<version> qlty` and are trivially identifiable in SIEM / CloudTrail / GuardDuty.
- The flag was first shipped in trufflehog **v3.82.9** (PR trufflesecurity/trufflehog#3297, merged 2024-09-13). Customers pinned to older versions would hard-fail at CLI parse, so this uses the driver `version_matcher` mechanism (same pattern as the radarlint plugins) to keep the original script for `<3.82.9` and apply the suffix only for `>=3.82.9`.

## Why default it

Every trufflehog run launched by Qlty is, by construction, a sanctioned scan. Leaving those calls visually indistinguishable from live-credential abuse is a customer footgun — a default fix protects everyone, not just customers who think to configure it. Truffle Security [recommends this pattern](https://trufflesecurity.com/blog/trufflehog-in-your-log) for the same reason, and Datadog [ships a default detector](https://docs.datadoghq.com/security/default_rules/def-000-f2a/) keyed on the bare `TruffleHog` User-Agent.

## Test plan

- [ ] `cargo check` — clean
- [ ] `cargo test` — full suite green
- [ ] `qlty fmt` + `qlty check --level=low --fix` on `plugin.toml` — no issues
- [ ] Plugin snapshot tests (`npm test` under `qlty-plugins/plugins`) pass on both version branches:
  - [ ] `secrets_v3.73.0` / `secrets_v3.80.1` still run via the `<3.82.9` script (no suffix flag, unchanged behavior)
  - [ ] `secrets_v3.82.12` / `no_issues_v3.82.12` run via the `>=3.82.9` script — JSON output unchanged since the suffix only affects outbound HTTP headers
- [ ] Manual smoke test: pin `trufflehog = "3.82.12"`, run `qlty check`, inspect the invoked command and confirm the `--user-agent-suffix=qlty` arg is present
- [ ] Manual smoke test: pin `trufflehog = "3.80.1"`, run `qlty check`, confirm the legacy script (no suffix) is used and trufflehog does not error

## Out of scope

Exposing a first-class `extra_args` / `append_args` field on `DriverDef` so users could customize flags without re-specifying the full script — worth a separate discussion if there's appetite.