### PR TITLE
feat(cli): centralize config loading with --skip-source-fetch support

### DIFF
--- a/qlty-cli/src/commands/build.rs
+++ b/qlty-cli/src/commands/build.rs
@@ -60,12 +60,7 @@ pub struct Build {
 impl Build {
     pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
         let workspace = Workspace::require_initialized()?;
-
-        if self.fetch_sources {
-            workspace.fetch_sources()?;
-        }
-
-        let config = workspace.config()?;
+        let config = workspace.load_config(!self.fetch_sources)?;
 
         let mut report = Report {
             metadata: self.build_metadata(&config),

--- a/qlty-cli/src/commands/check.rs
+++ b/qlty-cli/src/commands/check.rs
@@ -150,10 +150,7 @@ impl Check {
         self.validate_options()?;
 
         let workspace = Workspace::require_initialized()?;
-
-        if !self.skip_source_fetch {
-            workspace.fetch_sources()?;
-        }
+        workspace.prepare_sources(self.skip_source_fetch)?;
 
         let git_hook_stdin = if self.upstream_from_pre_push {
             match Self::read_pre_push_stdin()? {

--- a/qlty-cli/src/commands/config/migrate.rs
+++ b/qlty-cli/src/commands/config/migrate.rs
@@ -32,7 +32,7 @@ impl Migrate {
 
         let migration_settings = MigrationSettings::new(
             &workspace.root,
-            workspace.config()?,
+            workspace.load_config(false)?,
             &workspace.config_path()?,
             &classic_config_path,
             self.dry_run,

--- a/qlty-cli/src/commands/config/migrate.rs
+++ b/qlty-cli/src/commands/config/migrate.rs
@@ -32,7 +32,7 @@ impl Migrate {
 
         let migration_settings = MigrationSettings::new(
             &workspace.root,
-            workspace.load_config(false)?,
+            workspace.config()?,
             &workspace.config_path()?,
             &classic_config_path,
             self.dry_run,

--- a/qlty-cli/src/commands/config/show.rs
+++ b/qlty-cli/src/commands/config/show.rs
@@ -9,9 +9,7 @@ pub struct Show {}
 impl Show {
     pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
         let workspace = Workspace::require_initialized()?;
-        workspace.fetch_sources()?;
-
-        let config = workspace.config()?;
+        let config = workspace.load_config(false)?;
         let yaml_string = serde_yaml::to_string(&config).unwrap();
         println!("{}", yaml_string);
         CommandSuccess::ok()

--- a/qlty-cli/src/commands/config/validate.rs
+++ b/qlty-cli/src/commands/config/validate.rs
@@ -9,8 +9,7 @@ pub struct Validate {}
 impl Validate {
     pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
         let workspace = Workspace::require_initialized()?;
-        workspace.fetch_sources()?;
-        workspace.config()?;
+        workspace.load_config(false)?;
         CommandSuccess::ok()
     }
 }

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -149,6 +149,10 @@ pub struct Publish {
     /// The server will merge the uploads into a single report when qlty coverage complete is called.
     pub incomplete: bool,
 
+    /// Skip fetching sources before publishing. Requires sources to be cached locally.
+    #[arg(long)]
+    pub skip_source_fetch: bool,
+
     // Paths to coverage reports
     pub paths: Vec<String>,
 }
@@ -178,7 +182,7 @@ impl Publish {
             load_auth_token(&self.token, self.project.as_deref())?
         };
 
-        let config = load_config();
+        let config = load_config(self.skip_source_fetch);
         let plan = Planner::new(&config, &settings).compute()?;
 
         self.validate_plan(&plan)?;
@@ -255,7 +259,7 @@ impl Publish {
         let incomplete: bool = self.incomplete || self.total_parts_count.unwrap_or(1) > 1;
 
         let root = std::env::current_dir()?;
-        let config = load_config();
+        let config = load_config(self.skip_source_fetch);
         let java_src_dirs = if self.discover_java_src_dirs {
             let exclusion_strategy = if config.exclude_patterns.is_empty() {
                 ExclusionStrategy::DefaultHeuristics

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -1,6 +1,6 @@
 use super::utils::{
-    load_config, print_authentication_info, print_initial_messages, print_metadata, print_settings,
-    validate_metadata,
+    load_config_or_default, print_authentication_info, print_initial_messages, print_metadata,
+    print_settings, validate_metadata,
 };
 use crate::{CommandError, CommandSuccess};
 use anyhow::{bail, Result};
@@ -182,7 +182,7 @@ impl Publish {
             load_auth_token(&self.token, self.project.as_deref())?
         };
 
-        let config = load_config(self.skip_source_fetch);
+        let config = load_config_or_default(self.skip_source_fetch)?;
         let plan = Planner::new(&config, &settings).compute()?;
 
         self.validate_plan(&plan)?;
@@ -259,7 +259,7 @@ impl Publish {
         let incomplete: bool = self.incomplete || self.total_parts_count.unwrap_or(1) > 1;
 
         let root = std::env::current_dir()?;
-        let config = load_config(self.skip_source_fetch);
+        let config = load_config_or_default(self.skip_source_fetch)?;
         let java_src_dirs = if self.discover_java_src_dirs {
             let exclusion_strategy = if config.exclude_patterns.is_empty() {
                 ExclusionStrategy::DefaultHeuristics

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -1,6 +1,6 @@
 use super::utils::{
-    load_config_or_default, print_authentication_info, print_initial_messages, print_metadata,
-    print_settings, validate_metadata,
+    load_config, print_authentication_info, print_initial_messages, print_metadata, print_settings,
+    validate_metadata,
 };
 use crate::{CommandError, CommandSuccess};
 use anyhow::{bail, Result};
@@ -182,7 +182,7 @@ impl Publish {
             load_auth_token(&self.token, self.project.as_deref())?
         };
 
-        let config = load_config_or_default(self.skip_source_fetch)?;
+        let config = load_config(self.skip_source_fetch)?;
         let plan = Planner::new(&config, &settings).compute()?;
 
         self.validate_plan(&plan)?;
@@ -259,7 +259,7 @@ impl Publish {
         let incomplete: bool = self.incomplete || self.total_parts_count.unwrap_or(1) > 1;
 
         let root = std::env::current_dir()?;
-        let config = load_config_or_default(self.skip_source_fetch)?;
+        let config = load_config(self.skip_source_fetch)?;
         let java_src_dirs = if self.discover_java_src_dirs {
             let exclusion_strategy = if config.exclude_patterns.is_empty() {
                 ExclusionStrategy::DefaultHeuristics

--- a/qlty-cli/src/commands/coverage/utils.rs
+++ b/qlty-cli/src/commands/coverage/utils.rs
@@ -11,12 +11,9 @@ const COVERAGE_TOKEN_WORKSPACE_PREFIX: &str = "qltcw_";
 const COVERAGE_TOKEN_PROJECT_PREFIX: &str = "qltcp_";
 const OIDC_REGEX: &str = r"^([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)$";
 
-pub fn load_config() -> QltyConfig {
+pub fn load_config(skip_source_fetch: bool) -> QltyConfig {
     Workspace::new()
-        .and_then(|workspace| {
-            workspace.fetch_sources()?;
-            workspace.config()
-        })
+        .and_then(|workspace| workspace.load_config(skip_source_fetch))
         .unwrap_or_default()
 }
 

--- a/qlty-cli/src/commands/coverage/utils.rs
+++ b/qlty-cli/src/commands/coverage/utils.rs
@@ -15,7 +15,10 @@ pub fn load_config(skip_source_fetch: bool) -> Result<QltyConfig> {
     let Ok(workspace) = Workspace::new() else {
         return Ok(QltyConfig::default());
     };
+    load_config_for(&workspace, skip_source_fetch)
+}
 
+fn load_config_for(workspace: &Workspace, skip_source_fetch: bool) -> Result<QltyConfig> {
     if !workspace.config_exists()? {
         return Ok(QltyConfig::default());
     }
@@ -238,4 +241,82 @@ pub fn print_minimal_metadata(metadata: &CoverageMetadata, quiet: bool) {
     }
 
     eprintln!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use qlty_test_utilities::git::sample_repo;
+    use std::fs;
+
+    fn write_qlty_toml(root: &std::path::Path, contents: &str) {
+        fs::create_dir_all(root.join(".qlty")).unwrap();
+        fs::write(root.join(".qlty/qlty.toml"), contents).unwrap();
+    }
+
+    #[test]
+    fn test_load_config_when_qlty_toml_missing() {
+        let (temp_dir, _) = sample_repo();
+        let workspace = Workspace {
+            root: temp_dir.path().to_path_buf(),
+        };
+
+        let config = load_config_for(&workspace, false).unwrap();
+
+        assert_eq!(config.config_version, None);
+        assert!(config.plugin.is_empty());
+        assert!(config.exclude_patterns.is_empty());
+        assert_eq!(config.coverage.paths, None);
+        assert_eq!(config.coverage.ignores, None);
+    }
+
+    #[test]
+    fn test_load_config_when_qlty_toml_present_loads() {
+        let (temp_dir, _) = sample_repo();
+        write_qlty_toml(
+            temp_dir.path(),
+            r#"
+config_version = "0"
+
+[[source]]
+name = "default"
+default = true
+"#,
+        );
+        let workspace = Workspace {
+            root: temp_dir.path().to_path_buf(),
+        };
+
+        let config = load_config_for(&workspace, false).unwrap();
+
+        assert_eq!(config.config_version, Some("0".to_string()));
+    }
+
+    #[test]
+    fn test_load_config_errors_when_skip_and_git_source_not_cached() {
+        let (temp_dir, _) = sample_repo();
+        write_qlty_toml(
+            temp_dir.path(),
+            r#"
+config_version = "0"
+
+[[source]]
+name = "custom"
+repository = "https://github.com/qltysh/plugins"
+tag = "v99.99.99"
+"#,
+        );
+        let workspace = Workspace {
+            root: temp_dir.path().to_path_buf(),
+        };
+
+        let result = load_config_for(&workspace, true);
+
+        assert!(result.is_err());
+        let error_message = format!("{:#}", result.unwrap_err());
+        assert!(
+            error_message.contains("not available locally"),
+            "unexpected error: {error_message}"
+        );
+    }
 }

--- a/qlty-cli/src/commands/coverage/utils.rs
+++ b/qlty-cli/src/commands/coverage/utils.rs
@@ -11,21 +11,14 @@ const COVERAGE_TOKEN_WORKSPACE_PREFIX: &str = "qltcw_";
 const COVERAGE_TOKEN_PROJECT_PREFIX: &str = "qltcp_";
 const OIDC_REGEX: &str = r"^([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)$";
 
-/// Loads the workspace config, falling back to `QltyConfig::default()` when
-/// there is no workspace (e.g. not inside a git repo) or no `.qlty/qlty.toml`.
-/// Any other failure — e.g. fetch errors, or missing source cache when
-/// `skip_source_fetch` is true — is surfaced to the caller.
-pub fn load_config_or_default(skip_source_fetch: bool) -> Result<QltyConfig> {
+pub fn load_config(skip_source_fetch: bool) -> Result<QltyConfig> {
     let Ok(workspace) = Workspace::new() else {
         return Ok(QltyConfig::default());
     };
-    load_config_or_default_for(&workspace, skip_source_fetch)
+    load_config_for(&workspace, skip_source_fetch)
 }
 
-fn load_config_or_default_for(
-    workspace: &Workspace,
-    skip_source_fetch: bool,
-) -> Result<QltyConfig> {
+fn load_config_for(workspace: &Workspace, skip_source_fetch: bool) -> Result<QltyConfig> {
     if !workspace.config_exists()? {
         return Ok(QltyConfig::default());
     }
@@ -262,13 +255,13 @@ mod tests {
     }
 
     #[test]
-    fn test_load_config_or_default_when_qlty_toml_missing() {
+    fn test_load_config_when_qlty_toml_missing() {
         let (temp_dir, _) = sample_repo();
         let workspace = Workspace {
             root: temp_dir.path().to_path_buf(),
         };
 
-        let config = load_config_or_default_for(&workspace, false).unwrap();
+        let config = load_config_for(&workspace, false).unwrap();
 
         assert_eq!(config.config_version, None);
         assert!(config.plugin.is_empty());
@@ -278,7 +271,7 @@ mod tests {
     }
 
     #[test]
-    fn test_load_config_or_default_when_qlty_toml_present_loads() {
+    fn test_load_config_when_qlty_toml_present_loads() {
         let (temp_dir, _) = sample_repo();
         write_qlty_toml(
             temp_dir.path(),
@@ -294,13 +287,13 @@ default = true
             root: temp_dir.path().to_path_buf(),
         };
 
-        let config = load_config_or_default_for(&workspace, false).unwrap();
+        let config = load_config_for(&workspace, false).unwrap();
 
         assert_eq!(config.config_version, Some("0".to_string()));
     }
 
     #[test]
-    fn test_load_config_or_default_errors_when_skip_and_git_source_not_cached() {
+    fn test_load_config_errors_when_skip_and_git_source_not_cached() {
         let (temp_dir, _) = sample_repo();
         write_qlty_toml(
             temp_dir.path(),
@@ -317,7 +310,7 @@ tag = "v99.99.99"
             root: temp_dir.path().to_path_buf(),
         };
 
-        let result = load_config_or_default_for(&workspace, true);
+        let result = load_config_for(&workspace, true);
 
         assert!(result.is_err());
         let error_message = format!("{:#}", result.unwrap_err());

--- a/qlty-cli/src/commands/coverage/utils.rs
+++ b/qlty-cli/src/commands/coverage/utils.rs
@@ -272,6 +272,9 @@ mod tests {
 
         assert_eq!(config.config_version, None);
         assert!(config.plugin.is_empty());
+        assert!(config.exclude_patterns.is_empty());
+        assert_eq!(config.coverage.paths, None);
+        assert_eq!(config.coverage.ignores, None);
     }
 
     #[test]

--- a/qlty-cli/src/commands/coverage/utils.rs
+++ b/qlty-cli/src/commands/coverage/utils.rs
@@ -15,10 +15,7 @@ pub fn load_config(skip_source_fetch: bool) -> Result<QltyConfig> {
     let Ok(workspace) = Workspace::new() else {
         return Ok(QltyConfig::default());
     };
-    load_config_for(&workspace, skip_source_fetch)
-}
 
-fn load_config_for(workspace: &Workspace, skip_source_fetch: bool) -> Result<QltyConfig> {
     if !workspace.config_exists()? {
         return Ok(QltyConfig::default());
     }
@@ -241,82 +238,4 @@ pub fn print_minimal_metadata(metadata: &CoverageMetadata, quiet: bool) {
     }
 
     eprintln!();
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use qlty_test_utilities::git::sample_repo;
-    use std::fs;
-
-    fn write_qlty_toml(root: &std::path::Path, contents: &str) {
-        fs::create_dir_all(root.join(".qlty")).unwrap();
-        fs::write(root.join(".qlty/qlty.toml"), contents).unwrap();
-    }
-
-    #[test]
-    fn test_load_config_when_qlty_toml_missing() {
-        let (temp_dir, _) = sample_repo();
-        let workspace = Workspace {
-            root: temp_dir.path().to_path_buf(),
-        };
-
-        let config = load_config_for(&workspace, false).unwrap();
-
-        assert_eq!(config.config_version, None);
-        assert!(config.plugin.is_empty());
-        assert!(config.exclude_patterns.is_empty());
-        assert_eq!(config.coverage.paths, None);
-        assert_eq!(config.coverage.ignores, None);
-    }
-
-    #[test]
-    fn test_load_config_when_qlty_toml_present_loads() {
-        let (temp_dir, _) = sample_repo();
-        write_qlty_toml(
-            temp_dir.path(),
-            r#"
-config_version = "0"
-
-[[source]]
-name = "default"
-default = true
-"#,
-        );
-        let workspace = Workspace {
-            root: temp_dir.path().to_path_buf(),
-        };
-
-        let config = load_config_for(&workspace, false).unwrap();
-
-        assert_eq!(config.config_version, Some("0".to_string()));
-    }
-
-    #[test]
-    fn test_load_config_errors_when_skip_and_git_source_not_cached() {
-        let (temp_dir, _) = sample_repo();
-        write_qlty_toml(
-            temp_dir.path(),
-            r#"
-config_version = "0"
-
-[[source]]
-name = "custom"
-repository = "https://github.com/qltysh/plugins"
-tag = "v99.99.99"
-"#,
-        );
-        let workspace = Workspace {
-            root: temp_dir.path().to_path_buf(),
-        };
-
-        let result = load_config_for(&workspace, true);
-
-        assert!(result.is_err());
-        let error_message = format!("{:#}", result.unwrap_err());
-        assert!(
-            error_message.contains("not available locally"),
-            "unexpected error: {error_message}"
-        );
-    }
 }

--- a/qlty-cli/src/commands/coverage/utils.rs
+++ b/qlty-cli/src/commands/coverage/utils.rs
@@ -11,10 +11,26 @@ const COVERAGE_TOKEN_WORKSPACE_PREFIX: &str = "qltcw_";
 const COVERAGE_TOKEN_PROJECT_PREFIX: &str = "qltcp_";
 const OIDC_REGEX: &str = r"^([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)$";
 
-pub fn load_config(skip_source_fetch: bool) -> QltyConfig {
-    Workspace::new()
-        .and_then(|workspace| workspace.load_config(skip_source_fetch))
-        .unwrap_or_default()
+/// Loads the workspace config, falling back to `QltyConfig::default()` when
+/// there is no workspace (e.g. not inside a git repo) or no `.qlty/qlty.toml`.
+/// Any other failure — e.g. fetch errors, or missing source cache when
+/// `skip_source_fetch` is true — is surfaced to the caller.
+pub fn load_config_or_default(skip_source_fetch: bool) -> Result<QltyConfig> {
+    let Ok(workspace) = Workspace::new() else {
+        return Ok(QltyConfig::default());
+    };
+    load_config_or_default_for(&workspace, skip_source_fetch)
+}
+
+fn load_config_or_default_for(
+    workspace: &Workspace,
+    skip_source_fetch: bool,
+) -> Result<QltyConfig> {
+    if !workspace.config_exists()? {
+        return Ok(QltyConfig::default());
+    }
+
+    workspace.load_config(skip_source_fetch)
 }
 
 pub fn print_initial_messages(quiet: bool) {
@@ -232,4 +248,79 @@ pub fn print_minimal_metadata(metadata: &CoverageMetadata, quiet: bool) {
     }
 
     eprintln!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use qlty_test_utilities::git::sample_repo;
+    use std::fs;
+
+    fn write_qlty_toml(root: &std::path::Path, contents: &str) {
+        fs::create_dir_all(root.join(".qlty")).unwrap();
+        fs::write(root.join(".qlty/qlty.toml"), contents).unwrap();
+    }
+
+    #[test]
+    fn test_load_config_or_default_when_qlty_toml_missing() {
+        let (temp_dir, _) = sample_repo();
+        let workspace = Workspace {
+            root: temp_dir.path().to_path_buf(),
+        };
+
+        let config = load_config_or_default_for(&workspace, false).unwrap();
+
+        assert_eq!(config.config_version, None);
+        assert!(config.plugin.is_empty());
+    }
+
+    #[test]
+    fn test_load_config_or_default_when_qlty_toml_present_loads() {
+        let (temp_dir, _) = sample_repo();
+        write_qlty_toml(
+            temp_dir.path(),
+            r#"
+config_version = "0"
+
+[[source]]
+name = "default"
+default = true
+"#,
+        );
+        let workspace = Workspace {
+            root: temp_dir.path().to_path_buf(),
+        };
+
+        let config = load_config_or_default_for(&workspace, false).unwrap();
+
+        assert_eq!(config.config_version, Some("0".to_string()));
+    }
+
+    #[test]
+    fn test_load_config_or_default_errors_when_skip_and_git_source_not_cached() {
+        let (temp_dir, _) = sample_repo();
+        write_qlty_toml(
+            temp_dir.path(),
+            r#"
+config_version = "0"
+
+[[source]]
+name = "custom"
+repository = "https://github.com/qltysh/plugins"
+tag = "v99.99.99"
+"#,
+        );
+        let workspace = Workspace {
+            root: temp_dir.path().to_path_buf(),
+        };
+
+        let result = load_config_or_default_for(&workspace, true);
+
+        assert!(result.is_err());
+        let error_message = format!("{:#}", result.unwrap_err());
+        assert!(
+            error_message.contains("not available locally"),
+            "unexpected error: {error_message}"
+        );
+    }
 }

--- a/qlty-cli/src/commands/fmt.rs
+++ b/qlty-cli/src/commands/fmt.rs
@@ -65,10 +65,7 @@ impl Fmt {
         self.validate_options()?;
 
         let workspace = Workspace::require_initialized()?;
-
-        if !self.skip_source_fetch {
-            workspace.fetch_sources()?;
-        }
+        workspace.prepare_sources(self.skip_source_fetch)?;
 
         let settings = self.build_settings()?;
         let plan = Planner::new(ExecutionVerb::Fmt, &settings)?.compute()?;

--- a/qlty-cli/src/commands/install.rs
+++ b/qlty-cli/src/commands/install.rs
@@ -34,8 +34,7 @@ pub struct Install {
 impl Install {
     pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
         let workspace = Workspace::require_initialized()?;
-        workspace.fetch_sources()?;
-        let config = workspace.config()?;
+        let config = workspace.load_config(false)?;
 
         let mut settings = Settings {
             root: workspace.root.clone(),

--- a/qlty-cli/src/commands/metrics.rs
+++ b/qlty-cli/src/commands/metrics.rs
@@ -86,12 +86,11 @@ impl Metrics {
         self.run_assertions()?;
 
         let workspace = Workspace::new()?;
-        workspace.fetch_sources()?;
+        let config = workspace.load_config(false)?;
 
         let mut steps = Steps::new(self.quiet, 3);
         steps.start(THINKING, "Planning... ");
 
-        let config = workspace.config()?;
         let target_mode = self.compute_target_mode(&workspace);
         let mut workspace_entry_finder_builder = WorkspaceEntryFinderBuilder {
             mode: target_mode.clone(),

--- a/qlty-cli/src/commands/parse.rs
+++ b/qlty-cli/src/commands/parse.rs
@@ -22,9 +22,7 @@ pub struct Parse {
 impl Parse {
     pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
         let workspace = Workspace::new()?;
-        workspace.fetch_sources()?;
-
-        let config = workspace.config()?;
+        let config = workspace.load_config(false)?;
 
         let mut workspace_entry_finder_builder = WorkspaceEntryFinderBuilder {
             mode: TargetMode::Paths(1),

--- a/qlty-cli/src/commands/plugins/disable.rs
+++ b/qlty-cli/src/commands/plugins/disable.rs
@@ -55,7 +55,7 @@ impl ConfigDocument {
 impl Disable {
     pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
         let workspace = Workspace::require_initialized()?;
-        workspace.fetch_sources()?;
+        workspace.load_config(false)?;
 
         let mut config = ConfigDocument::new(&workspace)?;
 

--- a/qlty-cli/src/commands/plugins/enable.rs
+++ b/qlty-cli/src/commands/plugins/enable.rs
@@ -186,7 +186,7 @@ impl Enable {
         let workspace = Workspace::new()?;
 
         if workspace.config_exists()? {
-            workspace.fetch_sources()?;
+            workspace.load_config(false)?;
         } else {
             let library = workspace.library()?;
             library.create()?;

--- a/qlty-cli/src/commands/plugins/list.rs
+++ b/qlty-cli/src/commands/plugins/list.rs
@@ -10,8 +10,7 @@ pub struct List {}
 impl List {
     pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
         let workspace = Workspace::require_initialized()?;
-        workspace.fetch_sources()?;
-        let config = workspace.config()?;
+        let config = workspace.load_config(false)?;
 
         let mut available_plugin_names = config
             .plugins

--- a/qlty-cli/src/commands/plugins/upgrade.rs
+++ b/qlty-cli/src/commands/plugins/upgrade.rs
@@ -84,7 +84,7 @@ impl ConfigDocument {
 impl Upgrade {
     pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
         let workspace = Workspace::require_initialized()?;
-        workspace.fetch_sources()?;
+        workspace.load_config(false)?;
 
         let mut config = ConfigDocument::new(&workspace)?;
 

--- a/qlty-cli/src/commands/smells.rs
+++ b/qlty-cli/src/commands/smells.rs
@@ -63,9 +63,7 @@ impl Smells {
         self.run_assertions()?;
 
         let workspace = Workspace::new()?;
-        workspace.fetch_sources()?;
-
-        let config = workspace.config()?;
+        let config = workspace.load_config(false)?;
 
         let mut steps_count = 2;
 

--- a/qlty-cli/src/commands/validate.rs
+++ b/qlty-cli/src/commands/validate.rs
@@ -11,7 +11,7 @@ pub struct Validate {}
 impl Validate {
     pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
         let workspace = Workspace::require_initialized()?;
-        workspace.fetch_sources()?;
+        workspace.prepare_sources(false)?;
 
         let settings = self.build_settings()?;
         let plan = Planner::new(ExecutionVerb::Validate, &settings)?.compute()?;

--- a/qlty-cli/src/ui/unformatted.rs
+++ b/qlty-cli/src/ui/unformatted.rs
@@ -96,7 +96,7 @@ pub fn print_unformatted(
 
 fn apply_fmt(writer: &mut dyn std::io::Write, settings: &Settings) -> Result<bool> {
     let workspace = Workspace::require_initialized()?;
-    workspace.fetch_sources()?;
+    workspace.prepare_sources(false)?;
 
     let mut settings = settings.clone();
 

--- a/qlty-config/src/config.rs
+++ b/qlty-config/src/config.rs
@@ -201,7 +201,6 @@ mod test {
     #[test]
     fn default() {
         let workspace = Workspace::new().unwrap();
-        workspace.fetch_sources().unwrap();
-        workspace.config().unwrap();
+        workspace.load_config(false).unwrap();
     }
 }

--- a/qlty-config/src/config.rs
+++ b/qlty-config/src/config.rs
@@ -196,21 +196,11 @@ default = true
 
 #[cfg(test)]
 mod test {
-    use crate::{QltyConfig, Workspace};
+    use crate::Workspace;
 
     #[test]
     fn default() {
         let workspace = Workspace::new().unwrap();
         workspace.load_config(false).unwrap();
-    }
-
-    #[test]
-    fn qlty_config_default_is_empty() {
-        let config = QltyConfig::default();
-        assert_eq!(config.config_version, None);
-        assert!(config.plugin.is_empty());
-        assert!(config.exclude_patterns.is_empty());
-        assert_eq!(config.coverage.paths, None);
-        assert_eq!(config.coverage.ignores, None);
     }
 }

--- a/qlty-config/src/config.rs
+++ b/qlty-config/src/config.rs
@@ -196,11 +196,21 @@ default = true
 
 #[cfg(test)]
 mod test {
-    use crate::Workspace;
+    use crate::{QltyConfig, Workspace};
 
     #[test]
     fn default() {
         let workspace = Workspace::new().unwrap();
         workspace.load_config(false).unwrap();
+    }
+
+    #[test]
+    fn qlty_config_default_is_empty() {
+        let config = QltyConfig::default();
+        assert_eq!(config.config_version, None);
+        assert!(config.plugin.is_empty());
+        assert!(config.exclude_patterns.is_empty());
+        assert_eq!(config.coverage.paths, None);
+        assert_eq!(config.coverage.ignores, None);
     }
 }

--- a/qlty-config/src/migration/checks.rs
+++ b/qlty-config/src/migration/checks.rs
@@ -183,11 +183,7 @@ impl CheckMigration {
             DUPLICATION_DEFAULT_THRESHOLD,
         );
 
-        Self::migrate_default(
-            smells_table,
-            "similar_code",
-            DUPLICATION_DEFAULT_THRESHOLD,
-        );
+        Self::migrate_default(smells_table, "similar_code", DUPLICATION_DEFAULT_THRESHOLD);
 
         Ok(())
     }

--- a/qlty-config/src/sources/git_source.rs
+++ b/qlty-config/src/sources/git_source.rs
@@ -26,6 +26,10 @@ pub enum GitSourceReference {
 }
 
 impl Source for GitSource {
+    fn is_cached(&self) -> bool {
+        self.local_origin_ref_path(&self.library).exists()
+    }
+
     fn paths(&self) -> Result<Vec<PathBuf>> {
         let local_source = self.local_source();
         local_source.paths()

--- a/qlty-config/src/sources/source.rs
+++ b/qlty-config/src/sources/source.rs
@@ -75,6 +75,10 @@ impl Default for Box<dyn SourceFetch> {
 }
 
 pub trait Source: SourceFetch {
+    fn is_cached(&self) -> bool {
+        true
+    }
+
     fn plugin_tomls(&self) -> Result<Vec<SourceFile>> {
         let mut globset_builder = GlobSetBuilder::new();
 

--- a/qlty-config/src/sources/sources_list.rs
+++ b/qlty-config/src/sources/sources_list.rs
@@ -1,6 +1,6 @@
 use super::{Source, SourceFetch};
 use crate::TomlMerge;
-use anyhow::Result;
+use anyhow::{bail, Result};
 
 #[derive(Default, Clone)]
 pub struct SourcesList {
@@ -29,6 +29,18 @@ impl SourcesList {
 
         Ok(toml)
     }
+
+    pub fn validate_sources_cached(&self) -> Result<()> {
+        for source in &self.sources {
+            if !source.is_cached() {
+                bail!(
+                    "Source is not available locally. Run without --skip-source-fetch, or run `qlty sources fetch` first."
+                );
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl SourceFetch for SourcesList {
@@ -46,5 +58,52 @@ impl SourceFetch for SourcesList {
 
     fn clone_box(&self) -> Box<dyn SourceFetch> {
         Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::sources::{DefaultSource, GitSource, GitSourceReference, LocalSource};
+    use crate::Library;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_validate_sources_cached_with_empty_list() {
+        let sources_list = SourcesList::new();
+        assert!(sources_list.validate_sources_cached().is_ok());
+    }
+
+    #[test]
+    fn test_validate_sources_cached_with_default_source() {
+        let mut sources_list = SourcesList::new();
+        sources_list.sources.push(Box::new(DefaultSource {}));
+        assert!(sources_list.validate_sources_cached().is_ok());
+    }
+
+    #[test]
+    fn test_validate_sources_cached_with_local_source() {
+        let mut sources_list = SourcesList::new();
+        sources_list.sources.push(Box::new(LocalSource {
+            root: Path::new("/nonexistent/path").to_path_buf(),
+        }));
+        assert!(sources_list.validate_sources_cached().is_ok());
+    }
+
+    #[test]
+    fn test_validate_sources_cached_errors_when_git_source_not_cached() {
+        let temp_dir = tempdir().unwrap();
+        let library = Library::new(temp_dir.path()).unwrap();
+        let git_source = GitSource {
+            library,
+            origin: "https://github.com/qltysh/plugins".to_string(),
+            reference: GitSourceReference::Tag("v1.0.0".to_string()),
+        };
+
+        let mut sources_list = SourcesList::new();
+        sources_list.sources.push(Box::new(git_source));
+
+        assert!(sources_list.validate_sources_cached().is_err());
     }
 }

--- a/qlty-config/src/sources/sources_list.rs
+++ b/qlty-config/src/sources/sources_list.rs
@@ -34,7 +34,8 @@ impl SourcesList {
         for source in &self.sources {
             if !source.is_cached() {
                 bail!(
-                    "Source is not available locally. Run without --skip-source-fetch, or run `qlty sources fetch` first."
+                    "Source {:?} is not available locally. Run without --skip-source-fetch, or run `qlty sources fetch` first.",
+                    source
                 );
             }
         }

--- a/qlty-config/src/workspace.rs
+++ b/qlty-config/src/workspace.rs
@@ -53,6 +53,23 @@ impl Workspace {
         self.sources_list()?.fetch()
     }
 
+    pub fn prepare_sources(&self, skip_source_fetch: bool) -> Result<()> {
+        let sources_list = self.sources_list()?;
+
+        if skip_source_fetch {
+            sources_list.validate_sources_cached()?;
+        } else {
+            sources_list.fetch()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn load_config(&self, skip_source_fetch: bool) -> Result<QltyConfig> {
+        self.prepare_sources(skip_source_fetch)?;
+        self.config()
+    }
+
     pub fn config_exists(&self) -> Result<bool> {
         Ok(self.config_path()?.exists())
     }

--- a/qlty-smells/src/duplication/planner.rs
+++ b/qlty-smells/src/duplication/planner.rs
@@ -201,8 +201,7 @@ mod test {
     #[test]
     fn test_javascript_language_contains_filter_patterns_by_default() {
         let workspace = Workspace::new().unwrap();
-        workspace.fetch_sources().unwrap();
-        let config = workspace.config().unwrap();
+        let config = workspace.load_config(false).unwrap();
         assert!(!&config.language["javascript"]
             .smells
             .as_ref()


### PR DESCRIPTION
## Summary

- Centralizes source-fetch/config-load in `Workspace::prepare_sources()` and `Workspace::load_config()` so every CLI command uses the same pattern.
- Adds `--skip-source-fetch` to `qlty coverage publish`, matching `check`/`fmt`. When the flag is set and a remote source is not cached locally, the command errors instead of silently falling back to `QltyConfig::default()`.
- Fixes the bug where `coverage/utils.rs::load_config` swallowed fetch failures and discarded any cached remote source config — now it only falls back to default when no `qlty.toml` is present.

Implements https://github.com/qltysh/cloud/issues/8239.

## Design

- `Source::is_cached()` trait method (default `true`); `GitSource` overrides to check `local_origin_ref_path(...).exists()`.
- `SourcesList::validate_sources_cached()` returns an error if any source is missing locally.
- `Workspace::prepare_sources(skip)` is the new single entry point — it fetches or validates. `Workspace::load_config(skip)` composes that with `config()`.
- All commands that previously did `fetch_sources()` + `config()` (or a conditional fetch) now call one of those. Commands that use a `Planner` keep the fetch-then-planner pattern (the `Planner` still loads config internally) — scope limited per the ticket.
- `qlty sources fetch` and `qlty init` retain their bespoke logic.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes (no regressions; added four unit tests for `validate_sources_cached()`)
- [x] `cargo fmt --all --check` clean
- [x] `qlty check --level=low` clean
- [ ] Manual: `qlty coverage publish --skip-source-fetch` in a repo whose remote source is already cached under `.qlty/sources/...` — expect success.
- [ ] Manual: `qlty coverage publish --skip-source-fetch` in a repo whose remote source is NOT cached — expect an error with guidance to run `qlty sources fetch` or drop the flag.
- [ ] Manual: `qlty coverage publish` (no flag) — expect pre-existing behavior (fetches sources, then publishes).
- [ ] Manual: `qlty coverage publish` in a repo without `qlty.toml` — expect the command to still run (no config needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)