### PR TITLE
test: remove --verbose flag from qlty coverage publish (bc-check fixture)

### DIFF
--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -111,10 +111,6 @@ pub struct Publish {
     /// Print coverage
     pub print: bool,
 
-    #[arg(long)]
-    /// Verbose
-    pub verbose: bool,
-
     #[arg(long, hide = true, requires = "print")]
     /// JSON output
     pub json: bool,
@@ -494,11 +490,7 @@ impl Publish {
                 .bold()
             );
 
-            let (paths_to_show, show_all) = if self.verbose {
-                (missing_files.len(), true)
-            } else {
-                (std::cmp::min(20, missing_files.len()), false)
-            };
+            let (paths_to_show, show_all) = (std::cmp::min(20, missing_files.len()), false);
 
             eprintln!("\n    {}\n", style("Missing code files:").bold().yellow());
 


### PR DESCRIPTION
## Summary

**This PR is a test fixture for the `bc-check` skill added in #2767. DO NOT MERGE.**

It removes the `--verbose` CLI flag from `qlty coverage publish` — a visible, non-hidden flag on a command that runs in customer CI pipelines. This is a textbook segment-2 (CI) backwards-compatibility break: any customer whose CI invokes `qlty coverage publish --verbose` will start failing with a clap error after upgrading.

The purpose of this PR is to verify that the `bc-check` skill, when run against it, correctly:
- Flags the change under category (b) "CLI flag surface"
- Identifies segment 2 (CI users) as affected
- Assigns severity **risky** or **blocker**
- Suggests a mitigation (keep the flag as a no-op with a deprecation warning, or stage the removal over two releases)

If the skill returns a "safe" verdict on this PR, the skill is broken.

## How to test

1. Check out this branch or reference PR number in the skill invocation.
2. Ask Claude: "run bc-check on PR <this PR's number>".
3. Confirm the output report flags this as at least **risky** with segment 2 named.

## Changes

- Removes `pub verbose: bool` field from the `Publish` struct.
- Collapses the corresponding `if self.verbose` branch at `qlty-cli/src/commands/coverage/publish.rs` (previously expanded the missing-files output when `--verbose` was set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)