### PR TITLE
refactor(cli): remove --no-formatters flag from qlty check

### DIFF
--- a/qlty-cli/src/commands/check.rs
+++ b/qlty-cli/src/commands/check.rs
@@ -59,10 +59,6 @@ pub struct Check {
     #[arg(long)]
     pub r#unsafe: bool,
 
-    /// Disable formatter checks
-    #[arg(long)]
-    pub no_formatters: bool,
-
     /// Disable progress bar
     #[arg(long)]
     pub no_progress: bool,
@@ -221,11 +217,7 @@ impl Check {
                 } else {
                     return Ok(CommandSuccess {
                         trigger: Some(self.trigger),
-                        unformatted_count: if self.no_formatters {
-                            None
-                        } else {
-                            Some(report.unformatted_count())
-                        },
+                        unformatted_count: Some(report.unformatted_count()),
                         issues_count: Some(report.counts.total_issues),
                         security_issues_count: Some(report.counts.total_security_issues),
                         fixed_count: report.fixed.len(),
@@ -328,7 +320,7 @@ impl Check {
         settings.r#unsafe = self.r#unsafe;
         settings.jobs = self.jobs;
         settings.progress = !self.no_progress;
-        settings.formatters = !self.no_formatters;
+        settings.formatters = true;
         settings.filters = CheckFilter::from_optional_list(self.filter.clone());
         settings.upstream = self.compute_upstream(workspace, git_hook_stdin)?;
         settings.level = self.level;

--- a/qlty-cli/src/commands/init.rs
+++ b/qlty-cli/src/commands/init.rs
@@ -239,14 +239,7 @@ impl Init {
         );
         println!();
 
-        cmd!(
-            self.current_exe()?,
-            "check",
-            "--sample",
-            "5",
-            "--no-formatters"
-        )
-        .run()?;
+        cmd!(self.current_exe()?, "check", "--sample", "5").run()?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Removes the `--no-formatters` flag from `qlty check`
- Formatter checks are now always enabled
- Updates `qlty init` to stop passing `--no-formatters` to its post-init `qlty check --sample 5` invocation

This is intentionally a backwards-incompatible change used to exercise the automated BC-check routine on new PRs. Any user script invoking `qlty check --no-formatters` will now error with an unknown-argument failure.

## Test plan

- [x] `cargo check -p qlty`
- [x] `cargo test -p qlty`
- [x] `cargo fmt`
- [ ] Verify the BC-check routine flags the removed flag on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)