### PR TITLE
feat(plugins): add project install mode for Node and PHP plugins

### DIFF
--- a/qlty-check/src/cache.rs
+++ b/qlty-check/src/cache.rs
@@ -166,6 +166,11 @@ impl InvocationCacheKey {
             digest.add("plugin.prefix", prefix);
         }
 
+        digest.add(
+            "plugin.install_dir",
+            &format!("{:?}", self.plugin.install_dir),
+        );
+
         let driver = self.plugin.drivers.get(&self.driver_name).unwrap();
 
         digest.add("plugin.driver.script", &driver.script);
@@ -245,6 +250,7 @@ impl InvocationCacheKey {
 
         digest.add("qlty_version", &self.qlty_version);
         digest.add("tool", &self.tool.directory());
+        digest.add("tool_fingerprint", &self.tool.fingerprint());
         digest.add("driver_name", &self.driver_name);
 
         for config in self.configs.clone().iter().sorted() {

--- a/qlty-check/src/executor.rs
+++ b/qlty-check/src/executor.rs
@@ -417,7 +417,9 @@ impl Executor {
         loaded_config_files: &mut Vec<String>,
     ) -> Result<()> {
         for invocation in self.plan.invocations.iter() {
-            if invocation.driver.copy_configs_into_tool_install {
+            if invocation.driver.copy_configs_into_tool_install
+                && !invocation.plugin.install_dir.is_project()
+            {
                 for config_file in &invocation.plugin_configs {
                     if let Some(config_file) = Self::copy_configs_into_tool_install(
                         &config_file.path,

--- a/qlty-check/src/executor/invocation_script.rs
+++ b/qlty-check/src/executor/invocation_script.rs
@@ -93,7 +93,7 @@ fn get_config_file_paths(plan: &InvocationPlan) -> Vec<String> {
     plan.plugin_configs
         .iter()
         .map(|config| {
-            if plan.driver.copy_configs_into_tool_install {
+            if plan.driver.copy_configs_into_tool_install && !plan.plugin.install_dir.is_project() {
                 let config_file_name = config.path.file_name().unwrap().to_str().unwrap();
                 let config_file = path_to_native_string(join_path_string!(
                     plan.tool.directory(),

--- a/qlty-check/src/planner/config.rs
+++ b/qlty-check/src/planner/config.rs
@@ -2,7 +2,7 @@ use super::{ActivePlugin, Planner};
 use anyhow::bail;
 use anyhow::{anyhow, Result};
 use qlty_analysis::workspace_entries::TargetMode;
-use qlty_config::config::{DriverDef, EnabledPlugin, IssueMode, Platform, PluginDef};
+use qlty_config::config::{DriverDef, EnabledPlugin, IssueMode, Platform, PluginDef, Runtime};
 use semver::{Version, VersionReq};
 use std::path::{Path, PathBuf};
 use tracing::{debug, trace, warn};
@@ -122,6 +122,14 @@ fn configure_plugin(
         let mut plugin_def = plugin_def.clone();
 
         plugin_def.version = Some(enabled_plugin.version.clone());
+        plugin_def.install_dir = enabled_plugin.install_dir.unwrap_or_default();
+
+        if plugin_def.install_dir.is_project() {
+            match plugin_def.runtime {
+                Some(Runtime::Node) | Some(Runtime::Php) => {}
+                _ => bail!("install_dir = project is only supported for node and php plugins"),
+            }
+        }
 
         if !enabled_plugin.drivers.contains(&ALL.to_string()) {
             plugin_def
@@ -258,7 +266,7 @@ mod test {
         CheckFilter, Settings,
     };
     use qlty_config::{
-        config::{DriverDef, PluginFetch, PluginsConfig},
+        config::{DriverDef, InstallDir, PluginFetch, PluginsConfig},
         QltyConfig, Workspace,
     };
     use qlty_types::analysis::v1::ExecutionVerb;
@@ -267,7 +275,10 @@ mod test {
 
     fn build_planner(config: QltyConfig) -> Planner {
         let workspace = Workspace::default();
-        let settings = Settings::default();
+        let settings = Settings {
+            cache: false,
+            ..Default::default()
+        };
         let cache = Planner::build_cache(&workspace, &settings).unwrap();
 
         Planner {
@@ -760,5 +771,38 @@ mod test {
         let plugin = plugins.iter().find(|p| p.name == "test_plugin").unwrap();
         assert_eq!(plugin.plugin.drivers.len(), 1);
         assert_eq!(plugin.plugin.drivers["format"].script, "fmt");
+    }
+
+    #[test]
+    fn test_project_install_rejects_unsupported_runtime() {
+        let mut plugin_defs = HashMap::new();
+        plugin_defs.insert(
+            "test_plugin".to_string(),
+            PluginDef {
+                runtime: Some(Runtime::Ruby),
+                drivers: vec![("lint".to_string(), DriverDef::default())]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            },
+        );
+
+        let planner = build_planner(QltyConfig {
+            plugin: vec![EnabledPlugin {
+                name: "test_plugin".to_string(),
+                install_dir: Some(InstallDir::Project),
+                ..Default::default()
+            }],
+            plugins: PluginsConfig {
+                downloads: HashMap::new(),
+                releases: HashMap::new(),
+                definitions: plugin_defs,
+            },
+            ..Default::default()
+        });
+
+        let err = enabled_plugins(&planner).unwrap_err().to_string();
+        assert!(err.contains("install_dir = project"));
+        assert!(err.contains("node and php"));
     }
 }

--- a/qlty-check/src/planner/config.rs
+++ b/qlty-check/src/planner/config.rs
@@ -275,10 +275,7 @@ mod test {
 
     fn build_planner(config: QltyConfig) -> Planner {
         let workspace = Workspace::default();
-        let settings = Settings {
-            cache: false,
-            ..Default::default()
-        };
+        let settings = Settings::default();
         let cache = Planner::build_cache(&workspace, &settings).unwrap();
 
         Planner {

--- a/qlty-check/src/planner/config.rs
+++ b/qlty-check/src/planner/config.rs
@@ -1,6 +1,8 @@
 use super::{ActivePlugin, Planner};
 use anyhow::bail;
 use anyhow::{anyhow, Result};
+use qlty_analysis::join_path_string;
+use qlty_analysis::utils::fs::path_to_string;
 use qlty_analysis::workspace_entries::TargetMode;
 use qlty_config::config::{DriverDef, EnabledPlugin, IssueMode, Platform, PluginDef, Runtime};
 use semver::{Version, VersionReq};
@@ -185,6 +187,14 @@ fn configure_plugin(
             plugin_def.package_file = Some(package_file.to_str().unwrap_or_default().to_string());
         }
 
+        if plugin_def.install_dir.is_project() {
+            plugin_def.project_install_directory = resolve_project_install_directory(
+                plugin_def.package_file.as_deref(),
+                &planner.workspace.root,
+                enabled_plugin.prefix.as_deref(),
+            );
+        }
+
         // This is becoming a weird pattern, we should probably refactor this?
         plugin_def.fetch = enabled_plugin.fetch.clone();
         plugin_def.package_filters = enabled_plugin.package_filters.clone();
@@ -234,6 +244,21 @@ fn configure_plugin(
         Ok(plugin_def)
     } else {
         bail!("Unknown plugin {}", name)
+    }
+}
+
+fn resolve_project_install_directory(
+    package_file: Option<&str>,
+    workspace_root: &Path,
+    prefix: Option<&str>,
+) -> Option<String> {
+    if let Some(package_file) = package_file {
+        Path::new(package_file).parent().map(path_to_string)
+    } else {
+        Some(prefix.map_or_else(
+            || path_to_string(workspace_root),
+            |p| join_path_string!(workspace_root, p),
+        ))
     }
 }
 
@@ -801,5 +826,28 @@ mod test {
         let err = enabled_plugins(&planner).unwrap_err().to_string();
         assert!(err.contains("install_dir = project"));
         assert!(err.contains("node and php"));
+    }
+
+    #[test]
+    fn test_resolve_project_install_directory_uses_package_file_parent() {
+        let resolved = resolve_project_install_directory(
+            Some("/workspace/frontend/package.json"),
+            Path::new("/workspace"),
+            Some("ignored"),
+        );
+        assert_eq!(resolved, Some("/workspace/frontend".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_project_install_directory_falls_back_to_workspace_with_prefix() {
+        let resolved =
+            resolve_project_install_directory(None, Path::new("/workspace"), Some("backend"));
+        assert_eq!(resolved, Some("/workspace/backend".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_project_install_directory_no_prefix_returns_workspace() {
+        let resolved = resolve_project_install_directory(None, Path::new("/workspace"), None);
+        assert_eq!(resolved, Some("/workspace".to_string()));
     }
 }

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -729,12 +729,7 @@ pub trait Tool: Debug + Sync + Send {
     }
 
     fn project_install_directory(&self) -> Option<String> {
-        let plugin = self.plugin()?;
-        if !plugin.install_dir.is_project() {
-            return None;
-        }
-        let package_file = plugin.package_file.as_deref()?;
-        PathBuf::from(package_file).parent().map(path_to_string)
+        self.plugin()?.project_install_directory
     }
 
     fn env_paths(&self) -> Result<Vec<String>> {
@@ -1163,16 +1158,11 @@ mod test {
     }
 
     #[test]
-    fn test_tool_project_install_directory_uses_package_file_parent() {
-        let tempdir = tempdir().unwrap();
-        let package_file = tempdir.path().join("frontend").join("package.json");
-        std::fs::create_dir_all(package_file.parent().unwrap()).unwrap();
-        std::fs::write(&package_file, "{}").unwrap();
-
+    fn test_tool_project_install_directory_returns_plugin_field() {
         let tool = TestTool {
             plugin: Some(PluginDef {
                 install_dir: InstallDir::Project,
-                package_file: Some(path_to_string(&package_file)),
+                project_install_directory: Some("/workspace/frontend".to_string()),
                 ..Default::default()
             }),
             ..Default::default()
@@ -1180,7 +1170,7 @@ mod test {
 
         assert_eq!(
             tool.project_install_directory(),
-            Some(path_to_string(package_file.parent().unwrap()))
+            Some("/workspace/frontend".to_string())
         );
     }
 

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -671,7 +671,10 @@ pub trait Tool: Debug + Sync + Send {
     }
 
     fn install_log_path(&self) -> String {
-        format!("{}-install.log", self.cache_directory())
+        join_path_string!(
+            self.parent_directory(),
+            format!("{}-install.log", self.directory_name())
+        )
     }
 
     fn clone_box(&self) -> Box<dyn Tool>;

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -128,6 +128,10 @@ pub trait Tool: Debug + Sync + Send {
     fn version(&self) -> Option<String>;
 
     fn directory(&self) -> String {
+        self.cache_directory()
+    }
+
+    fn cache_directory(&self) -> String {
         path_to_string(PathBuf::from(self.parent_directory()).join(self.directory_name()))
     }
 
@@ -140,7 +144,7 @@ pub trait Tool: Debug + Sync + Send {
     }
 
     fn debug_files_directory(&self) -> String {
-        format!("{}-installation-debug-files", self.directory())
+        format!("{}-installation-debug-files", self.cache_directory())
     }
 
     fn runtime(&self) -> Option<Box<dyn Tool>> {
@@ -166,6 +170,12 @@ pub trait Tool: Debug + Sync + Send {
         }
 
         if let Some(plugin) = self.plugin() {
+            sha.update(format!("{:?}", plugin.install_dir));
+
+            if let Some(project_install_directory) = self.project_install_directory() {
+                sha.update(project_install_directory);
+            }
+
             if let Some(package) = plugin.package {
                 sha.update(&package);
             }
@@ -329,11 +339,11 @@ pub trait Tool: Debug + Sync + Send {
     }
 
     fn donefile_path(&self) -> PathBuf {
-        PathBuf::from(format!("{}.done", self.directory()))
+        PathBuf::from(format!("{}.done", self.cache_directory()))
     }
 
     fn lockfile_path(&self) -> PathBuf {
-        PathBuf::from(format!("{}.lock", self.directory()))
+        PathBuf::from(format!("{}.lock", self.cache_directory()))
     }
 
     fn exists(&self) -> bool {
@@ -661,10 +671,7 @@ pub trait Tool: Debug + Sync + Send {
     }
 
     fn install_log_path(&self) -> String {
-        join_path_string!(
-            self.parent_directory(),
-            format!("{}-install.log", self.directory_name())
-        )
+        format!("{}-install.log", self.cache_directory())
     }
 
     fn clone_box(&self) -> Box<dyn Tool>;
@@ -716,6 +723,15 @@ pub trait Tool: Debug + Sync + Send {
 
     fn plugin(&self) -> Option<PluginDef> {
         None
+    }
+
+    fn project_install_directory(&self) -> Option<String> {
+        let plugin = self.plugin()?;
+        if !plugin.install_dir.is_project() {
+            return None;
+        }
+        let package_file = plugin.package_file.as_deref()?;
+        PathBuf::from(package_file).parent().map(path_to_string)
     }
 
     fn env_paths(&self) -> Result<Vec<String>> {
@@ -820,6 +836,7 @@ mod test {
     use crate::Progress;
     use command_builder::test::ENV_LOCK;
     use qlty_analysis::utils::fs::path_to_string;
+    use qlty_config::config::InstallDir;
     use std::env::var;
     use tempfile::tempdir;
     use tracing_test::traced_test;
@@ -1103,7 +1120,7 @@ mod test {
             ..Default::default()
         };
 
-        let hash = "[runtime_package]V[package]V[extra_package1]V[extra_package2]V[package_file]";
+        let hash = "ToolCache[runtime_package]VToolCache[package]V[extra_package1]V[extra_package2]V[package_file]";
         let mut hasher = sha2::Sha256::new();
         hasher.update(hash);
         assert_eq!(tool.fingerprint(), format!("{:x}", hasher.finalize())[..12]);
@@ -1140,6 +1157,52 @@ mod test {
             ))
         );
         assert_eq!(env.get("TEST"), Some(&"test".to_string()));
+    }
+
+    #[test]
+    fn test_tool_project_install_directory_uses_package_file_parent() {
+        let tempdir = tempdir().unwrap();
+        let package_file = tempdir.path().join("frontend").join("package.json");
+        std::fs::create_dir_all(package_file.parent().unwrap()).unwrap();
+        std::fs::write(&package_file, "{}").unwrap();
+
+        let tool = TestTool {
+            plugin: Some(PluginDef {
+                install_dir: InstallDir::Project,
+                package_file: Some(path_to_string(&package_file)),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            tool.project_install_directory(),
+            Some(path_to_string(package_file.parent().unwrap()))
+        );
+    }
+
+    #[test]
+    fn test_tool_fingerprint_changes_for_project_install_dir() {
+        let base_plugin = PluginDef {
+            package: Some("test".to_string()),
+            version: Some("1.0.0".to_string()),
+            prefix: Some("frontend".to_string()),
+            ..Default::default()
+        };
+
+        let cache_install = TestTool {
+            plugin: Some(base_plugin.clone()),
+            ..Default::default()
+        };
+        let project_install = TestTool {
+            plugin: Some(PluginDef {
+                install_dir: InstallDir::Project,
+                ..base_plugin
+            }),
+            ..Default::default()
+        };
+
+        assert_ne!(cache_install.fingerprint(), project_install.fingerprint());
     }
 
     #[test]

--- a/qlty-check/src/tool/node.rs
+++ b/qlty-check/src/tool/node.rs
@@ -1,4 +1,6 @@
 pub mod package_json;
+pub mod project_installer;
+
 use super::command_builder::default_command_builder;
 use super::command_builder::CommandBuilder;
 use super::Tool;
@@ -8,7 +10,9 @@ use crate::tool::RuntimeTool;
 use crate::ui::ProgressBar;
 use crate::ui::ProgressTask;
 use anyhow::Result;
+use project_installer::NodeProjectInstaller;
 use qlty_analysis::join_path_string;
+use qlty_config::config::InstallDir;
 use qlty_config::config::OperatingSystem;
 use qlty_config::config::PluginDef;
 use qlty_config::config::{Cpu, DownloadDef, System};
@@ -115,12 +119,17 @@ impl NodeJS {
 
 impl RuntimeTool for NodeJS {
     fn package_tool(&self, name: &str, plugin: &PluginDef) -> Box<dyn Tool> {
-        Box::new(NodePackage {
+        let package = NodePackage {
             name: name.to_owned(),
             plugin: plugin.clone(),
             runtime: self.clone(),
             cmd: default_command_builder(),
-        })
+        };
+
+        match plugin.install_dir {
+            InstallDir::Project => Box::new(NodeProjectInstaller::new(package)),
+            InstallDir::ToolCache => Box::new(package),
+        }
     }
 }
 
@@ -130,6 +139,12 @@ pub struct NodePackage {
     pub plugin: PluginDef,
     pub runtime: NodeJS,
     cmd: Box<dyn CommandBuilder>,
+}
+
+impl NodePackage {
+    pub(super) fn cmd(&self) -> &dyn CommandBuilder {
+        self.cmd.as_ref()
+    }
 }
 
 impl Tool for NodePackage {
@@ -169,11 +184,7 @@ impl Tool for NodePackage {
 
         self.run_command(self.cmd.build(
             NPM_COMMAND,
-            vec![
-                "install",
-                "--force",
-                format!("{}@{}", name, version).as_str(),
-            ],
+            vec!["install", "--force", &format!("{name}@{version}")],
         ))
     }
 
@@ -238,7 +249,7 @@ pub mod test {
         Progress, Tool,
     };
     use assert_json_diff::assert_json_eq;
-    use qlty_config::config::{ExtraPackage, PluginDef};
+    use qlty_config::config::{ExtraPackage, InstallDir, PluginDef};
     use serde_json::Value;
     use std::{
         path::Path,
@@ -419,6 +430,64 @@ pub mod test {
                 json_contents,
                 json!({"dependencies":{"tool_dep":"1.0.0","test":"1.0.0"}})
             );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn node_project_installer_runs_in_workspace() {
+        with_node_package(|pkg, temp_path, list| {
+            let pkg_root = temp_path.path().join("frontend");
+            let pkg_file = pkg_root.join("package.json");
+            std::fs::create_dir_all(&pkg_root)?;
+            std::fs::write(&pkg_file, r#"{"name":"frontend"}"#)?;
+
+            pkg.plugin.install_dir = InstallDir::Project;
+            pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+
+            let installer = super::NodeProjectInstaller::new(pkg.clone());
+            assert_eq!(
+                installer.directory(),
+                pkg_root.to_str().unwrap().replace('\\', "/")
+            );
+
+            installer.install(&new_task())?;
+            assert_eq!(
+                list.lock().unwrap().clone(),
+                vec![vec![NPM_COMMAND, "install", "--force", "--no-package-lock"]]
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn node_project_installer_fingerprint_changes_with_package_file() {
+        with_node_package(|pkg, temp_path, _| {
+            let pkg_root = temp_path.path().join("frontend");
+            let pkg_file = pkg_root.join("package.json");
+            std::fs::create_dir_all(&pkg_root)?;
+            std::fs::write(&pkg_file, r#"{"name":"frontend"}"#)?;
+
+            pkg.plugin.install_dir = InstallDir::Project;
+            pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            reroute_tools_root(&temp_path, pkg);
+
+            let installer = super::NodeProjectInstaller::new(pkg.clone());
+            let fingerprint_before = installer.fingerprint();
+            let donefile_before = installer.donefile_path();
+
+            std::fs::write(
+                &pkg_file,
+                r#"{"name":"frontend","dependencies":{"eslint":"9.0.0"}}"#,
+            )?;
+
+            let fingerprint_after = installer.fingerprint();
+            let donefile_after = installer.donefile_path();
+
+            assert_ne!(fingerprint_before, fingerprint_after);
+            assert_ne!(donefile_before, donefile_after);
+
             Ok(())
         });
     }

--- a/qlty-check/src/tool/node.rs
+++ b/qlty-check/src/tool/node.rs
@@ -444,12 +444,10 @@ pub mod test {
 
             pkg.plugin.install_dir = InstallDir::Project;
             pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            pkg.plugin.project_install_directory = Some(pkg_root.to_str().unwrap().to_string());
 
             let installer = super::NodeProjectInstaller::new(pkg.clone());
-            assert_eq!(
-                installer.directory(),
-                pkg_root.to_str().unwrap().replace('\\', "/")
-            );
+            assert_eq!(installer.directory(), pkg_root.to_str().unwrap());
 
             installer.install(&new_task())?;
             assert_eq!(
@@ -471,6 +469,7 @@ pub mod test {
 
             pkg.plugin.install_dir = InstallDir::Project;
             pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            pkg.plugin.project_install_directory = Some(pkg_root.to_str().unwrap().to_string());
             reroute_tools_root(&temp_path, pkg);
 
             let installer = super::NodeProjectInstaller::new(pkg.clone());
@@ -487,6 +486,35 @@ pub mod test {
 
             assert_ne!(fingerprint_before, fingerprint_after);
             assert_ne!(donefile_before, donefile_after);
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn node_project_installer_without_package_file_installs_package_only() {
+        with_node_package(|pkg, temp_path, list| {
+            let pkg_root = temp_path.path().join("frontend");
+            std::fs::create_dir_all(&pkg_root)?;
+
+            pkg.plugin.install_dir = InstallDir::Project;
+            pkg.plugin.project_install_directory = Some(pkg_root.to_str().unwrap().to_string());
+
+            let installer = super::NodeProjectInstaller::new(pkg.clone());
+            assert_eq!(installer.directory(), pkg_root.to_str().unwrap());
+
+            installer.install(&new_task())?;
+            assert_eq!(
+                list.lock().unwrap().clone(),
+                vec![vec![
+                    NPM_COMMAND,
+                    "install",
+                    "--no-save",
+                    "--package-lock=false",
+                    "--force",
+                    "test@1.0.0"
+                ]]
+            );
 
             Ok(())
         });

--- a/qlty-check/src/tool/node/project_installer.rs
+++ b/qlty-check/src/tool/node/project_installer.rs
@@ -1,0 +1,89 @@
+use super::{NodePackage, NPM_COMMAND};
+use crate::tool::ToolType;
+use crate::ui::{ProgressBar, ProgressTask};
+use crate::Tool;
+use anyhow::Result;
+use qlty_analysis::join_path_string;
+use qlty_config::config::PluginDef;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct NodeProjectInstaller {
+    package: NodePackage,
+}
+
+impl NodeProjectInstaller {
+    pub fn new(package: NodePackage) -> Self {
+        Self { package }
+    }
+}
+
+impl Tool for NodeProjectInstaller {
+    fn name(&self) -> String {
+        self.package.name()
+    }
+
+    fn directory(&self) -> String {
+        self.project_install_directory()
+            .unwrap_or_else(|| self.package.cache_directory())
+    }
+
+    fn tool_type(&self) -> ToolType {
+        ToolType::RuntimePackage
+    }
+
+    fn runtime(&self) -> Option<Box<dyn Tool>> {
+        self.package.runtime()
+    }
+
+    fn version(&self) -> Option<String> {
+        self.package.version()
+    }
+
+    fn version_command(&self) -> Option<String> {
+        self.package.version_command()
+    }
+
+    fn version_regex(&self) -> String {
+        self.package.version_regex()
+    }
+
+    fn install(&self, task: &ProgressTask) -> Result<()> {
+        self.package_file_install(task)
+    }
+
+    fn package_file_install(&self, task: &ProgressTask) -> Result<()> {
+        task.set_dim_message(&format!("{NPM_COMMAND} install"));
+        self.run_command(
+            self.package
+                .cmd()
+                .build(NPM_COMMAND, vec!["install", "--force", "--no-package-lock"]),
+        )
+    }
+
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
+        let mut paths = self.package.runtime.extra_env_paths()?;
+        paths.insert(
+            0,
+            join_path_string!(self.directory(), "node_modules", ".bin"),
+        );
+        Ok(paths)
+    }
+
+    fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
+        let mut env = self.package.runtime.extra_env_vars()?;
+        env.insert(
+            "NODE_PATH".to_string(),
+            join_path_string!(self.directory(), "node_modules"),
+        );
+        Ok(env)
+    }
+
+    fn clone_box(&self) -> Box<dyn Tool> {
+        Box::new(self.clone())
+    }
+
+    fn plugin(&self) -> Option<PluginDef> {
+        self.package.plugin()
+    }
+}

--- a/qlty-check/src/tool/node/project_installer.rs
+++ b/qlty-check/src/tool/node/project_installer.rs
@@ -49,7 +49,32 @@ impl Tool for NodeProjectInstaller {
     }
 
     fn install(&self, task: &ProgressTask) -> Result<()> {
-        self.package_file_install(task)
+        let plugin = self.package.plugin.clone();
+        if plugin.package_file.is_some() {
+            self.package_file_install(task)?;
+        } else {
+            if let (Some(package), Some(version)) = (&plugin.package, &plugin.version) {
+                self.package_install(task, package, version)?;
+            }
+            for pkg in &plugin.extra_packages {
+                self.package_install(task, &pkg.name, &pkg.version)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn package_install(&self, _task: &ProgressTask, name: &str, version: &str) -> Result<()> {
+        let package = format!("{name}@{version}");
+        self.run_command(self.package.cmd().build(
+            NPM_COMMAND,
+            vec![
+                "install",
+                "--no-save",
+                "--package-lock=false",
+                "--force",
+                package.as_str(),
+            ],
+        ))
     }
 
     fn package_file_install(&self, task: &ProgressTask) -> Result<()> {

--- a/qlty-check/src/tool/php.rs
+++ b/qlty-check/src/tool/php.rs
@@ -1,4 +1,6 @@
 pub mod composer;
+pub mod project_installer;
+
 use super::command_builder::{default_command_builder, CommandBuilder};
 use super::installations::initialize_installation;
 use super::runnable_archive::RunnableArchive;
@@ -10,8 +12,9 @@ use anyhow::{bail, Context, Result};
 use composer::Composer;
 use duct::cmd;
 use itertools::Itertools;
+use project_installer::PhpProjectInstaller;
 use qlty_analysis::utils::fs::path_to_native_string;
-use qlty_config::config::PluginDef;
+use qlty_config::config::{InstallDir, PluginDef};
 use sha2::Digest;
 use std::collections::HashMap;
 use std::env::split_paths;
@@ -96,12 +99,17 @@ impl Php {
 
 impl RuntimeTool for Php {
     fn package_tool(&self, name: &str, plugin: &PluginDef) -> Box<dyn Tool> {
-        Box::new(PhpPackage {
+        let package = PhpPackage {
             name: name.to_owned(),
             plugin: plugin.clone(),
             runtime: self.clone(),
             cmd: default_command_builder(),
-        })
+        };
+
+        match plugin.install_dir {
+            InstallDir::Project => Box::new(PhpProjectInstaller::new(package)),
+            InstallDir::ToolCache => Box::new(package),
+        }
     }
 }
 
@@ -111,6 +119,12 @@ pub struct PhpPackage {
     pub plugin: PluginDef,
     pub runtime: Php,
     cmd: Box<dyn CommandBuilder>,
+}
+
+impl PhpPackage {
+    pub(super) fn cmd(&self) -> &dyn CommandBuilder {
+        self.cmd.as_ref()
+    }
 }
 
 impl Tool for PhpPackage {
@@ -124,12 +138,6 @@ impl Tool for PhpPackage {
 
     fn runtime(&self) -> Option<Box<dyn Tool>> {
         Some(Box::new(self.runtime.clone()))
-    }
-
-    fn update_hash(&self, sha: &mut sha2::Sha256) -> Result<()> {
-        sha.update(self.name().as_bytes());
-
-        Ok(())
     }
 
     fn version(&self) -> Option<String> {
@@ -149,26 +157,18 @@ impl Tool for PhpPackage {
     }
 
     fn package_install(&self, task: &ProgressTask, name: &str, version: &str) -> Result<()> {
-        task.set_dim_message(&format!("Installing {}", name));
+        task.set_dim_message(&format!("Installing {name}"));
         let composer = Composer {
             cmd: default_command_builder(),
         };
-
-        let composer_phar = PathBuf::from(composer.directory()).join("composer.phar");
-        let composer_path = composer_phar.to_str().with_context(|| {
-            format!(
-                "Failed to convert composer path to string: {:?}",
-                composer_phar
-            )
-        })?;
-
+        let phar = composer.phar_path()?;
         self.run_command(self.cmd.build(
             "php",
             vec![
-                &path_to_native_string(composer_path),
+                &phar,
                 "require",
                 "--no-interaction",
-                format!("{}:{}", name, version).as_str(),
+                &format!("{name}:{version}"),
             ],
         ))
     }
@@ -182,7 +182,6 @@ impl Tool for PhpPackage {
             composer.setup(task)?;
             composer.install_package_file(self)?;
         }
-
         Ok(())
     }
 
@@ -229,7 +228,7 @@ pub mod test {
         ui::ProgressTask,
         Progress, Tool,
     };
-    use qlty_config::config::PluginDef;
+    use qlty_config::config::{InstallDir, PluginDef};
     use std::sync::{Arc, Mutex};
     use tempfile::{tempdir, TempDir};
 
@@ -268,16 +267,6 @@ pub mod test {
     }
 
     #[test]
-    fn php_package_install_no_package_file() {
-        with_php_package(|pkg, _, list| {
-            pkg.package_file_install(&new_task())?;
-            assert!(list.lock().unwrap().is_empty());
-
-            Ok(())
-        });
-    }
-
-    #[test]
     fn php_package_file_install() {
         with_php_package(|pkg, temp_path, list| {
             let pkg_file = temp_path.path().join("composer.json");
@@ -313,6 +302,96 @@ pub mod test {
                     ]
                 ]
             );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn php_project_installer_runs_in_workspace() {
+        with_php_package(|pkg, temp_path, list| {
+            let pkg_root = temp_path.path().join("backend");
+            let pkg_file = pkg_root.join("composer.json");
+            std::fs::create_dir_all(&pkg_root)?;
+            std::fs::write(&pkg_file, r#"{}"#)?;
+
+            pkg.plugin.install_dir = InstallDir::Project;
+            pkg.plugin.package = Some("vendor/test".to_string());
+            pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+
+            let composer = Composer {
+                cmd: stub_cmd(list.clone()),
+            };
+            let installer = PhpProjectInstaller::new(pkg.clone());
+
+            assert_eq!(
+                installer.directory(),
+                pkg_root.to_str().unwrap().replace('\\', "/")
+            );
+            assert_eq!(
+                installer.extra_env_paths()?,
+                vec![qlty_analysis::join_path_string!(
+                    pkg_root.to_str().unwrap(),
+                    "vendor",
+                    "bin"
+                )]
+            );
+            assert!(installer.extra_env_vars()?.is_empty());
+
+            let composer_phar = path_to_native_string(format!(
+                "{}/.qlty/cache/tools/composer/{}/composer.phar",
+                temp_path.path().display(),
+                composer.directory_name()
+            ));
+
+            installer.install(&new_task())?;
+            assert_eq!(
+                list.lock().unwrap().clone(),
+                [
+                    vec![
+                        "php".to_string(),
+                        "-r".to_string(),
+                        "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+                            .to_string(),
+                    ],
+                    vec!["php".to_string(), "composer-setup.php".to_string()],
+                    vec![
+                        "php".to_string(),
+                        composer_phar,
+                        "install".to_string(),
+                        "--no-interaction".to_string(),
+                        "--ignore-platform-reqs".to_string(),
+                    ]
+                ]
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn php_project_installer_fingerprint_changes_with_package_file() {
+        with_php_package(|pkg, temp_path, _| {
+            let pkg_root = temp_path.path().join("backend");
+            let pkg_file = pkg_root.join("composer.json");
+            std::fs::create_dir_all(&pkg_root)?;
+            std::fs::write(&pkg_file, r#"{}"#)?;
+
+            pkg.plugin.install_dir = InstallDir::Project;
+            pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            reroute_tools_root(&temp_path, pkg);
+
+            let installer = PhpProjectInstaller::new(pkg.clone());
+            let fingerprint_before = installer.fingerprint();
+            let donefile_before = installer.donefile_path();
+
+            std::fs::write(&pkg_file, r#"{"require":{"phpstan/phpstan":"^2.0"}}"#)?;
+
+            let fingerprint_after = installer.fingerprint();
+            let donefile_after = installer.donefile_path();
+
+            assert_ne!(fingerprint_before, fingerprint_after);
+            assert_ne!(donefile_before, donefile_after);
 
             Ok(())
         });

--- a/qlty-check/src/tool/php.rs
+++ b/qlty-check/src/tool/php.rs
@@ -267,6 +267,16 @@ pub mod test {
     }
 
     #[test]
+    fn php_package_install_no_package_file() {
+        with_php_package(|pkg, _, list| {
+            pkg.package_file_install(&new_task())?;
+            assert!(list.lock().unwrap().is_empty());
+
+            Ok(())
+        });
+    }
+
+    #[test]
     fn php_package_file_install() {
         with_php_package(|pkg, temp_path, list| {
             let pkg_file = temp_path.path().join("composer.json");

--- a/qlty-check/src/tool/php.rs
+++ b/qlty-check/src/tool/php.rs
@@ -328,16 +328,14 @@ pub mod test {
             pkg.plugin.install_dir = InstallDir::Project;
             pkg.plugin.package = Some("vendor/test".to_string());
             pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            pkg.plugin.project_install_directory = Some(pkg_root.to_str().unwrap().to_string());
 
             let composer = Composer {
                 cmd: stub_cmd(list.clone()),
             };
             let installer = PhpProjectInstaller::new(pkg.clone());
 
-            assert_eq!(
-                installer.directory(),
-                pkg_root.to_str().unwrap().replace('\\', "/")
-            );
+            assert_eq!(installer.directory(), pkg_root.to_str().unwrap());
             assert_eq!(
                 installer.extra_env_paths()?,
                 vec![qlty_analysis::join_path_string!(
@@ -389,6 +387,7 @@ pub mod test {
 
             pkg.plugin.install_dir = InstallDir::Project;
             pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            pkg.plugin.project_install_directory = Some(pkg_root.to_str().unwrap().to_string());
             reroute_tools_root(&temp_path, pkg);
 
             let installer = PhpProjectInstaller::new(pkg.clone());
@@ -402,6 +401,56 @@ pub mod test {
 
             assert_ne!(fingerprint_before, fingerprint_after);
             assert_ne!(donefile_before, donefile_after);
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn php_project_installer_without_package_file_installs_package_only() {
+        with_php_package(|pkg, temp_path, list| {
+            let pkg_root = temp_path.path().join("backend");
+            std::fs::create_dir_all(&pkg_root)?;
+
+            pkg.plugin.install_dir = InstallDir::Project;
+            pkg.plugin.package = Some("vendor/test".to_string());
+            pkg.plugin.project_install_directory = Some(pkg_root.to_str().unwrap().to_string());
+
+            let composer = Composer {
+                cmd: stub_cmd(list.clone()),
+            };
+            let installer = PhpProjectInstaller::new(pkg.clone());
+            assert_eq!(installer.directory(), pkg_root.to_str().unwrap());
+
+            let composer_phar = path_to_native_string(format!(
+                "{}/.qlty/cache/tools/composer/{}/composer.phar",
+                temp_path.path().display(),
+                composer.directory_name()
+            ));
+
+            installer.install(&new_task())?;
+            assert_eq!(
+                list.lock().unwrap().clone(),
+                [
+                    vec![
+                        "php".to_string(),
+                        "-r".to_string(),
+                        "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+                            .to_string(),
+                    ],
+                    vec!["php".to_string(), "composer-setup.php".to_string()],
+                    vec![
+                        "php".to_string(),
+                        composer_phar,
+                        "require".to_string(),
+                        "--dev".to_string(),
+                        "--with-all-dependencies".to_string(),
+                        "--ignore-platform-reqs".to_string(),
+                        "--no-interaction".to_string(),
+                        "vendor/test:1.0.0".to_string()
+                    ]
+                ]
+            );
 
             Ok(())
         });

--- a/qlty-check/src/tool/php/composer.rs
+++ b/qlty-check/src/tool/php/composer.rs
@@ -71,9 +71,7 @@ impl Tool for Composer {
 }
 
 impl Composer {
-    pub fn install_package_file(&self, php_package: &PhpPackage) -> Result<()> {
-        info!("Installing composer package file");
-        Self::update_composer_json(php_package)?;
+    pub fn phar_path(&self) -> Result<String> {
         let composer_phar = PathBuf::from(self.directory()).join("composer.phar");
         let composer_path = composer_phar.to_str().with_context(|| {
             format!(
@@ -81,13 +79,20 @@ impl Composer {
                 composer_phar
             )
         })?;
+        Ok(path_to_native_string(composer_path))
+    }
+
+    pub fn install_package_file(&self, php_package: &PhpPackage) -> Result<()> {
+        info!("Installing composer package file");
+        Self::update_composer_json(php_package)?;
+        let phar = self.phar_path()?;
 
         let cmd = self
             .cmd
             .build(
                 "php",
                 vec![
-                    &path_to_native_string(composer_path),
+                    &phar,
                     "update",
                     "--no-interaction",
                     "--ignore-platform-reqs",
@@ -358,18 +363,6 @@ pub mod test {
     #[test]
     fn test_update_existing_composer_json() {
         with_php_package(|pkg, tempdir, _| {
-            let existing_composer_file = PathBuf::from(pkg.directory()).join("composer.json");
-            std::fs::write(
-                &existing_composer_file,
-                r#"
-                {
-                    "require": {
-                        "tool": "1.0.0"
-                    }
-                }"#,
-            )
-            .unwrap();
-
             let package_file = tempdir.path().join("user-composer.json");
             std::fs::write(
                 &package_file,
@@ -393,6 +386,17 @@ pub mod test {
 
             pkg.plugin.package_file = Some(path_to_string(package_file));
             reroute_tools_root(tempdir, pkg);
+            let existing_composer_file = PathBuf::from(pkg.directory()).join("composer.json");
+            std::fs::write(
+                &existing_composer_file,
+                r#"
+                {
+                    "require": {
+                        "tool": "1.0.0"
+                    }
+                }"#,
+            )
+            .unwrap();
 
             Composer::update_composer_json(pkg).unwrap();
 

--- a/qlty-check/src/tool/php/project_installer.rs
+++ b/qlty-check/src/tool/php/project_installer.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use qlty_analysis::join_path_string;
 use qlty_config::config::PluginDef;
 use std::collections::HashMap;
+use tracing::warn;
 
 #[derive(Debug, Clone)]
 pub struct PhpProjectInstaller {
@@ -50,7 +51,44 @@ impl Tool for PhpProjectInstaller {
     }
 
     fn install(&self, task: &ProgressTask) -> Result<()> {
-        self.package_file_install(task)
+        let plugin = self.package.plugin.clone();
+        if plugin.package_file.is_some() {
+            self.package_file_install(task)?;
+        } else {
+            if let (Some(package), Some(version)) = (&plugin.package, &plugin.version) {
+                self.package_install(task, package, version)?;
+            }
+            for pkg in &plugin.extra_packages {
+                self.package_install(task, &pkg.name, &pkg.version)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn package_install(&self, task: &ProgressTask, name: &str, version: &str) -> Result<()> {
+        warn!(
+            "Project install for '{name}' will modify composer.json in {}; \
+             provide a package_file to avoid this.",
+            self.directory()
+        );
+        task.set_dim_message(&format!("Installing {name}"));
+        let composer = Composer {
+            cmd: self.package.cmd().clone_box(),
+        };
+        composer.setup(task)?;
+        let phar = composer.phar_path()?;
+        self.run_command(self.package.cmd().build(
+            "php",
+            vec![
+                &phar,
+                "require",
+                "--dev",
+                "--with-all-dependencies",
+                "--ignore-platform-reqs",
+                "--no-interaction",
+                &format!("{name}:{version}"),
+            ],
+        ))
     }
 
     fn package_file_install(&self, task: &ProgressTask) -> Result<()> {

--- a/qlty-check/src/tool/php/project_installer.rs
+++ b/qlty-check/src/tool/php/project_installer.rs
@@ -1,0 +1,90 @@
+use super::composer::Composer;
+use super::PhpPackage;
+use crate::tool::ToolType;
+use crate::ui::{ProgressBar, ProgressTask};
+use crate::Tool;
+use anyhow::Result;
+use qlty_analysis::join_path_string;
+use qlty_config::config::PluginDef;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct PhpProjectInstaller {
+    package: PhpPackage,
+}
+
+impl PhpProjectInstaller {
+    pub fn new(package: PhpPackage) -> Self {
+        Self { package }
+    }
+}
+
+impl Tool for PhpProjectInstaller {
+    fn name(&self) -> String {
+        self.package.name()
+    }
+
+    fn directory(&self) -> String {
+        self.project_install_directory()
+            .unwrap_or_else(|| self.package.cache_directory())
+    }
+
+    fn tool_type(&self) -> ToolType {
+        ToolType::RuntimePackage
+    }
+
+    fn runtime(&self) -> Option<Box<dyn Tool>> {
+        self.package.runtime()
+    }
+
+    fn version(&self) -> Option<String> {
+        self.package.version()
+    }
+
+    fn version_command(&self) -> Option<String> {
+        self.package.version_command()
+    }
+
+    fn version_regex(&self) -> String {
+        self.package.version_regex()
+    }
+
+    fn install(&self, task: &ProgressTask) -> Result<()> {
+        self.package_file_install(task)
+    }
+
+    fn package_file_install(&self, task: &ProgressTask) -> Result<()> {
+        let composer = Composer {
+            cmd: self.package.cmd().clone_box(),
+        };
+        composer.setup(task)?;
+
+        task.set_dim_message("composer install");
+        let phar = composer.phar_path()?;
+        self.run_command(self.package.cmd().build(
+            "php",
+            vec![
+                &phar,
+                "install",
+                "--no-interaction",
+                "--ignore-platform-reqs",
+            ],
+        ))
+    }
+
+    fn extra_env_paths(&self) -> Result<Vec<String>> {
+        Ok(vec![join_path_string!(self.directory(), "vendor", "bin")])
+    }
+
+    fn extra_env_vars(&self) -> Result<HashMap<String, String>> {
+        Ok(HashMap::new())
+    }
+
+    fn clone_box(&self) -> Box<dyn Tool> {
+        Box::new(self.clone())
+    }
+
+    fn plugin(&self) -> Option<PluginDef> {
+        self.package.plugin()
+    }
+}

--- a/qlty-config/src/config.rs
+++ b/qlty-config/src/config.rs
@@ -25,7 +25,7 @@ pub use exclude::Exclude;
 pub use file_type::FileType;
 pub use language::Language;
 pub use plugin::{
-    CheckTrigger, DriverBatchBy, DriverDef, DriverType, EnabledPlugin, ExtraPackage,
+    CheckTrigger, DriverBatchBy, DriverDef, DriverType, EnabledPlugin, ExtraPackage, InstallDir,
     InvocationDirectoryDef, InvocationDirectoryType, IssueMode, OutputDestination, OutputFormat,
     OutputMissing, PackageFileCandidate, Platform, PluginDef, PluginEnvironment, PluginFetch,
     Runtime, SuggestionMode, TargetDef, TargetType,

--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -461,6 +461,7 @@ fn merge_enabled_plugins(existing: &EnabledPlugin, new: &EnabledPlugin) -> Enabl
         prefix: existing.prefix.clone(),
         mode: Some(merged_mode),
         version,
+        install_dir: new.install_dir.or(existing.install_dir),
         skip_upstream: new.skip_upstream.or(existing.skip_upstream),
         package_file: new.package_file.clone().or(existing.package_file.clone()),
         triggers: prioritize_new_array(&existing.triggers, &new.triggers),
@@ -512,7 +513,7 @@ fn sort_enabled_plugins(plugins: &mut [EnabledPlugin]) {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::config::{CheckTrigger, ExtraPackage, IssueMode, PluginFetch};
+    use crate::config::{CheckTrigger, ExtraPackage, InstallDir, IssueMode, PluginFetch};
     use crate::warning_tracker::{clear_warnings, collected_warnings};
     use std::path::PathBuf;
     use std::sync::{LazyLock, Mutex, MutexGuard};
@@ -780,6 +781,7 @@ mod test {
             prefix: Some("prefix1".to_string()),
             mode: Some(IssueMode::Block),
             version: "1.0.0".to_string(),
+            install_dir: Some(InstallDir::ToolCache),
             triggers: vec![CheckTrigger::Manual],
             skip_upstream: Some(true),
             package_file: Some("package1".to_string()),
@@ -802,6 +804,7 @@ mod test {
             prefix: Some("prefix2".to_string()),
             mode: Some(IssueMode::Disabled),
             version: "2.0.0".to_string(),
+            install_dir: Some(InstallDir::Project),
             triggers: vec![CheckTrigger::PreCommit],
             skip_upstream: Some(false),
             package_file: Some("package2".to_string()),
@@ -825,6 +828,7 @@ mod test {
         assert_eq!(merged.prefix, Some("prefix1".to_string()));
         assert_eq!(merged.mode, Some(IssueMode::Disabled));
         assert_eq!(merged.version, "2.0.0");
+        assert_eq!(merged.install_dir, Some(InstallDir::Project));
         assert_eq!(merged.triggers, vec![CheckTrigger::PreCommit]);
         assert_eq!(merged.skip_upstream, Some(false));
         assert_eq!(merged.package_file, Some("package2".to_string()));
@@ -1052,6 +1056,7 @@ mod test {
                 prefix: Some("shared".to_string()),
                 mode: Some(IssueMode::Block),
                 version: "1.0.0".to_string(),
+                install_dir: Some(InstallDir::ToolCache),
                 triggers: vec![CheckTrigger::Manual],
                 skip_upstream: Some(true),
                 package_file: Some("package1".to_string()),
@@ -1073,6 +1078,7 @@ mod test {
                 prefix: Some("shared".to_string()),
                 mode: Some(IssueMode::Disabled),
                 version: "2.0.0".to_string(),
+                install_dir: Some(InstallDir::Project),
                 triggers: vec![CheckTrigger::PreCommit],
                 skip_upstream: Some(false),
                 package_file: Some("package2".to_string()),

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -406,6 +406,9 @@ pub struct PluginDef {
     #[serde(default)]
     pub install_dir: InstallDir,
 
+    #[serde(skip)]
+    pub project_install_directory: Option<String>,
+
     #[serde(default)]
     pub supported_platforms: Vec<Platform>,
 
@@ -729,20 +732,11 @@ impl EnabledPlugin {
             ));
         }
 
-        if self.install_dir.unwrap_or_default().is_project() {
-            if self.package_file.is_none() {
-                return Err(anyhow::anyhow!(
-                    "Plugin '{}' has 'install_dir = project' but no 'package_file'. Project installs require a package_file.",
-                    self.name
-                ));
-            }
-
-            if !self.package_filters.is_empty() {
-                return Err(anyhow::anyhow!(
-                    "Plugin '{}' has both 'install_dir = project' and 'package_filters' configured. Project installs do not support package_filters.",
-                    self.name
-                ));
-            }
+        if self.install_dir.unwrap_or_default().is_project() && !self.package_filters.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Plugin '{}' has both 'install_dir = project' and 'package_filters' configured. Project installs do not support package_filters.",
+                self.name
+            ));
         }
 
         Ok(())

--- a/qlty-config/src/config/plugin.rs
+++ b/qlty-config/src/config/plugin.rs
@@ -404,6 +404,9 @@ pub struct PluginDef {
     pub prefix: Option<String>,
 
     #[serde(default)]
+    pub install_dir: InstallDir,
+
+    #[serde(default)]
     pub supported_platforms: Vec<Platform>,
 
     #[serde(default)]
@@ -699,6 +702,9 @@ pub struct EnabledPlugin {
 
     #[serde(default)]
     pub prefix: Option<String>,
+
+    #[serde(default)]
+    pub install_dir: Option<InstallDir>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
@@ -721,6 +727,22 @@ impl EnabledPlugin {
                 "Plugin '{}' has 'package_filters' configured but no 'package_file'. The 'package_filters' option requires 'package_file' to be specified.",
                 self.name
             ));
+        }
+
+        if self.install_dir.unwrap_or_default().is_project() {
+            if self.package_file.is_none() {
+                return Err(anyhow::anyhow!(
+                    "Plugin '{}' has 'install_dir = project' but no 'package_file'. Project installs require a package_file.",
+                    self.name
+                ));
+            }
+
+            if !self.package_filters.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Plugin '{}' has both 'install_dir = project' and 'package_filters' configured. Project installs do not support package_filters.",
+                    self.name
+                ));
+            }
         }
 
         Ok(())
@@ -770,6 +792,20 @@ impl PluginFetch {
         }
 
         Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallDir {
+    #[default]
+    ToolCache,
+    Project,
+}
+
+impl InstallDir {
+    pub fn is_project(&self) -> bool {
+        matches!(self, InstallDir::Project)
     }
 }
 
@@ -1028,5 +1064,24 @@ mod tests {
         assert!(error_message.contains("package_filters"));
         assert!(error_message.contains("package_file"));
         assert!(error_message.contains("requires"));
+    }
+
+    #[test]
+    fn test_enabled_plugin_validate_failure_with_project_install_and_package_filters() {
+        let plugin = EnabledPlugin {
+            name: "test-plugin".to_string(),
+            install_dir: Some(InstallDir::Project),
+            package_file: Some("package.json".to_string()),
+            package_filters: vec!["some-filter".to_string()],
+            ..Default::default()
+        };
+
+        let result = plugin.validate();
+        assert!(result.is_err());
+
+        let error_message = result.unwrap_err().to_string();
+        assert!(error_message.contains("test-plugin"));
+        assert!(error_message.contains("install_dir"));
+        assert!(error_message.contains("package_filters"));
     }
 }


### PR DESCRIPTION
## Summary

Adds a new `install_dir` plugin configuration option (`tool_cache` default, `project`). In project mode, qlty runs the linter against the user's existing workspace instead of staging a synthetic copy in qlty's tool cache.

```toml
[[plugin]]
name = "prettier"
version = "3.6.2"
package_file = "package.json"
install_dir = "project"
```

`package_file` is optional in project mode:
- **With `package_file`**: qlty runs `npm install` / `composer install` against the user's manifest. Linter is expected to be a dep there.
- **Without `package_file`**: qlty installs only the linter into the workspace. Node uses `npm install --no-save --package-lock=false --force` (doesn't touch user's `package.json` or lock). PHP uses `composer require --dev` and emits a `warn!` because that mutates the user's `composer.json` — opt-in tradeoff for users who want the tool installed in their project.

## Why

Several real-world bugs are caused by linters running in qlty's cache directory instead of the user's project:

- **Closes qltysh/qlty#2499** — Prettier doesn't honor `.prettierignore`. In cache mode prettier's `cwd` is the qlty cache and it never sees `.prettierignore`; in project mode `cwd` is the user's project root and the file is picked up naturally. Verified end-to-end (cache mode flags 2 files, project mode flags 1, the ignored file is correctly skipped).
- Plugins that import user code via tool config files (vitest, postcss, knip, etc.) need the project's actual `node_modules` and absolute file resolution to work correctly.

## Design

- New `InstallDir` enum on `PluginDef` (always set) and `Option<InstallDir>` on `EnabledPlugin` (matches `mode`/`skip_upstream`/`package_file` patterns; merged via `.or()`).
- Strategy is selected once at construction time. `RuntimeTool::package_tool` returns either a `NodePackage` / `PhpPackage` (cache) or a `NodeProjectInstaller` / `PhpProjectInstaller` (project). No `match install_dir` branches in hot paths.
- Project installers compose their package counterpart and override only the methods that differ: `directory`, `install`, `package_install`, `package_file_install`, `extra_env_paths`, `extra_env_vars`.
- `project_install_directory` is resolved once in the planner via a free `resolve_project_install_directory(package_file, workspace_root, prefix)` helper and stored on `PluginDef` as a `#[serde(skip)]` field. Tool layer just reads the field.
- Path normalization uses `path_to_string` / `join_path_string!` so the resolved value is always forward-slash form across platforms.
- `install` overrides on the project installers split the contract: with `package_file` → `package_file_install` only (skip the linter-specific install); without `package_file` → `package_install` for the main package + `extra_packages`.

## Validation rules

- `install_dir = project` is incompatible with `package_filters` (project mode trusts the user's resolved deps)
- `install_dir = project` is rejected for non-Node/PHP runtimes at planning time

## Test plan

- [x] Unit tests: project installer commands (with/without `package_file` for both Node and PHP), fingerprint changes with package_file content, validation failures, three branches of `resolve_project_install_directory`
- [x] Manual: `tmp/stylelint-v17-repro` (Node, with `package_file`) — `cwd` is workspace, `node_modules/.bin` on PATH, `package.json`/lock md5 unchanged
- [x] Manual: `tmp/laravel-modular-template` with phpstan (PHP, with `package_file`) — `cwd` is workspace, `vendor/bin` on PATH, `composer.json`/lock md5 unchanged
- [x] Manual: `tmp/prettier-ignore-repro` — confirms qltysh/qlty#2499 fix (cache mode flags 2 files, project mode flags 1)
- [x] `cargo test`, `qlty fmt`, `qlty check --level=low --fix` all clean

## Notes

- Adding `tool_fingerprint` to the cache key invalidates existing caches once on upgrade. Pre-existing tools re-run on first execution after this lands.
- Future work: lockfile-aware package manager detection (pnpm/yarn) to fully address qltysh/support#295; concurrent-install lock to handle multiple project-install plugins targeting the same workspace.

Closes qltysh/qlty#2754 (the prior `system: true` design).