### PR TITLE
fix: honor .qlty/configs/ for biome and knip plugins

### DIFF
--- a/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.in/.gitignore
+++ b/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.in/.gitignore
@@ -1,0 +1,4 @@
+.qlty/results
+.qlty/logs
+.qlty/out
+.qlty/sources

--- a/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.in/.qlty/configs/config.yml
+++ b/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.in/.qlty/configs/config.yml
@@ -1,0 +1,1 @@
+configuration: true

--- a/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.in/.qlty/qlty.toml
+++ b/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.in/.qlty/qlty.toml
@@ -1,0 +1,9 @@
+config_version = "0"
+
+[[source]]
+name = "custom"
+directory = "custom_source"
+
+[[plugin]]
+name = "exists"
+version = "1.0.0"

--- a/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.in/custom_source/source.toml
+++ b/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.in/custom_source/source.toml
@@ -1,0 +1,13 @@
+config_version = "0"
+
+[plugins.definitions.exists]
+file_types = ["shell"]
+config_files = ["config.yml"]
+
+[plugins.definitions.exists.drivers.lint]
+prepare_script = "mkdir ${linter} && echo dir %2 > ${linter}/ls.cmd || echo dir %2 > ${linter}/ls.cmd"
+copy_configs_into_tool_install = true
+config_script = "${config_file}"
+script = "ls ${config_script} || dir ${config_script}"
+success_codes = [0]
+output = "pass_fail"

--- a/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.in/sample.sh
+++ b/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.in/sample.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "hello"

--- a/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.stderr
+++ b/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.stderr
@@ -1,0 +1,3 @@
+     [0/1] [..]Planning...  [..]s
+     [1/1] [..]Analyzing all targets... [..]
+✔ No issues

--- a/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.stdout
+++ b/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.stdout
@@ -1,0 +1,6 @@
+ JOBS: 1 [..]
+
+Plugin  Result   Targets   Time   Debug File
+exists  Success  1 target  [..]s  .qlty/out/invoke-[..].yaml
+
+Checked 1 file

--- a/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.toml
+++ b/qlty-cli/tests/cmd/check/copy_config_to_tool_install_from_qlty_configs.toml
@@ -1,0 +1,2 @@
+bin.name = "qlty"
+args = ["check", "--all", "--no-cache", "--verbose"]

--- a/qlty-plugins/plugins/linters/biome/plugin.toml
+++ b/qlty-plugins/plugins/linters/biome/plugin.toml
@@ -14,7 +14,9 @@ package_file_candidate = "package.json"
 package_file_candidate_filters = ["biome"]
 
 [plugins.definitions.biome.drivers.lint]
-script = "biome lint --reporter=json ${target}"
+script = "biome lint --reporter=json ${config_script} ${target}"
+config_script = "--config-path ${config_file}"
+copy_configs_into_tool_install = true
 success_codes = [0, 1]
 output = "stdout"
 output_format = "biome"
@@ -24,7 +26,9 @@ suggested = "config"
 output_missing = "parse"
 
 [plugins.definitions.biome.drivers.format]
-script = "biome format --write ${target}"
+script = "biome format --write ${config_script} ${target}"
+config_script = "--config-path ${config_file}"
+copy_configs_into_tool_install = true
 success_codes = [0, 1]
 output = "rewrite"
 batch = true

--- a/qlty-plugins/plugins/linters/knip/plugin.toml
+++ b/qlty-plugins/plugins/linters/knip/plugin.toml
@@ -21,7 +21,9 @@ version_command = "knip --version"
 description = "Find unused files, dependencies, and exports in JavaScript and TypeScript projects"
 
 [plugins.definitions.knip.drivers.lint]
-script = "knip --no-progress --reporter json"
+script = "knip --no-progress --reporter json ${config_script}"
+config_script = "--config ${config_file}"
+copy_configs_into_tool_install = true
 target = { type = "parent_with", path = "package.json" }
 runs_from = { type = "target_directory" }
 success_codes = [0, 1]


### PR DESCRIPTION
## Summary

- Add `copy_configs_into_tool_install = true` and `config_script` to biome (lint + format) and knip (lint) drivers
- Add a trycmd integration test verifying a config in `.qlty/configs/` is copied to the tool install dir and accessible via `${config_file}`
- Closes the bug reported in https://github.com/qltysh/support/issues/296

## Root cause

Both plugins relied on the workspace-root symlink mechanism (`load_config_file_from_qlty_dir`, `executor.rs:350–370`) to make `.qlty/configs/` files visible. This mechanism silently breaks in two ways:

1. **Knip** uses `runs_from = target_directory` — its CWD is the directory containing `package.json`, not workspace root. The symlink placed at workspace root is invisible to knip's config discovery in any monorepo or subdirectory setup.
2. **Biome** runs from workspace root, so the symlink is technically in its CWD, but biome does not follow symlinks during config discovery.

## Fix

Follow the same pattern used by phpstan and eslint v9+:

- Add `config_script = "--config-path ${config_file}"` (biome) / `config_script = "--config ${config_file}"` (knip)
- Set `copy_configs_into_tool_install = true` on all affected drivers

`replace_config_script()` replaces `${config_script}` with the empty string when no config is found, so both tools continue to work for users without a config file. When a config is present (whether at repo root or in `.qlty/configs/`), it is physically copied into `tool.directory()` and the absolute path is passed to the tool via CLI flag — independent of CWD and symlink-following behaviour.

## Test plan

- [ ] New trycmd test `copy_config_to_tool_install_from_qlty_configs` — places `config.yml` in `.qlty/configs/`, runs a plugin with `copy_configs_into_tool_install = true` and `config_script`, verifies the config is accessible at the tool-dir path (i.e. the copy succeeded and `${config_file}` resolved correctly)
- [ ] Existing `copy_config_to_tool_install_with_exported_config` test continues to pass
- [ ] CI check tests pass

> **Note:** The expected stdout/stderr files for the new test were written to match the existing `copy_config_to_tool_install_with_exported_config` test pattern. If minor whitespace differences cause a snapshot mismatch, run `TRYCMD=overwrite cargo test -p qlty-cli copy_config_to_tool_install_from_qlty_configs` to regenerate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)