### PR TITLE
Update qlty-action coverage version in workflow

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run Test
         run: cargo llvm-cov --lcov --output-path target/lcov.info -- --include-ignored
 
-      - uses: qltysh/qlty-action/coverage@a19242102d17e497f437d7466aa01b528537e899
+      - uses: qltysh/qlty-action/coverage@f071a76ab07c05c4326f50342b7b477db89624f6 # node24-smoke / pre-release
         if: ${{ matrix.os != 'windows-latest' }}
         with:
           oidc: true


### PR DESCRIPTION
Bumps the coverage upload step to qltysh/qlty-action@f071a76 to validate the node24 runtime migration (qltysh/qlty-action#177) against a real CI workflow before we cut a release.                                             
                                                                          
  ## Test plan                                                                  
  - [ ] CI run is green                                                         
  - [ ] No "Node.js 20 actions are deprecated" warning naming                   
        qltysh/qlty-action/coverage in the run logs                             
                                                   
  Will repin to `@v2` (or a new tag) once qltysh/qlty-action#177 merges and ships.                      
