### PR TITLE
fix(rubocop): pass --force-exclusion so AllCops Exclude is respected

### DIFF
--- a/qlty-plugins/plugins/linters/rubocop/plugin.toml
+++ b/qlty-plugins/plugins/linters/rubocop/plugin.toml
@@ -13,7 +13,7 @@ package_file_candidate = "Gemfile"
 package_file_candidate_filters = ["rubocop", "standard"]
 
 [plugins.definitions.rubocop.drivers.lint]
-script = "rubocop --format json ${target}"
+script = "rubocop --force-exclusion --format json ${target}"
 success_codes = [0, 1]
 output = "stdout"
 output_format = "rubocop"
@@ -23,7 +23,7 @@ suggested = "targets"
 output_missing = "parse"
 
 [plugins.definitions.rubocop.drivers.format]
-script = "rubocop --fix-layout ${target}"
+script = "rubocop --force-exclusion --fix-layout ${target}"
 success_codes = [0, 1]
 output = "rewrite"
 cache_results = true


### PR DESCRIPTION
Closes #2784.

## Summary

Qlty currently ignores `AllCops: Exclude` patterns in `.rubocop.yml`. The cause: Qlty invokes rubocop with explicit file targets, and rubocop only applies `Exclude` during file discovery — not when files are passed on the command line. The `--force-exclusion` flag makes rubocop honor `Exclude` even with explicit targets.

This adds `--force-exclusion` to both the `lint` and `format` drivers in `qlty-plugins/plugins/linters/rubocop/plugin.toml`.

### Customer impact

Customers currently have to mirror their `.rubocop.yml` `AllCops: Exclude` patterns into `exclude_patterns` in `.qlty.toml` to get the expected behavior. After this change, the rubocop config is the single source of truth, matching how rubocop behaves natively.

### Reproduction / verification

Reproduced and verified the fix end-to-end in dh-sandbox/example-foobar-1#24:

1. Added a `spec/example_test_spec.rb` with `RSpec/ExampleWording` / `RSpec/BeEq` / `Layout/ExtraSpacing` violations — `qlty check` flagged it.
2. Added `AllCops: Exclude: ['spec/**/*.rb']` to `.rubocop.yml` — `qlty check` still flagged it (the bug).
3. Overrode the rubocop driver locally to add `--force-exclusion` — findings cleared.

This PR moves that override into the upstream plugin definition.

## Test plan

- [ ] CI green (rubocop plugin snapshot tests don't reference the script literal, so existing snapshots should be unaffected)
- [ ] Manual smoke test on a project with `AllCops: Exclude` to confirm excluded files are now skipped
- [ ] Confirm a project *without* any Exclude entries still produces the same findings (no false negatives)