### PR TITLE
fix(biome): pass --config-path explicitly to support .qlty/configs/

### DIFF
--- a/qlty-plugins/plugins/linters/biome/fixtures/__snapshots__/basic_with_config_v2.3.7.shot
+++ b/qlty-plugins/plugins/linters/biome/fixtures/__snapshots__/basic_with_config_v2.3.7.shot
@@ -1,0 +1,259 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`linter=biome fixture=basic_with_config version=2.3.7 1`] = `
+{
+  "issues": [
+    {
+      "category": "CATEGORY_LINT",
+      "level": "LEVEL_MEDIUM",
+      "location": {
+        "path": ".qlty/configs/biome.json",
+        "range": {
+          "endColumn": 61,
+          "endLine": 2,
+          "startColumn": 14,
+          "startLine": 2,
+        },
+      },
+      "message": "The configuration schema version does not match the CLI version 2.3.7",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "deserialize",
+      "snippet": "  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",",
+      "snippetWithContext": "{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "style": {
+        "useEnumInitializers": "off"
+      }
+    }
+  }
+}",
+      "tool": "biome",
+    },
+    {
+      "category": "CATEGORY_STYLE",
+      "level": "LEVEL_FMT",
+      "location": {
+        "path": ".qlty/configs/biome.json",
+      },
+      "message": "Incorrect formatting, autoformat by running \`qlty fmt\`.",
+      "mode": "MODE_BLOCK",
+      "onAddedLine": true,
+      "ruleKey": "fmt",
+      "tool": "biome",
+    },
+    {
+      "category": "CATEGORY_STYLE",
+      "level": "LEVEL_FMT",
+      "location": {
+        "path": "basic.in.ts",
+      },
+      "message": "Incorrect formatting, autoformat by running \`qlty fmt\`.",
+      "mode": "MODE_BLOCK",
+      "onAddedLine": true,
+      "ruleKey": "fmt",
+      "tool": "biome",
+    },
+    {
+      "category": "CATEGORY_LINT",
+      "level": "LEVEL_MEDIUM",
+      "location": {
+        "path": "basic.in.ts",
+        "range": {
+          "endColumn": 22,
+          "endLine": 13,
+          "startColumn": 3,
+          "startLine": 13,
+        },
+      },
+      "message": "This block statement doesn't serve any purpose and can be safely removed.",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "lint/complexity/noUselessLoneBlockStatements",
+      "snippet": "  { !foo ? null : 1 }",
+      "snippetWithContext": "
+enum Bar { Baz };
+
+const foo = (bar: Bar) => {
+  switch (bar) {
+    case Bar.Baz:
+      foobar();
+      barfoo();
+      break;
+  }
+  { !foo ? null : 1 }
+}
+
+enum Foo { Bae };",
+      "suggestions": [
+        {
+          "patch": "--- original
++++ modified
+@@ -9,8 +9,7 @@
+       foobar();
+       barfoo();
+       break;
+-  }
+-  { !foo ? null : 1 }
++  }!foo ? null : 1 
+ }
+
+ enum Foo { Bae };
+",
+          "replacements": [
+            {
+              "location": {
+                "range": {
+                  "endColumn": 5,
+                  "endLine": 13,
+                  "startColumn": 4,
+                  "startLine": 12,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 22,
+                  "endLine": 13,
+                  "startColumn": 21,
+                  "startLine": 13,
+                },
+              },
+            },
+          ],
+          "source": "SUGGESTION_SOURCE_TOOL",
+        },
+      ],
+      "tool": "biome",
+    },
+    {
+      "category": "CATEGORY_LINT",
+      "level": "LEVEL_MEDIUM",
+      "location": {
+        "path": "basic.in.ts",
+        "range": {
+          "endColumn": 9,
+          "endLine": 16,
+          "startColumn": 6,
+          "startLine": 16,
+        },
+      },
+      "message": "This variable Foo is unused.",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "lint/correctness/noUnusedVariables",
+      "snippet": "enum Foo { Bae };",
+      "snippetWithContext": "const foo = (bar: Bar) => {
+  switch (bar) {
+    case Bar.Baz:
+      foobar();
+      barfoo();
+      break;
+  }
+  { !foo ? null : 1 }
+}
+
+enum Foo { Bae };",
+      "tool": "biome",
+    },
+    {
+      "category": "CATEGORY_LINT",
+      "level": "LEVEL_MEDIUM",
+      "location": {
+        "path": "basic.in.ts",
+        "range": {
+          "endColumn": 10,
+          "endLine": 6,
+          "startColumn": 7,
+          "startLine": 6,
+        },
+      },
+      "message": "This variable foo is unused.",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "lint/correctness/noUnusedVariables",
+      "snippet": "const foo = (bar: Bar) => {",
+      "snippetWithContext": "const foobar = () => { }
+const barfoo = () => { }
+
+enum Bar { Baz };
+
+const foo = (bar: Bar) => {
+  switch (bar) {
+    case Bar.Baz:
+      foobar();
+      barfoo();
+      break;
+  }
+  { !foo ? null : 1 }
+}
+
+enum Foo { Bae };",
+      "suggestions": [
+        {
+          "patch": "--- original
++++ modified
+@@ -3,8 +3,8 @@
+
+ enum Bar { Baz };
+
+-const foo = (bar: Bar) => {
+-  switch (bar) {
++const _foo = (bar: Bar) => {
++  switch_fooar) {
+     case Bar.Baz:
+       foobar();
+       barfoo();
+",
+          "replacements": [
+            {
+              "location": {
+                "range": {
+                  "endColumn": 10,
+                  "endLine": 6,
+                  "startColumn": 7,
+                  "startLine": 6,
+                },
+              },
+            },
+            {
+              "data": "_foo",
+              "location": {
+                "range": {
+                  "endColumn": 10,
+                  "endLine": 6,
+                  "startColumn": 10,
+                  "startLine": 6,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 12,
+                  "endLine": 7,
+                  "startColumn": 9,
+                  "startLine": 7,
+                },
+              },
+            },
+            {
+              "data": "_foo",
+              "location": {
+                "range": {
+                  "endColumn": 12,
+                  "endLine": 7,
+                  "startColumn": 12,
+                  "startLine": 7,
+                },
+              },
+            },
+          ],
+          "source": "SUGGESTION_SOURCE_TOOL",
+        },
+      ],
+      "tool": "biome",
+    },
+  ],
+}
+`;

--- a/qlty-plugins/plugins/linters/biome/fixtures/basic_with_config.in/.qlty/configs/biome.json
+++ b/qlty-plugins/plugins/linters/biome/fixtures/basic_with_config.in/.qlty/configs/biome.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "style": {
+        "useEnumInitializers": "off"
+      }
+    }
+  }
+}

--- a/qlty-plugins/plugins/linters/biome/fixtures/basic_with_config.in/basic.in.ts
+++ b/qlty-plugins/plugins/linters/biome/fixtures/basic_with_config.in/basic.in.ts
@@ -1,0 +1,16 @@
+const foobar = () => { }
+const barfoo = () => { }
+
+enum Bar { Baz };
+
+const foo = (bar: Bar) => {
+  switch (bar) {
+    case Bar.Baz:
+      foobar();
+      barfoo();
+      break;
+  }
+  { !foo ? null : 1 }
+}
+
+enum Foo { Bae };

--- a/qlty-plugins/plugins/linters/biome/plugin.toml
+++ b/qlty-plugins/plugins/linters/biome/plugin.toml
@@ -14,7 +14,9 @@ package_file_candidate = "package.json"
 package_file_candidate_filters = ["biome"]
 
 [plugins.definitions.biome.drivers.lint]
-script = "biome lint --reporter=json ${target}"
+script = "biome lint --reporter=json ${config_script} ${target}"
+config_script = "--config-path ${config_file}"
+copy_configs_into_tool_install = true
 success_codes = [0, 1]
 output = "stdout"
 output_format = "biome"
@@ -24,7 +26,9 @@ suggested = "config"
 output_missing = "parse"
 
 [plugins.definitions.biome.drivers.format]
-script = "biome format --write ${target}"
+script = "biome format --write ${config_script} ${target}"
+config_script = "--config-path ${config_file}"
+copy_configs_into_tool_install = true
 success_codes = [0, 1]
 output = "rewrite"
 batch = true

--- a/qlty-plugins/plugins/linters/biome/plugin.toml
+++ b/qlty-plugins/plugins/linters/biome/plugin.toml
@@ -13,7 +13,8 @@ description = "A static analyzer for web projects"
 package_file_candidate = "package.json"
 package_file_candidate_filters = ["biome"]
 
-[plugins.definitions.biome.drivers.lint]
+[[plugins.definitions.biome.drivers.lint.version]]
+version_matcher = ">=2.0.0"
 script = "biome lint --reporter=json ${config_script} ${target}"
 config_script = "--config-path ${config_file}"
 copy_configs_into_tool_install = true
@@ -25,7 +26,20 @@ cache_results = true
 suggested = "config"
 output_missing = "parse"
 
-[plugins.definitions.biome.drivers.format]
+[[plugins.definitions.biome.drivers.lint.version]]
+version_matcher = "<2.0.0"
+script = "biome lint --reporter=json ${target}"
+success_codes = [0, 1]
+output = "stdout"
+output_format = "biome"
+batch = true
+cache_results = true
+suggested = "config"
+output_missing = "parse"
+known_good_version = "1.9.4"
+
+[[plugins.definitions.biome.drivers.format.version]]
+version_matcher = ">=2.0.0"
 script = "biome format --write ${config_script} ${target}"
 config_script = "--config-path ${config_file}"
 copy_configs_into_tool_install = true
@@ -35,3 +49,14 @@ batch = true
 cache_results = true
 driver_type = "formatter"
 suggested = "config"
+
+[[plugins.definitions.biome.drivers.format.version]]
+version_matcher = "<2.0.0"
+script = "biome format --write ${target}"
+success_codes = [0, 1]
+output = "rewrite"
+batch = true
+cache_results = true
+driver_type = "formatter"
+suggested = "config"
+known_good_version = "1.9.4"


### PR DESCRIPTION
## Summary

Fixes biome v2 not honoring configs in `.qlty/configs/biome.json`. Closes [qltysh/support#299](https://github.com/qltysh/support/issues/299).

## Root cause

Biome v2 changed config discovery: instead of a simple upward-walk from CWD, it scans the project tree and treats every `biome.json` it finds as a "root configuration". When more than one is found, biome aborts with:

> × Found a nested root configuration, but there's already a root configuration.

qlty's existing mechanism for exposing `.qlty/configs/biome.json` to biome creates a symlink at the workspace root pointing to the config in `.qlty/configs/`. Biome v2 walks the project, finds the symlink (counted as a root config) AND the original in `.qlty/configs/` (also counted as a root config), and errors out before reading either.

Verified against the [official repro](https://github.com/laura-mlg/qlty-biome-knip-test) — biome v2 fails on `main`, passes with this change.

## Fix

Same pattern as phpstan and eslint v9+:

- `script` interpolates `${config_script}` so the flag only appears when a config is present
- `config_script = "--config-path ${config_file}"` tells biome to read the user's config explicitly
- `copy_configs_into_tool_install = true` writes the config into the tool's install directory (outside the project tree), which biome's project-walk no longer sees as a duplicate

`replace_config_script()` substitutes `${config_script}` with an empty string when no config is present, so users without a config are unaffected.

### Why explicit `--config-path` alone wasn't enough

`--config-path` decides *which* config biome uses, but biome v2's project-walk for nested-root detection still runs. Both the workspace-root symlink and `.qlty/configs/biome.json` (when included as a lint target by qlty's workspace walker — biome lints `.json` files) trigger the error when the config is in-tree. Putting the config at `tool.directory()`, outside the project, sidesteps both.

## Test plan

- [x] Reproduced original bug on `main` against [official repro](https://github.com/laura-mlg/qlty-biome-knip-test) with biome 2.3.7 — got `× Found a nested root configuration` error
- [x] Same repro with this branch — biome 2.3.7 honors `.qlty/configs/biome.json` (lint rule disabled in config is suppressed; only formatter issues remain)
- [x] biome 1.9.4 still works (no regression on the older path)
- [x] `cargo test` passes
- [x] `qlty fmt` and `qlty check --level=low --fix` clean

## Notes

This is a follow-up to #2782, scoped down to just the biome change. The knip change in that PR has a separate issue (knip 5.21.2 rejects absolute `--config` paths) and needs a different approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)