### PR TITLE
fix(check): scrub env values from serialized invocation records

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
           # Windows
           - target: x86_64-pc-windows-msvc
-            runner: windows-latest
+            runner: windows-2022
             archive_format: zip
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-15, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-2022]
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     concurrency:
@@ -57,7 +57,7 @@ jobs:
         run: cargo llvm-cov --lcov --output-path target/lcov.info -- --include-ignored
 
       - uses: qltysh/qlty-action/coverage@f071a76ab07c05c4326f50342b7b477db89624f6 # node24-smoke / pre-release
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.os != 'windows-2022' }}
         with:
           oidc: true
           files: target/lcov.info

--- a/qlty-check/src/executor/invocation_result.rs
+++ b/qlty-check/src/executor/invocation_result.rs
@@ -42,6 +42,28 @@ pub enum InvocationStatus {
     ParseError,
 }
 
+fn keys_only_env(env: HashMap<String, String>) -> HashMap<String, String> {
+    if env_scrubbing_disabled() {
+        return env;
+    }
+
+    scrub_env_values(env)
+}
+
+fn scrub_env_values(env: HashMap<String, String>) -> HashMap<String, String> {
+    env.into_keys().map(|key| (key, String::new())).collect()
+}
+
+fn env_scrubbing_disabled() -> bool {
+    match std::env::var("QLTY_INSECURE_KEEP_INVOCATION_ENV") {
+        Ok(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            normalized == "1" || normalized == "true"
+        }
+        Err(_) => false,
+    }
+}
+
 impl InvocationResult {
     pub fn from_command_output(
         plan: &InvocationPlan,
@@ -85,9 +107,14 @@ impl InvocationResult {
                     .collect(),
                 script: rerun.to_string(),
                 cwd: path_to_string(&plan.invocation_directory),
-                env: plan.tool.env().with_context(|| {
+                // Record only the environment variable names, not their values. Values can
+                // contain user secrets (e.g. `${env.NAME}` interpolation), and this struct is
+                // serialized into invocation artifacts that get uploaded, where redaction does
+                // not reach. Set QLTY_INSECURE_KEEP_INVOCATION_ENV=1 to retain values for
+                // local debugging.
+                env: keys_only_env(plan.tool.env().with_context(|| {
                     format!("Failed to get environment for {}", plan.tool.name())
-                })?,
+                })?),
                 started_at: Some(start_time.into()),
                 duration_secs: duration as f32,
                 exit_code: exec_result.exit_code,
@@ -542,5 +569,35 @@ impl InvocationResult {
         } else {
             PathBuf::from(path)
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn scrub_env_values_drops_values() {
+        let mut env = HashMap::new();
+        env.insert("SECRET_TOKEN".to_string(), "super-secret".to_string());
+        env.insert("PATH".to_string(), "/usr/bin".to_string());
+
+        let scrubbed = scrub_env_values(env);
+
+        assert_eq!(scrubbed.get("SECRET_TOKEN"), Some(&String::new()));
+        assert_eq!(scrubbed.get("PATH"), Some(&String::new()));
+    }
+
+    #[test]
+    fn scrub_env_values_preserves_keys() {
+        let mut env = HashMap::new();
+        env.insert("SECRET_TOKEN".to_string(), "super-secret".to_string());
+        env.insert("PATH".to_string(), "/usr/bin".to_string());
+
+        let scrubbed = scrub_env_values(env);
+
+        assert_eq!(scrubbed.len(), 2);
+        assert!(scrubbed.contains_key("SECRET_TOKEN"));
+        assert!(scrubbed.contains_key("PATH"));
     }
 }


### PR DESCRIPTION
## Summary

`Invocation.env` recorded the full environment (names **and** values) of each plugin invocation. When a value was interpolated from a secret via `${env.NAME}`, that secret was serialized into invocation artifacts:

- `.qlty/builds/<build_id>/invocations-*.jsonl`
- `.qlty/builds/<build_id>/invocations.json.gz`
- `.qlty/out/invoke-*.yaml`

These artifacts get uploaded unredacted, since redaction only covers stdout/stderr — never serialized structs.

## Fix

Record only environment variable **names**, not their values, at the point `Invocation` is constructed (`invocation_result.rs`). Because `env` is write-only diagnostic data that is never read back, scrubbing at the source covers every serialization path (jsonl, gz, yaml outfile, `build --print`) with a single change.

Keys are preserved so the diagnostic value of "which vars were set" is retained — only the values are dropped.

## Escape hatch

Set `QLTY_INSECURE_KEEP_INVOCATION_ENV=1` (or `true`) to retain values for local debugging. Follows the existing `QLTY_INSECURE_ALLOW_HTTP` convention; default behavior is secure.

## CI

Separately, this branch pins the Rust-compiling Windows jobs (`cli.yml`, `build.yml`) to `windows-2022`. The `windows-latest` image rolled to VS 18 / MSVC 14.51, which the `aws-lc-sys` build (via rustls's `aws-lc-rs` backend) can't compile — `cmake 0.1.53` panics with "couldn't determine visual studio generator", and bumping cmake/cc is blocked by `tree-sitter-javascript 0.21.4` pinning `cc ~1.0.90`. This is pre-existing infra breakage, unrelated to the secret-scrubbing change.

## Tests

Added unit tests for the scrub transform. All 211 `qlty-check` tests pass; typecheck and `cargo fmt` clean.

Ref: qltysh/qltysh#635

🤖 Generated with [Claude Code](https://claude.com/claude-code)