### PR TITLE
Add --selection to qlty coverage publish and complete

### DIFF
--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -54,12 +54,11 @@ pub struct Complete {
     /// workspace and if it cannot be inferred from the git origin.
     pub project: Option<String>,
 
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "selected")]
-    /// Complete the uploads published with the same --selection value.
-    /// Selected and unselected uploads assemble into separate reports, so this
-    /// must match the value passed to qlty coverage publish. Defaults to
-    /// "selected"; pass --selection=<label> to name the selection.
-    pub selection: Option<String>,
+    #[arg(long)]
+    /// Complete the uploads published with --selection. Selected and
+    /// unselected uploads assemble into separate reports, so pass this
+    /// exactly when it was passed to qlty coverage publish.
+    pub selection: bool,
 
     #[arg(long)]
     /// Perform a dry-run without actually completing the coverage
@@ -143,7 +142,7 @@ impl Complete {
             tag: self.tag.clone(),
             quiet: self.quiet,
             project: self.project.clone(),
-            selection: self.selection.clone(),
+            selection: self.selection.then(|| "selected".to_string()),
             ..Default::default()
         }
     }

--- a/qlty-cli/src/commands/coverage/complete.rs
+++ b/qlty-cli/src/commands/coverage/complete.rs
@@ -54,6 +54,13 @@ pub struct Complete {
     /// workspace and if it cannot be inferred from the git origin.
     pub project: Option<String>,
 
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "selected")]
+    /// Complete the uploads published with the same --selection value.
+    /// Selected and unselected uploads assemble into separate reports, so this
+    /// must match the value passed to qlty coverage publish. Defaults to
+    /// "selected"; pass --selection=<label> to name the selection.
+    pub selection: Option<String>,
+
     #[arg(long)]
     /// Perform a dry-run without actually completing the coverage
     pub dry_run: bool,
@@ -136,6 +143,7 @@ impl Complete {
             tag: self.tag.clone(),
             quiet: self.quiet,
             project: self.project.clone(),
+            selection: self.selection.clone(),
             ..Default::default()
         }
     }

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -149,11 +149,13 @@ pub struct Publish {
     /// The server will merge the uploads into a single report when qlty coverage complete is called.
     pub incomplete: bool,
 
-    #[arg(long)]
-    /// Mark this upload as a selective (subset) test run — e.g. only the tests
-    /// affected by a pull request's changes. Selective coverage contributes to
-    /// diff coverage only and is excluded from total coverage.
-    pub selective: bool,
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "selected")]
+    /// Mark this upload as coming from a selected subset of the test suite —
+    /// e.g. only the tests affected by a pull request's changes. Selected
+    /// coverage contributes to diff coverage only and is excluded from total
+    /// coverage. Defaults to "selected"; pass --selection=<label> to name the
+    /// selection.
+    pub selection: Option<String>,
 
     /// Skip fetching sources before publishing. Requires sources to be cached locally.
     #[arg(long)]
@@ -300,11 +302,7 @@ impl Publish {
             strip_prefix,
             tag: self.tag.clone(),
             total_parts_count: self.total_parts_count,
-            selection: if self.selective {
-                Some("selective".to_string())
-            } else {
-                None
-            },
+            selection: self.selection.clone(),
         })
     }
 

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -149,6 +149,12 @@ pub struct Publish {
     /// The server will merge the uploads into a single report when qlty coverage complete is called.
     pub incomplete: bool,
 
+    #[arg(long)]
+    /// Mark this upload as a selective (subset) test run — e.g. only the tests
+    /// affected by a pull request's changes. Selective coverage contributes to
+    /// diff coverage only and is excluded from total coverage.
+    pub selective: bool,
+
     /// Skip fetching sources before publishing. Requires sources to be cached locally.
     #[arg(long)]
     pub skip_source_fetch: bool,
@@ -294,6 +300,11 @@ impl Publish {
             strip_prefix,
             tag: self.tag.clone(),
             total_parts_count: self.total_parts_count,
+            selection: if self.selective {
+                Some("selective".to_string())
+            } else {
+                None
+            },
         })
     }
 

--- a/qlty-cli/src/commands/coverage/publish.rs
+++ b/qlty-cli/src/commands/coverage/publish.rs
@@ -149,13 +149,12 @@ pub struct Publish {
     /// The server will merge the uploads into a single report when qlty coverage complete is called.
     pub incomplete: bool,
 
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "selected")]
+    #[arg(long)]
     /// Mark this upload as coming from a selected subset of the test suite —
     /// e.g. only the tests affected by a pull request's changes. Selected
     /// coverage contributes to diff coverage only and is excluded from total
-    /// coverage. Defaults to "selected"; pass --selection=<label> to name the
-    /// selection.
-    pub selection: Option<String>,
+    /// coverage.
+    pub selection: bool,
 
     /// Skip fetching sources before publishing. Requires sources to be cached locally.
     #[arg(long)]
@@ -302,7 +301,7 @@ impl Publish {
             strip_prefix,
             tag: self.tag.clone(),
             total_parts_count: self.total_parts_count,
-            selection: self.selection.clone(),
+            selection: self.selection.then(|| "selected".to_string()),
         })
     }
 

--- a/qlty-coverage/src/publish/planner.rs
+++ b/qlty-coverage/src/publish/planner.rs
@@ -201,6 +201,7 @@ impl MetadataPlanner {
         metadata.name = self.settings.name.clone();
         metadata.total_parts_count = self.settings.total_parts_count;
         metadata.incomplete = self.settings.incomplete;
+        metadata.selection = self.settings.selection.clone();
 
         // Override metadata with command line arguments
         if let Some(build_id) = self.settings.override_build_id.clone() {
@@ -605,6 +606,25 @@ mod tests {
         let metadata_planner = MetadataPlanner::new(&settings, None);
         let metadata = metadata_planner.compute().unwrap();
         assert_eq!(metadata.reference_type, ReferenceType::Unspecified as i32);
+    }
+
+    #[test]
+    fn test_selection_set_from_settings() {
+        let settings = Settings {
+            selection: Some("selective".to_string()),
+            ..Default::default()
+        };
+        let metadata_planner = MetadataPlanner::new(&settings, None);
+        let metadata = metadata_planner.compute().unwrap();
+        assert_eq!(metadata.selection, Some("selective".to_string()));
+    }
+
+    #[test]
+    fn test_selection_defaults_to_none() {
+        let settings = Settings::default();
+        let metadata_planner = MetadataPlanner::new(&settings, None);
+        let metadata = metadata_planner.compute().unwrap();
+        assert_eq!(metadata.selection, None);
     }
 
     #[test]

--- a/qlty-coverage/src/publish/planner.rs
+++ b/qlty-coverage/src/publish/planner.rs
@@ -611,12 +611,12 @@ mod tests {
     #[test]
     fn test_selection_set_from_settings() {
         let settings = Settings {
-            selection: Some("selective".to_string()),
+            selection: Some("selected".to_string()),
             ..Default::default()
         };
         let metadata_planner = MetadataPlanner::new(&settings, None);
         let metadata = metadata_planner.compute().unwrap();
-        assert_eq!(metadata.selection, Some("selective".to_string()));
+        assert_eq!(metadata.selection, Some("selected".to_string()));
     }
 
     #[test]

--- a/qlty-coverage/src/publish/planner.rs
+++ b/qlty-coverage/src/publish/planner.rs
@@ -170,6 +170,7 @@ impl MetadataPlanner {
             nanos: now.nanosecond() as i32,
         });
         metadata.tag = self.settings.tag.clone();
+        metadata.selection = self.settings.selection.clone();
 
         Ok(metadata)
     }
@@ -624,6 +625,25 @@ mod tests {
         let settings = Settings::default();
         let metadata_planner = MetadataPlanner::new(&settings, None);
         let metadata = metadata_planner.compute().unwrap();
+        assert_eq!(metadata.selection, None);
+    }
+
+    #[test]
+    fn test_minimal_selection_set_from_settings() {
+        let settings = Settings {
+            selection: Some("selected".to_string()),
+            ..Default::default()
+        };
+        let metadata_planner = MetadataPlanner::new(&settings, None);
+        let metadata = metadata_planner.compute_minimal().unwrap();
+        assert_eq!(metadata.selection, Some("selected".to_string()));
+    }
+
+    #[test]
+    fn test_minimal_selection_defaults_to_none() {
+        let settings = Settings::default();
+        let metadata_planner = MetadataPlanner::new(&settings, None);
+        let metadata = metadata_planner.compute_minimal().unwrap();
         assert_eq!(metadata.selection, None);
     }
 

--- a/qlty-coverage/src/publish/settings.rs
+++ b/qlty-coverage/src/publish/settings.rs
@@ -26,6 +26,7 @@ pub struct Settings {
     pub strip_prefix: Option<String>,
     pub tag: Option<String>,
     pub total_parts_count: Option<u32>,
+    pub selection: Option<String>,
 
     pub paths: Vec<String>,
 }

--- a/qlty-types/src/protos/qlty.tests.v1.rs
+++ b/qlty-types/src/protos/qlty.tests.v1.rs
@@ -88,6 +88,8 @@ pub struct CoverageMetadata {
     pub reference: ::prost::alloc::string::String,
     #[prost(bool, tag="43")]
     pub complete: bool,
+    #[prost(string, optional, tag="44")]
+    pub selection: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReportFile {

--- a/qlty-types/src/protos/qlty.tests.v1.serde.rs
+++ b/qlty-types/src/protos/qlty.tests.v1.serde.rs
@@ -136,6 +136,9 @@ impl serde::Serialize for CoverageMetadata {
         if self.complete {
             len += 1;
         }
+        if self.selection.is_some() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("qlty.tests.v1.CoverageMetadata", len)?;
         if !self.upload_id.is_empty() {
             struct_ser.serialize_field("uploadId", &self.upload_id)?;
@@ -268,6 +271,9 @@ impl serde::Serialize for CoverageMetadata {
         if self.complete {
             struct_ser.serialize_field("complete", &self.complete)?;
         }
+        if let Some(v) = self.selection.as_ref() {
+            struct_ser.serialize_field("selection", v)?;
+        }
         struct_ser.end()
     }
 }
@@ -353,6 +359,7 @@ impl<'de> serde::Deserialize<'de> for CoverageMetadata {
             "buildUrl",
             "reference",
             "complete",
+            "selection",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -400,6 +407,7 @@ impl<'de> serde::Deserialize<'de> for CoverageMetadata {
             BuildUrl,
             Reference,
             Complete,
+            Selection,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -464,6 +472,7 @@ impl<'de> serde::Deserialize<'de> for CoverageMetadata {
                             "buildUrl" | "build_url" => Ok(GeneratedField::BuildUrl),
                             "reference" => Ok(GeneratedField::Reference),
                             "complete" => Ok(GeneratedField::Complete),
+                            "selection" => Ok(GeneratedField::Selection),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -526,6 +535,7 @@ impl<'de> serde::Deserialize<'de> for CoverageMetadata {
                 let mut build_url__ = None;
                 let mut reference__ = None;
                 let mut complete__ = None;
+                let mut selection__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::UploadId => {
@@ -790,6 +800,12 @@ impl<'de> serde::Deserialize<'de> for CoverageMetadata {
                             }
                             complete__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::Selection => {
+                            if selection__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("selection"));
+                            }
+                            selection__ = map_.next_value()?;
+                        }
                     }
                 }
                 Ok(CoverageMetadata {
@@ -836,6 +852,7 @@ impl<'de> serde::Deserialize<'de> for CoverageMetadata {
                     build_url: build_url__,
                     reference: reference__.unwrap_or_default(),
                     complete: complete__.unwrap_or_default(),
+                    selection: selection__,
                 })
             }
         }


### PR DESCRIPTION
## Summary

Adds a bare `--selection` flag to `qlty coverage publish` **and** `qlty coverage complete` for uploads produced by a selective (subset) test run — e.g. only the tests affected by a pull request's changes. When set, the CLI sends `selection: "selected"`; when omitted, the field is absent (a full test-suite run). Labeled selections are not supported yet — the server accepts exactly `"selected"` — but the wire protocol carries a string so labels can be introduced later without protocol changes.

The server treats a non-null `selection` as selective coverage: it contributes to diff coverage only — no total coverage, no component coverage — and selected/unselected uploads for the same commit and tag assemble into **separate reports**. That last part is why `complete` needs the flag too: a complete call finalizes the report keyed by its selection, so it must be passed exactly when the publish it completes passed it. Without it, a selective multi-part (`--incomplete`) upload can never be finalized.

- `selection` (optional string, tag 44) on the CoverageMetadata proto + pbjson serde
- `publish`: `--selection` → `Settings` → `MetadataPlanner::compute()` → metadata.json
- `complete`: `--selection` → `Settings` → `MetadataPlanner::compute_minimal()` → the complete request body

🤖 Generated with [Claude Code](https://claude.com/claude-code)