### PR TITLE
feat(check): include failing install command output in build messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,6 +2862,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
+ "thiserror 2.0.16",
  "tracing",
  "tracing-test",
  "ureq",

--- a/qlty-check/Cargo.toml
+++ b/qlty-check/Cargo.toml
@@ -55,6 +55,7 @@ shell-escape.workspace = true
 sysinfo.workspace = true
 tar.workspace = true
 tempfile.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 ureq.workspace = true
 url.workspace = true

--- a/qlty-check/src/executor.rs
+++ b/qlty-check/src/executor.rs
@@ -776,7 +776,11 @@ fn install_error_message(name: &str, error: &Error) -> Message {
 }
 
 fn install_error_details(error: &Error) -> String {
-    if let Some(command_error) = error.downcast_ref::<ToolCommandError>() {
+    let command_error = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<ToolCommandError>());
+
+    if let Some(command_error) = command_error {
         let output_tail = command_error.output_tail();
 
         if !output_tail.is_empty() {

--- a/qlty-check/src/executor.rs
+++ b/qlty-check/src/executor.rs
@@ -8,6 +8,7 @@ use crate::llm::Fixer;
 use crate::planner::check_filters::CheckFilters;
 use crate::planner::config_files::config_globset;
 use crate::planner::source_extractor::SourceExtractor;
+use crate::tool::command_error::ToolCommandError;
 use crate::Tool;
 use crate::{
     cache::IssueCache,
@@ -15,7 +16,7 @@ use crate::{
     ui::{Progress, ProgressBar},
 };
 use crate::{cache::IssuesCacheHit, planner::Plan, results::FormattedFile, Results};
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Context, Error, Result};
 use chrono::Utc;
 pub use driver::Driver;
 use ignore::{DirEntry, WalkBuilder, WalkState};
@@ -83,16 +84,7 @@ impl Executor {
             if self.plan.skip_errored_plugins {
                 if let Err(err) = result {
                     error!("Error installing tool {}: {:?}", name, err);
-
-                    install_messages.push(Message {
-                        timestamp: Some(Utc::now().into()),
-                        module: "qlty_check::executor".to_string(),
-                        ty: "executor.install.error".to_string(),
-                        level: MessageLevel::Error.into(),
-                        message: format!("Error installing tool {}", name),
-                        details: err.to_string(),
-                        ..Default::default()
-                    });
+                    install_messages.push(install_error_message(&name, &err));
                 }
             } else {
                 result?;
@@ -771,6 +763,30 @@ fn run_invocation(
     Ok(result)
 }
 
+fn install_error_message(name: &str, error: &Error) -> Message {
+    Message {
+        timestamp: Some(Utc::now().into()),
+        module: "qlty_check::executor".to_string(),
+        ty: "executor.install.error".to_string(),
+        level: MessageLevel::Error.into(),
+        message: format!("Error installing tool {name}"),
+        details: install_error_details(error),
+        ..Default::default()
+    }
+}
+
+fn install_error_details(error: &Error) -> String {
+    if let Some(command_error) = error.downcast_ref::<ToolCommandError>() {
+        let output_tail = command_error.output_tail();
+
+        if !output_tail.is_empty() {
+            return format!("{error}\n\n{output_tail}");
+        }
+    }
+
+    error.to_string()
+}
+
 fn walk_collect_entries_parallel(builder: &WalkBuilder) -> Vec<DirEntry> {
     let dents = Arc::new(Mutex::new(vec![]));
 
@@ -787,4 +803,57 @@ fn walk_collect_entries_parallel(builder: &WalkBuilder) -> Vec<DirEntry> {
 
     let dents = dents.lock().unwrap();
     dents.to_vec()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anyhow::anyhow;
+
+    fn command_error() -> ToolCommandError {
+        ToolCommandError {
+            command: vec!["npm".to_string(), "install".to_string()],
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "npm error code E404\nnpm error 404 Not Found".to_string(),
+        }
+    }
+
+    #[test]
+    fn install_error_details_appends_command_output() {
+        let error = Error::from(command_error()).context("Error installing eslint@9.7.0.");
+
+        let details = install_error_details(&error);
+
+        assert_eq!(
+            details,
+            "Error installing eslint@9.7.0.\n\nnpm error code E404\nnpm error 404 Not Found"
+        );
+    }
+
+    #[test]
+    fn install_error_details_with_empty_command_output() {
+        let mut error = command_error();
+        error.stderr = String::new();
+
+        assert_eq!(
+            install_error_details(&Error::from(error)),
+            r#"Command ["npm", "install"] exited with code 1"#
+        );
+    }
+
+    #[test]
+    fn install_error_details_without_command_error() {
+        assert_eq!(install_error_details(&anyhow!("boom")), "boom");
+    }
+
+    #[test]
+    fn install_error_message_fields() {
+        let message = install_error_message("eslint", &anyhow!("boom"));
+
+        assert_eq!(message.ty, "executor.install.error");
+        assert_eq!(message.level, MessageLevel::Error as i32);
+        assert_eq!(message.message, "Error installing tool eslint");
+        assert_eq!(message.details, "boom");
+    }
 }

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -1,4 +1,5 @@
 pub mod command_builder;
+pub mod command_error;
 mod download;
 mod github;
 pub mod go;
@@ -20,6 +21,7 @@ use crate::ui::ProgressTask;
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
 use command_builder::Command;
+use command_error::ToolCommandError;
 use console::style;
 use duct::Expression;
 use fslock::LockFile;
@@ -453,11 +455,13 @@ pub trait Tool: Debug + Sync + Send {
 
         let output = result?;
         if !output.status.success() {
-            bail!(
-                "Command {:?} exited with code {}",
-                command.lock().map_err(|_| lock_error())?,
-                output.status.code().unwrap_or_default()
-            );
+            return Err(ToolCommandError {
+                command: command.lock().map_err(|_| lock_error())?.clone(),
+                exit_code: exit_status_code(&output.status),
+                stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            }
+            .into());
         }
 
         Ok(())

--- a/qlty-check/src/tool/command_error.rs
+++ b/qlty-check/src/tool/command_error.rs
@@ -1,0 +1,78 @@
+use thiserror::Error;
+
+const OUTPUT_TAIL_LINES: usize = 10;
+
+#[derive(Debug, Error)]
+#[error("Command {command:?} exited with code {exit_code}")]
+pub struct ToolCommandError {
+    pub command: Vec<String>,
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl ToolCommandError {
+    pub fn output_tail(&self) -> String {
+        let source = if self.stderr.trim().is_empty() {
+            &self.stdout
+        } else {
+            &self.stderr
+        };
+
+        let lines: Vec<&str> = source
+            .lines()
+            .map(str::trim_end)
+            .filter(|line| !line.is_empty())
+            .collect();
+
+        lines[lines.len().saturating_sub(OUTPUT_TAIL_LINES)..].join("\n")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn command_error(stdout: &str, stderr: &str) -> ToolCommandError {
+        ToolCommandError {
+            command: vec!["npm".to_string(), "install".to_string()],
+            exit_code: 1,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+        }
+    }
+
+    #[test]
+    fn display_includes_command_and_exit_code() {
+        assert_eq!(
+            command_error("", "").to_string(),
+            r#"Command ["npm", "install"] exited with code 1"#
+        );
+    }
+
+    #[test]
+    fn output_tail_prefers_stderr() {
+        let error = command_error("out line", "err line");
+        assert_eq!(error.output_tail(), "err line");
+    }
+
+    #[test]
+    fn output_tail_falls_back_to_stdout() {
+        let error = command_error("out line", " \n");
+        assert_eq!(error.output_tail(), "out line");
+    }
+
+    #[test]
+    fn output_tail_returns_last_lines() {
+        let lines: Vec<String> = (1..=12).map(|n| format!("line {n}")).collect();
+        let error = command_error("", &lines.join("\n"));
+
+        assert_eq!(error.output_tail(), lines[2..].join("\n"));
+    }
+
+    #[test]
+    fn output_tail_skips_blank_lines() {
+        let error = command_error("", "one\n\n  \ntwo");
+        assert_eq!(error.output_tail(), "one\ntwo");
+    }
+}


### PR DESCRIPTION
## What

When a plugin install fails under `--skip-errored-plugins` (how cloud builds run), the `executor.install.error` message uploaded with the build only carried the outermost error string — `Error installing eslint@9.7.0. See more: <path to a log file on the build machine>` — which is useless on the build page. The actual package-manager output was captured all along, but only landed in the local install log.

This PR plumbs that output into the message:

- `Tool::run_command` now returns a typed `ToolCommandError` (thiserror) carrying the command, exit code, and captured stdout/stderr instead of a formatted `bail!` string. Its `Display` is identical to the old bail message, so terminal behavior is unchanged.
- `Executor::install` downcasts it through the anyhow context chain and appends the last 10 non-empty output lines to `Message.details`.
- The exit code uses the existing `exit_status_code` helper, so a signal-killed install reports the signal number instead of a misleading `0`.

`ty`/`level`/`message` are unchanged, so the existing ingestion into ClickHouse and the build-page message rendering pick this up with no server-side changes.

## Why

First step toward detecting private-package install failures caused by missing [build secrets](https://docs.qlty.sh/cloud/build-secrets). A follow-up will classify npm auth failures (`E401`/`E404`) from `ToolCommandError.stderr` and emit actionable guidance.

## Example

Verified end-to-end against a private GitHub Packages dependency (`qlty-build-secrets-demo` setup). Message details, before → after:

```
Error installing eslint@9.7.0.

    See more: /Users/…/eslint/9.7.0-…-install.log
```

```
Error installing eslint@9.7.0.

    See more: /Users/…/eslint/9.7.0-…-install.log

npm WARN using --force Recommended protections disabled.
npm ERR! code E401
npm ERR! 401 Unauthorized - GET https://npm.pkg.github.com/@marschattha%2feslint-config-qlty-demo - authentication token not provided
npm ERR! A complete log of this run can be found in: /Users/…/_logs/…-debug-0.log
```

Also verified: wrong token (`E401 … User cannot be authenticated with the token provided`), and valid token via `${env.NPM_TOKEN}` (install succeeds, no error message, private config resolves). The token value never appears in exports or logs in any scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)