### PR TITLE
Pin qltysh/qlty-action to v2.2.2 by commit SHA

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Qlty CLI
-        uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899
+        uses: qltysh/qlty-action/install@b413a89d8f3a8b36b9edd20b7ef1ad7ae0a7ac3a # version 2.2.2
 
       - name: Update CHANGELOG.md
         id: claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Qlty CLI
-        uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899
+        uses: qltysh/qlty-action/install@b413a89d8f3a8b36b9edd20b7ef1ad7ae0a7ac3a # version 2.2.2
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run Test
         run: cargo llvm-cov --lcov --output-path target/lcov.info -- --include-ignored
 
-      - uses: qltysh/qlty-action/coverage@f071a76ab07c05c4326f50342b7b477db89624f6 # node24-smoke / pre-release
+      - uses: qltysh/qlty-action/coverage@b413a89d8f3a8b36b9edd20b7ef1ad7ae0a7ac3a # version 2.2.2
         if: ${{ matrix.os != 'windows-2022' }}
         with:
           oidc: true

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           persist-credentials: false
-      - uses: qltysh/qlty-action/fmt@a19242102d17e497f437d7466aa01b528537e899
+      - uses: qltysh/qlty-action/fmt@b413a89d8f3a8b36b9edd20b7ef1ad7ae0a7ac3a # version 2.2.2
       - name: Commit changes
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:


### PR DESCRIPTION
Pins `qltysh/qlty-action` actions to [`b413a89d8f3a8b36b9edd20b7ef1ad7ae0a7ac3a`](https://github.com/qltysh/qlty-action/commit/b413a89d8f3a8b36b9edd20b7ef1ad7ae0a7ac3a) (version 2.2.2).

Pinning actions to a full commit SHA (instead of a mutable tag) ensures workflow runs always execute the exact, audited revision of the action.

Changes:
- `.github/workflows/fmt.yml`: `qltysh/qlty-action/fmt@a19242102d17e497f437d7466aa01b528537e899` → `@b413a89d8f3a8b36b9edd20b7ef1ad7ae0a7ac3a # version 2.2.2`
- `.github/workflows/changelog.yml`: `qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899` → `@b413a89d8f3a8b36b9edd20b7ef1ad7ae0a7ac3a # version 2.2.2`
- `.github/workflows/cli.yml`: `qltysh/qlty-action/coverage@f071a76ab07c05c4326f50342b7b477db89624f6` → `@b413a89d8f3a8b36b9edd20b7ef1ad7ae0a7ac3a # version 2.2.2`
- `.github/workflows/claude.yml`: `qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899` → `@b413a89d8f3a8b36b9edd20b7ef1ad7ae0a7ac3a # version 2.2.2`