### PR TITLE
fix(check): recreate dangling .qlty symlinks after cache deletion

### DIFF
--- a/qlty-config/src/library.rs
+++ b/qlty-config/src/library.rs
@@ -254,29 +254,39 @@ impl Library {
     }
 
     fn try_symlink_if_missing(&self, target: &Path, link: &Path) -> Result<()> {
-        if !link.exists() {
-            #[cfg(unix)]
-            {
-                if let Err(err) = std::os::unix::fs::symlink(target, link) {
-                    error!(
-                        "Failed to create symlink from {} to {}: {}",
-                        target.display(),
-                        link.display(),
-                        err
-                    );
-                }
+        // Path::exists() follows symlinks, so a dangling symlink (e.g. one left
+        // behind after the cache directory was deleted) reports false while still
+        // blocking symlink creation with EEXIST. Check the link node itself and
+        // remove it if it is a symlink whose target is gone.
+        if let Ok(metadata) = link.symlink_metadata() {
+            if metadata.file_type().is_symlink() && !link.exists() {
+                fs::remove_file(link)?;
+            } else {
+                return Ok(());
             }
+        }
 
-            #[cfg(windows)]
-            {
-                if let Err(err) = std::os::windows::fs::symlink_dir(target, link) {
-                    error!(
-                        "Failed to create symlink from {} to {}: {}",
-                        target.display(),
-                        link.display(),
-                        err
-                    );
-                }
+        #[cfg(unix)]
+        {
+            if let Err(err) = std::os::unix::fs::symlink(target, link) {
+                error!(
+                    "Failed to create symlink from {} to {}: {}",
+                    target.display(),
+                    link.display(),
+                    err
+                );
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            if let Err(err) = std::os::windows::fs::symlink_dir(target, link) {
+                error!(
+                    "Failed to create symlink from {} to {}: {}",
+                    target.display(),
+                    link.display(),
+                    err
+                );
             }
         }
 
@@ -306,5 +316,70 @@ impl Library {
         }
 
         Ok(existing_dirs)
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod test {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn setup() -> (TempDir, Library, PathBuf, PathBuf) {
+        let temp_dir = TempDir::new().unwrap();
+        let library = Library::new(temp_dir.path()).unwrap();
+
+        let target = temp_dir.path().join("target");
+        fs::create_dir_all(&target).unwrap();
+
+        let link = temp_dir.path().join("link");
+
+        (temp_dir, library, target, link)
+    }
+
+    #[test]
+    fn try_symlink_creates_link_when_missing() {
+        let (_temp_dir, library, target, link) = setup();
+
+        library.try_symlink_if_missing(&target, &link).unwrap();
+
+        assert_eq!(fs::read_link(&link).unwrap(), target);
+    }
+
+    #[test]
+    fn try_symlink_replaces_dangling_link() {
+        let (temp_dir, library, target, link) = setup();
+
+        let missing_target = temp_dir.path().join("deleted-cache-dir");
+        std::os::unix::fs::symlink(&missing_target, &link).unwrap();
+
+        library.try_symlink_if_missing(&target, &link).unwrap();
+
+        assert_eq!(fs::read_link(&link).unwrap(), target);
+    }
+
+    #[test]
+    fn try_symlink_keeps_valid_link() {
+        let (temp_dir, library, target, link) = setup();
+
+        let other_target = temp_dir.path().join("other-target");
+        fs::create_dir_all(&other_target).unwrap();
+        std::os::unix::fs::symlink(&other_target, &link).unwrap();
+
+        library.try_symlink_if_missing(&target, &link).unwrap();
+
+        assert_eq!(fs::read_link(&link).unwrap(), other_target);
+    }
+
+    #[test]
+    fn try_symlink_keeps_existing_directory() {
+        let (_temp_dir, library, target, link) = setup();
+
+        fs::create_dir_all(&link).unwrap();
+
+        library.try_symlink_if_missing(&target, &link).unwrap();
+
+        assert!(link.is_dir());
+        assert!(fs::read_link(&link).is_err());
     }
 }


### PR DESCRIPTION
## Problem

If `~/.qlty/cache/repos` is deleted (a natural troubleshooting step), the `.qlty/out` and `.qlty/logs` symlinks in every previously-checked workspace are left dangling. The next `qlty check` then fails with an opaque error:

```
 > FATAL error occurred running 7 invocations
```

The logs show why:

```
ERROR qlty_config::library: Failed to create symlink from .../cache/repos/<hash>/out to .../.qlty/out: File exists (os error 17)
ERROR qlty_check::executor::invocation_result: Failed to create directory: .../.qlty/out
ERROR qlty_check::executor: Invocation failed for actionlint/lint: Failed to write invocation results ... No such file or directory (os error 2)
```

## Root cause

`Library::try_symlink_if_missing` gates symlink creation on `!link.exists()`. `Path::exists()` follows symlinks, so a dangling symlink reports `false` — but the link node still exists, so `symlink()` fails with `EEXIST`. That error is only logged, so the run proceeds with the broken link in place and every invocation fails writing through it.

## Fix

Inspect the link node itself with `symlink_metadata()`. If it is a symlink whose target is gone, remove it and recreate it pointing at the current cache directory. Valid symlinks and real files/directories at the path are left untouched, preserving existing behavior.

## Testing

- Added unit tests for `try_symlink_if_missing` covering: link missing, dangling link (the bug), valid link, and a real directory at the link path. Gated `#[cfg(unix)]` since symlink creation on Windows CI requires elevated privileges.
- Verified end-to-end: reproduced the failure in a workspace whose `.qlty/out` and `.qlty/logs` pointed at a deleted cache hash — the released binary fails with the FATAL error above; the patched binary heals the symlinks and completes with `✔ No issues`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)