### PR TITLE
fix(ci): unbreak Plugin Tests on macOS and Windows runners

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15, ubuntu-latest, windows-latest]
+        os: [macos-15, ubuntu-latest, windows-2022]
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     concurrency:
@@ -72,7 +72,7 @@ jobs:
           key: ${{ runner.os }}-qlty-${{ env.CACHE_MONTH }}-v1
 
       - name: Setup PHP with PECL extension
-        uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         if: contains(matrix.os, 'macos')
 
       - name: Setup Ruby


### PR DESCRIPTION
## Problem

The Plugin Tests workflow has been red on its weekly scheduled runs since 2026-05-22 (last green 2026-05-15), and fails identically on unrelated PRs (e.g. #2805). Two independent runner-image regressions:

**macos-15** — the `shivammathur/setup-php` pin (v2.35.4, Aug 2025) can no longer install the default PHP 8.5 on the current macos-15 image; the job dies in setup before any repo code runs:

```
✗ PHP Could not setup PHP 8.5
php: command not found
```

**windows-latest** — the image now ships Visual Studio 18 / MSVC 14.51, which breaks the `aws-lc-sys v0.29.0` build script during `cargo build`:

```
vcruntime_c11_stdatomic.h(16): fatal error C1189: #error: "C atomics require C11 or later"
couldn't determine visual studio generator
```

## Fix

- Bump `setup-php` to v2.37.2 (SHA-pinned, matching repo convention).
- Pin the Windows job to `windows-2022`, matching the Unit Tests workflow (`cli.yml`), which is green on that image. A proper fix for VS 18 would be upgrading `aws-lc-sys` via a rustls bump, which can happen independently.

## Testing

This PR touches `.github/workflows/plugins.yml`, which is in the workflow's `pull_request` paths filter — so the Plugin Tests run on this PR exercises both fixes directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)