### PR TITLE
feat(release): draft changelog entry automatically in Prepare Release

### DIFF
--- a/.github/prompts/changelog.md
+++ b/.github/prompts/changelog.md
@@ -27,7 +27,10 @@ Follow these steps:
    reference PR numbers like `(#2762)`.
 5. If there are no externally observable changes, still add the section with a
    single brief bullet summarizing the most significant internal change.
-6. If a PR author is not a member of the team, include a shout out thanking
+6. If CHANGELOG.md contains an `## Unreleased` section, fold its bullets into
+   the new version's section and remove the `## Unreleased` heading, so the
+   same changes are not listed twice.
+7. If a PR author is not a member of the team, include a shout out thanking
    them. (Team members are @noahd1, @lsegal, @brynary, @marschattha,
    @davehenton, @laura-mlg. They don't need shout outs.)
 

--- a/.github/prompts/changelog.md
+++ b/.github/prompts/changelog.md
@@ -1,0 +1,38 @@
+# Draft a changelog entry for an upcoming release
+
+You are drafting the CHANGELOG.md entry for an upcoming release of this
+repository. The workflow invoking you provides three values:
+
+- `VERSION`: the version being released, without a leading "v"
+- `LAST_TAG`: the git tag of the most recent release
+- `DATE`: today's date (YYYY-MM-DD)
+
+Follow these steps:
+
+1. Use `git log ${LAST_TAG}..HEAD --oneline --first-parent` to list the
+   changes merged since the last release. (If a change was not made through a
+   pull request, you can safely skip it.)
+2. For each merged pull request, retrieve the PR title and description from
+   GitHub for additional context using `gh pr view`.
+3. Ignore changes which are chores, docs only, CI changes, tests only,
+   style/formatting changes, build pipeline changes, and routine dependency
+   bumps that don't change the CLI's behavior. The CHANGELOG.md only contains
+   changes which are externally observable new features, enhancements, and
+   fixes. (A dependency update that fixes a security vulnerability in the
+   published CLI counts as a fix.)
+4. Add exactly one new section to the top of CHANGELOG.md, directly below the
+   `# Changelog` heading: `## v${VERSION} (${DATE})`. Follow the existing
+   format of the file — group changes under `### New`, `### Improved`, and
+   `### Fixed` subheadings when there is more than one kind of change, and
+   reference PR numbers like `(#2762)`.
+5. If there are no externally observable changes, still add the section with a
+   single brief bullet summarizing the most significant internal change.
+6. If a PR author is not a member of the team, include a shout out thanking
+   them. (Team members are @noahd1, @lsegal, @brynary, @marschattha,
+   @davehenton, @laura-mlg. They don't need shout outs.)
+
+Rules:
+
+- Only edit CHANGELOG.md, and only add the single new section. Do not reword
+  or reorganize existing entries.
+- Do not commit, push, or open pull requests; the workflow handles that.

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -52,14 +52,71 @@ jobs:
             "${RELEASE_VERSION}"
 
           echo "version=$(cargo metadata --format-version 1 | jq -r ".workspace_members[0]" | cut -d# -f2)" >> "$GITHUB_OUTPUT"
+
+          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
+          echo "last_tag=$LAST_TAG" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
         env:
           RELEASE_VERSION: ${{ inputs.increment == 'version' && inputs.version || inputs.increment || 'minor' }}
+      - name: Draft changelog entry
+        uses: anthropics/claude-code-action@493279a9d94b7cc5d07a98e5e66cb03313805350 # version 1.0.166
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            Follow the instructions in .github/prompts/changelog.md with these values:
+
+            VERSION: ${{ steps.version.outputs.version }}
+            LAST_TAG: ${{ steps.version.outputs.last_tag }}
+            DATE: ${{ steps.version.outputs.date }}
+          claude_args: >-
+            --allowedTools "Read,Grep,Glob,Edit(CHANGELOG.md),Write(CHANGELOG.md),Bash(git log:*),Bash(git show:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh release list:*)"
+      - name: Validate drafted changes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          if ! grep -q "^## v${VERSION} " CHANGELOG.md; then
+            echo "Error: No '## v${VERSION}' entry was added to CHANGELOG.md"
+            exit 1
+          fi
+
+          # Only the changelog and cargo version bumps may change
+          git status --porcelain | while read -r _status file; do
+            case "$file" in
+              CHANGELOG.md|Cargo.lock|Cargo.toml|*/Cargo.toml) ;;
+              *)
+                echo "Error: Unexpected change to $file"
+                exit 1
+                ;;
+            esac
+          done
+
+          # Extract the new entry for the PR body
+          awk "/^## v${VERSION} /{flag=1; next} /^## v[0-9]/{flag=0} flag" \
+            CHANGELOG.md > "$RUNNER_TEMP/changelog_entry.txt"
+
+          echo "Drafted changelog entry:"
+          cat "$RUNNER_TEMP/changelog_entry.txt"
+
+          {
+            echo "Automated PR for release ${VERSION}."
+            echo
+            echo "Review (and edit, if needed) the changelog entry below, then"
+            echo "merge this pull request to publish the release."
+            echo
+            echo "## Draft release notes"
+            echo
+            cat "$RUNNER_TEMP/changelog_entry.txt"
+          } > "$RUNNER_TEMP/pr_body.md"
       - name: Commit changes
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
           token: ${{ steps.app-token.outputs.token }}
           title: Release ${{ steps.version.outputs.version }}
-          body: Automated PR for release ${{ steps.version.outputs.version }}
+          body-path: ${{ runner.temp }}/pr_body.md
           branch: release-${{ steps.version.outputs.version }}
           sign-commits: true
           commit-message: Release ${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,14 @@ jobs:
           STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          awk "/^## v${STEPS_VERSION_OUTPUTS_VERSION} /{flag=1; next} /^## v[0-9]/{flag=0} flag" \
+            CHANGELOG.md > "$RUNNER_TEMP/notes.txt"
+
+          if ! grep -q '[^[:space:]]' "$RUNNER_TEMP/notes.txt"; then
+            echo "No CHANGELOG.md entry found for v${STEPS_VERSION_OUTPUTS_VERSION}; using default notes"
+            echo "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.txt"
+          fi
+
           gh release create "v${STEPS_VERSION_OUTPUTS_VERSION}" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" target/distrib/*
   s3-upload:
     needs: release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,74 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Recreate dangling `.qlty` symlinks after the cache directory is deleted (#2805)
+
+## v0.632.0 (2026-07-01)
+
+### New
+
+- Add native CI detection for Harness CI to coverage uploads (#2799)
+
+## v0.631.0 (2026-06-23)
+
+### Fixed
+
+- Scrub environment variable values from serialized invocation records (#2797)
+
+## v0.630.0 (2026-05-08)
+
+### Fixed
+
+- Revert the Biome `--config-path` change from v0.629.0 (#2791)
+
+## v0.629.0 (2026-05-07)
+
+### Fixed
+
+- Pass `--config-path` to Biome so configs in `.qlty/configs/` are honored (#2788)
+- Pass `--config` to Knip so configs in `.qlty/configs/` are honored in nested-package layouts (#2789)
+
+## v0.628.0 (2026-05-06)
+
+### New
+
+- Add VB.NET maintainability support (#2759)
+
+### Fixed
+
+- Pass `--force-exclusion` to RuboCop so `AllCops: Exclude` is respected (#2786)
+
+## v0.627.0 (2026-05-05)
+
+### New
+
+- Add Scala maintainability support (#2778)
+
+### Fixed
+
+- Clamp line counters to file bounds to prevent overflow crashes during metrics analysis (#2777)
+
+## v0.626.0 (2026-05-01)
+
+### Fixed
+
+- Handle `-1` line numbers in editorconfig-checker output so its issues are reported (#2773)
+
+## v0.625.0 (2026-04-24)
+
+### New
+
+- Centralize config loading with `--skip-source-fetch` support, with graceful fallback in `qlty coverage publish` (#2766)
+
+## v0.624.0 (2026-04-22)
+
+### Fixed
+
+- Revert the config loading centralization from v0.623.0 due to a `qlty coverage publish` regression (#2764)
+
 ## v0.623.0 (2026-04-20)
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Fixed
-
-- Recreate dangling `.qlty` symlinks after the cache directory is deleted (#2805)
-
 ## v0.632.0 (2026-07-01)
 
 ### New


### PR DESCRIPTION
## Summary

Ports the changelog automation from [qlty-action's prepare-release workflow](https://github.com/qltysh/qlty-action/blob/main/.github/workflows/prepare-release.yml) into this repo's Prepare Release workflow, and backfills the changelog entries that were missing since v0.623.0.

## Changes

### `feat`: Automate changelog drafting in Prepare Release

- **`.github/prompts/changelog.md`** (new): instructions for drafting a single release entry from the PRs merged since the last tag — same rules as qlty-action's prompt, adapted for the CLI and this repo's team list.
- **`.github/workflows/prepare_release.yml`**:
  - The `Bump version` step now also outputs `last_tag` and `date`.
  - A new `Draft changelog entry` step runs `anthropics/claude-code-action` (same pinned SHA as qlty-action) with a restricted `--allowedTools` list: it can only edit `CHANGELOG.md` and run read-only `git`/`gh` commands.
  - A new `Validate drafted changes` step fails if no `## v${VERSION}` heading was added or if anything other than `CHANGELOG.md` and the cargo version bumps (`Cargo.toml`, `*/Cargo.toml`, `Cargo.lock`) changed. It writes the extracted entry and PR body to `$RUNNER_TEMP` so `create-pull-request` doesn't commit them.
  - The release PR body now includes the draft release notes via `body-path` (supported by the pinned `create-pull-request` v7.0.8) so they can be reviewed and edited before merge.

### `feat`: Use the changelog entry as GitHub Release notes

- **`.github/workflows/release.yml`**: the `Create GitHub Release` step now extracts the released version's section from `CHANGELOG.md` for the release notes, falling back to the previous boilerplate text if no entry is found.

### `docs`: Backfill CHANGELOG.md

The newest entry was v0.623.0 while the latest release is v0.632.0. Adds entries for v0.624.0 through v0.632.0, drawn from the merged PRs in each release range.

## Notes

- The `ANTHROPIC_API_KEY` secret already exists in this repo.
- No Rust code is touched, so the test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


