### PR TITLE
fix(knip): pin typescript to 6.0.3 via extra_packages

### DIFF
--- a/qlty-plugins/plugins/linters/knip/plugin.toml
+++ b/qlty-plugins/plugins/linters/knip/plugin.toml
@@ -17,6 +17,9 @@ config_files = [
 affects_cache = ["package.json"]
 latest_version = "5.70.2"
 known_good_version = "5.21.2"
+# knip peers on typescript (>=5.0.4, unbounded before knip 5.62); an unpinned
+# install now resolves typescript 7.x, which removed APIs knip relies on
+extra_packages = ["typescript@6.0.3"]
 version_command = "knip --version"
 description = "Find unused files, dependencies, and exports in JavaScript and TypeScript projects"
 


### PR DESCRIPTION
## Problem

The Plugin Tests scheduled run on main has been failing on all three OSes since 2026-07-10 (last green 2026-07-08) — the `knip` fixtures at version 5.21.2 (`basic`, `basic_nested`) fail during tool setup:

```
TypeError: ts.getDefaultLibFilePath is not a function
    at .../knip/dist/typescript/createHosts.js:7:37
```

knip is installed into its tool sandbox via `npm install --force knip@5.21.2` with no lockfile. knip 5.21.2 declares an **unbounded** typescript peer dependency (`>=5.0.4`), and TypeScript 7.0 (the Go-based rewrite) was published to npm in that window — npm now resolves `typescript@7.0.2`, which no longer exports `ts.getDefaultLibFilePath`, so even `knip --version` crashes. knip 5.70.2 is unaffected because its peer range is `>=5.0.4 <7`.

## Fix

Pin a compatible TypeScript alongside knip using the existing `extra_packages` mechanism:

```toml
extra_packages = ["typescript@6.0.3"]
```

- 6.0.3 is the latest pre-7 release and satisfies the peer ranges of both tested knip versions (5.21.2 and 5.70.2).
- Bumping `known_good_version` instead was ruled out — it was deliberately reverted to 5.21.2 in 03c5d08c to keep default users on the legacy script path.
- `extra_packages` versions are folded into the tool cache hash, so existing cached installs are not reused.

## Testing

- Reproduced locally: `npm install --force knip@5.21.2` resolves typescript 7.0.2 and `knip --version` crashes; with typescript 6.0.3 installed alongside, it works.
- `cd plugins && npx jest linters/knip` against a freshly built binary: 3/3 pass (5.21.2 `basic`, 5.21.2 `basic_nested`, 5.70.2 `basic_with_config`).
- `cargo test`, `qlty fmt`, `qlty check --level=low --fix` all clean.

This PR touches `qlty-plugins/**`, so the Plugin Tests workflow runs on it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Interaction with user config

The pin is only a default for the bare `npm install knip@<version>` path; both user-level escape hatches override it cleanly:

- **User `extra_packages` in qlty.toml** are appended after the definition's (`planner/config.rs`) and installed in order (`tool.rs`), so a user pinning their own `typescript@X` wins (last install replaces `node_modules/typescript`). The `package_file`/`extra_packages` mutual-exclusion validation runs on the user's `EnabledPlugin` only, so it is unaffected by this definition-level pin.
- **User `package_file`** takes full precedence: `Tool::install` skips `extra_packages` entirely when `package_file` is set (covered by `node_package_install_package_file_overrides_extra_packages`), so typescript resolution follows the project's package.json, same as before this change.
