### PR TITLE
feat(check): classify npm install auth failures and link to build secrets docs

### DIFF
--- a/qlty-check/src/executor.rs
+++ b/qlty-check/src/executor.rs
@@ -1,4 +1,5 @@
 mod driver;
+mod install_error;
 mod invocation_result;
 mod invocation_script;
 pub mod staging_area;
@@ -8,7 +9,6 @@ use crate::llm::Fixer;
 use crate::planner::check_filters::CheckFilters;
 use crate::planner::config_files::config_globset;
 use crate::planner::source_extractor::SourceExtractor;
-use crate::tool::command_error::ToolCommandError;
 use crate::Tool;
 use crate::{
     cache::IssueCache,
@@ -16,10 +16,10 @@ use crate::{
     ui::{Progress, ProgressBar},
 };
 use crate::{cache::IssuesCacheHit, planner::Plan, results::FormattedFile, Results};
-use anyhow::{bail, Context, Error, Result};
-use chrono::Utc;
+use anyhow::{bail, Context, Result};
 pub use driver::Driver;
 use ignore::{DirEntry, WalkBuilder, WalkState};
+use install_error::install_error_message;
 pub use invocation_result::{InvocationResult, InvocationStatus};
 pub use invocation_script::{compute_invocation_script, plan_target_list};
 use itertools::Itertools;
@@ -763,34 +763,6 @@ fn run_invocation(
     Ok(result)
 }
 
-fn install_error_message(name: &str, error: &Error) -> Message {
-    Message {
-        timestamp: Some(Utc::now().into()),
-        module: "qlty_check::executor".to_string(),
-        ty: "executor.install.error".to_string(),
-        level: MessageLevel::Error.into(),
-        message: format!("Error installing tool {name}"),
-        details: install_error_details(error),
-        ..Default::default()
-    }
-}
-
-fn install_error_details(error: &Error) -> String {
-    let command_error = error
-        .chain()
-        .find_map(|cause| cause.downcast_ref::<ToolCommandError>());
-
-    if let Some(command_error) = command_error {
-        let output_tail = command_error.output_tail();
-
-        if !output_tail.is_empty() {
-            return format!("{error}\n\n{output_tail}");
-        }
-    }
-
-    error.to_string()
-}
-
 fn walk_collect_entries_parallel(builder: &WalkBuilder) -> Vec<DirEntry> {
     let dents = Arc::new(Mutex::new(vec![]));
 
@@ -807,57 +779,4 @@ fn walk_collect_entries_parallel(builder: &WalkBuilder) -> Vec<DirEntry> {
 
     let dents = dents.lock().unwrap();
     dents.to_vec()
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use anyhow::anyhow;
-
-    fn command_error() -> ToolCommandError {
-        ToolCommandError {
-            command: vec!["npm".to_string(), "install".to_string()],
-            exit_code: 1,
-            stdout: String::new(),
-            stderr: "npm error code E404\nnpm error 404 Not Found".to_string(),
-        }
-    }
-
-    #[test]
-    fn install_error_details_appends_command_output() {
-        let error = Error::from(command_error()).context("Error installing eslint@9.7.0.");
-
-        let details = install_error_details(&error);
-
-        assert_eq!(
-            details,
-            "Error installing eslint@9.7.0.\n\nnpm error code E404\nnpm error 404 Not Found"
-        );
-    }
-
-    #[test]
-    fn install_error_details_with_empty_command_output() {
-        let mut error = command_error();
-        error.stderr = String::new();
-
-        assert_eq!(
-            install_error_details(&Error::from(error)),
-            r#"Command ["npm", "install"] exited with code 1"#
-        );
-    }
-
-    #[test]
-    fn install_error_details_without_command_error() {
-        assert_eq!(install_error_details(&anyhow!("boom")), "boom");
-    }
-
-    #[test]
-    fn install_error_message_fields() {
-        let message = install_error_message("eslint", &anyhow!("boom"));
-
-        assert_eq!(message.ty, "executor.install.error");
-        assert_eq!(message.level, MessageLevel::Error as i32);
-        assert_eq!(message.message, "Error installing tool eslint");
-        assert_eq!(message.details, "boom");
-    }
 }

--- a/qlty-check/src/executor/install_error.rs
+++ b/qlty-check/src/executor/install_error.rs
@@ -1,0 +1,150 @@
+use crate::tool::command_error::ToolCommandError;
+use anyhow::Error;
+use chrono::Utc;
+use qlty_types::analysis::v1::{Message, MessageLevel};
+
+pub fn install_error_message(name: &str, error: &Error) -> Message {
+    let command_error = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<ToolCommandError>());
+
+    let mut message = format!("Error installing tool {name}");
+    let details = install_error_details(error, command_error);
+    let mut ty = "executor.install.error";
+
+    if let Some(failure) = command_error.and_then(|command_error| command_error.failure.as_ref()) {
+        message = format!("{message}: {}", failure.summary);
+        ty = failure.kind.message_ty();
+    }
+
+    Message {
+        timestamp: Some(Utc::now().into()),
+        module: "qlty_check::executor".to_string(),
+        ty: ty.to_string(),
+        level: MessageLevel::Error.into(),
+        message,
+        details,
+        ..Default::default()
+    }
+}
+
+fn install_error_details(error: &Error, command_error: Option<&ToolCommandError>) -> String {
+    if let Some(command_error) = command_error {
+        let output_tail = command_error.output_tail();
+
+        if !output_tail.is_empty() {
+            return format!("{error}\n\n{output_tail}");
+        }
+    }
+
+    error.to_string()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::tool::install_failure::{InstallFailure, InstallFailureKind, BUILD_SECRETS_URL};
+    use anyhow::anyhow;
+
+    const AUTH_FAILED_STDERR: &str = "npm ERR! code E401\nnpm ERR! 401 Unauthorized - GET https://npm.pkg.github.com/@marschattha%2feslint-config-qlty-demo - authentication token not provided";
+
+    fn command_error(stderr: &str, failure: Option<InstallFailure>) -> ToolCommandError {
+        ToolCommandError {
+            command: vec!["npm".to_string(), "install".to_string()],
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: stderr.to_string(),
+            failure,
+        }
+    }
+
+    fn wrapped(stderr: &str, failure: Option<InstallFailure>) -> Error {
+        Error::from(command_error(stderr, failure)).context("Error installing eslint@9.7.0.")
+    }
+
+    #[test]
+    fn auth_failure_upgrades_message_and_ty() {
+        let failure = InstallFailure {
+            kind: InstallFailureKind::AuthenticationFailed,
+            summary: format!("npm registry authentication failed (see {BUILD_SECRETS_URL})"),
+        };
+
+        let message = install_error_message("eslint", &wrapped(AUTH_FAILED_STDERR, Some(failure)));
+
+        assert_eq!(
+            message.message,
+            format!(
+                "Error installing tool eslint: npm registry authentication failed (see {BUILD_SECRETS_URL})"
+            )
+        );
+        assert_eq!(message.ty, "executor.install.auth_error");
+        assert!(message
+            .details
+            .contains("authentication token not provided"));
+    }
+
+    #[test]
+    fn maybe_private_failure_gets_not_found_ty() {
+        let failure = InstallFailure {
+            kind: InstallFailureKind::PackageMaybePrivate,
+            summary: "npm package not found (it may be private)".to_string(),
+        };
+
+        let message =
+            install_error_message("eslint", &wrapped("npm error code E404", Some(failure)));
+
+        assert_eq!(
+            message.message,
+            "Error installing tool eslint: npm package not found (it may be private)"
+        );
+        assert_eq!(message.ty, "executor.install.package_not_found");
+    }
+
+    #[test]
+    fn unclassified_failure_stays_generic() {
+        let message = install_error_message("clippy", &wrapped("error: linking failed", None));
+
+        assert_eq!(message.message, "Error installing tool clippy");
+        assert_eq!(message.ty, "executor.install.error");
+    }
+
+    #[test]
+    fn classified_ty_values_match_the_cli_filter_prefix() {
+        for kind in [
+            InstallFailureKind::AuthenticationFailed,
+            InstallFailureKind::AccessDenied,
+            InstallFailureKind::PackageMaybePrivate,
+        ] {
+            assert!(kind.message_ty().starts_with("executor.install."));
+        }
+    }
+
+    #[test]
+    fn details_append_command_output() {
+        let message = install_error_message("eslint", &wrapped(AUTH_FAILED_STDERR, None));
+
+        assert!(message
+            .details
+            .starts_with("Error installing eslint@9.7.0.\n\nnpm ERR! code E401"));
+    }
+
+    #[test]
+    fn details_without_command_output() {
+        let message = install_error_message("eslint", &Error::from(command_error("", None)));
+
+        assert_eq!(
+            message.details,
+            r#"Command ["npm", "install"] exited with code 1"#
+        );
+    }
+
+    #[test]
+    fn message_fields_without_command_error() {
+        let message = install_error_message("eslint", &anyhow!("boom"));
+
+        assert_eq!(message.ty, "executor.install.error");
+        assert_eq!(message.level, MessageLevel::Error as i32);
+        assert_eq!(message.message, "Error installing tool eslint");
+        assert_eq!(message.details, "boom");
+    }
+}

--- a/qlty-check/src/tool.rs
+++ b/qlty-check/src/tool.rs
@@ -3,6 +3,7 @@ pub mod command_error;
 mod download;
 mod github;
 pub mod go;
+pub mod install_failure;
 mod installations;
 pub mod java;
 pub mod node;
@@ -25,6 +26,7 @@ use command_error::ToolCommandError;
 use console::style;
 use duct::Expression;
 use fslock::LockFile;
+use install_failure::InstallFailure;
 use installations::initialize_installation;
 use installations::write_to_file;
 use qlty_analysis::join_path_string;
@@ -267,7 +269,6 @@ pub trait Tool: Debug + Sync + Send {
                     let log_path = self.install_log_path();
                     if Path::new(&log_path).exists() {
                         const BUILD_LOG_LINES_LIMIT: usize = 50;
-                        const STDERR_LOG_LINES_LIMIT: usize = 20;
 
                         fn extract_last_lines(lines: &[&str], limit: usize) -> String {
                             lines[lines.len().saturating_sub(limit)..].join("\n")
@@ -280,7 +281,7 @@ pub trait Tool: Debug + Sync + Send {
                                     let build_log =
                                         extract_last_lines(&lines, BUILD_LOG_LINES_LIMIT);
                                     let stderr_log =
-                                        extract_last_lines(&lines, STDERR_LOG_LINES_LIMIT);
+                                        extract_last_lines(&lines, self.install_log_tail_lines());
                                     (build_log, stderr_log)
                                 }
                                 Err(err) => {
@@ -420,6 +421,10 @@ pub trait Tool: Debug + Sync + Send {
         );
     }
 
+    fn classify_install_failure(&self, _error: &ToolCommandError) -> Option<InstallFailure> {
+        None
+    }
+
     fn post_install(&self, _task: &ProgressTask) -> Result<()> {
         Ok(())
     }
@@ -455,13 +460,16 @@ pub trait Tool: Debug + Sync + Send {
 
         let output = result?;
         if !output.status.success() {
-            return Err(ToolCommandError {
+            let mut command_error = ToolCommandError {
                 command: command.lock().map_err(|_| lock_error())?.clone(),
                 exit_code: exit_status_code(&output.status),
                 stdout: String::from_utf8_lossy(&output.stdout).to_string(),
                 stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-            }
-            .into());
+                failure: None,
+            };
+            command_error.failure = self.classify_install_failure(&command_error);
+
+            return Err(command_error.into());
         }
 
         Ok(())
@@ -669,6 +677,10 @@ pub trait Tool: Debug + Sync + Send {
             self.parent_directory(),
             format!("{}-install.log", self.directory_name())
         )
+    }
+
+    fn install_log_tail_lines(&self) -> usize {
+        20
     }
 
     fn clone_box(&self) -> Box<dyn Tool>;

--- a/qlty-check/src/tool/command_error.rs
+++ b/qlty-check/src/tool/command_error.rs
@@ -1,3 +1,4 @@
+use super::install_failure::InstallFailure;
 use thiserror::Error;
 
 const OUTPUT_TAIL_LINES: usize = 10;
@@ -9,6 +10,7 @@ pub struct ToolCommandError {
     pub exit_code: i32,
     pub stdout: String,
     pub stderr: String,
+    pub failure: Option<InstallFailure>,
 }
 
 impl ToolCommandError {
@@ -39,6 +41,7 @@ mod test {
             exit_code: 1,
             stdout: stdout.to_string(),
             stderr: stderr.to_string(),
+            failure: None,
         }
     }
 

--- a/qlty-check/src/tool/install_failure.rs
+++ b/qlty-check/src/tool/install_failure.rs
@@ -1,0 +1,25 @@
+pub const BUILD_SECRETS_URL: &str = "https://docs.qlty.sh/cloud/build-secrets";
+
+#[derive(Debug)]
+pub struct InstallFailure {
+    pub kind: InstallFailureKind,
+    pub summary: String,
+}
+
+#[derive(Debug)]
+pub enum InstallFailureKind {
+    AuthenticationFailed,
+    AccessDenied,
+    PackageMaybePrivate,
+}
+
+impl InstallFailureKind {
+    pub fn message_ty(&self) -> &'static str {
+        match self {
+            InstallFailureKind::AuthenticationFailed | InstallFailureKind::AccessDenied => {
+                "executor.install.auth_error"
+            }
+            InstallFailureKind::PackageMaybePrivate => "executor.install.package_not_found",
+        }
+    }
+}

--- a/qlty-check/src/tool/node.rs
+++ b/qlty-check/src/tool/node.rs
@@ -3,7 +3,9 @@ use super::command_builder::default_command_builder;
 use super::command_builder::CommandBuilder;
 use super::Tool;
 use super::ToolType;
+use crate::tool::command_error::ToolCommandError;
 use crate::tool::download::Download;
+use crate::tool::install_failure::{InstallFailure, InstallFailureKind, BUILD_SECRETS_URL};
 use crate::tool::RuntimeTool;
 use crate::ui::ProgressBar;
 use crate::ui::ProgressTask;
@@ -12,6 +14,7 @@ use qlty_analysis::join_path_string;
 use qlty_config::config::OperatingSystem;
 use qlty_config::config::PluginDef;
 use qlty_config::config::{Cpu, DownloadDef, System};
+use regex::Regex;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::path::Path;
@@ -224,14 +227,63 @@ impl Tool for NodePackage {
     fn plugin(&self) -> Option<PluginDef> {
         Some(self.plugin.clone())
     }
+
+    fn classify_install_failure(&self, error: &ToolCommandError) -> Option<InstallFailure> {
+        detect_npm_failure(error)
+    }
+
+    fn install_log_tail_lines(&self) -> usize {
+        10
+    }
+}
+
+fn detect_npm_failure(error: &ToolCommandError) -> Option<InstallFailure> {
+    let output = format!("{}\n{}", error.stdout, error.stderr);
+
+    let code_regex = Regex::new(r"npm (?:ERR!|error) code (E401|E403|E404)").unwrap();
+    let code = code_regex.captures(&output)?.get(1)?.as_str();
+
+    let failure = match code {
+        "E401" => InstallFailure {
+            kind: InstallFailureKind::AuthenticationFailed,
+            summary: format!("npm registry authentication failed (see {BUILD_SECRETS_URL})"),
+        },
+        "E403" if mentions_scoped_package(&output, "403") => InstallFailure {
+            kind: InstallFailureKind::AccessDenied,
+            summary: format!("npm registry access was denied (see {BUILD_SECRETS_URL})"),
+        },
+        "E404" if mentions_scoped_package(&output, "404") => InstallFailure {
+            kind: InstallFailureKind::PackageMaybePrivate,
+            summary: format!("npm package not found (it may be private; see {BUILD_SECRETS_URL})"),
+        },
+        _ => return None,
+    };
+
+    Some(failure)
+}
+
+// Unscoped failures are usually typos, yanked versions, or public-registry
+// blocks; only scoped packages (@owner/name) plausibly live on an
+// authenticated private registry. Checked only on the failing status lines so
+// that incidental scoped mentions elsewhere in the output (e.g. deprecation
+// warnings) don't match.
+fn mentions_scoped_package(output: &str, status: &str) -> bool {
+    let scoped_regex = Regex::new(r"@[\w.-]+(/|%2[fF])[\w.-]+").unwrap();
+
+    output
+        .lines()
+        .filter(|line| line.contains(status))
+        .any(|line| scoped_regex.is_match(line))
 }
 
 #[cfg(test)]
 pub mod test {
-    use super::NodePackage;
+    use super::{detect_npm_failure, NodePackage};
     use crate::{
         tool::{
             command_builder::test::{reroute_tools_root, stub_cmd, ENV_LOCK},
+            command_error::ToolCommandError,
+            install_failure::{InstallFailureKind, BUILD_SECRETS_URL},
             node::NPM_COMMAND,
         },
         ui::ProgressTask,
@@ -421,5 +473,100 @@ pub mod test {
             );
             Ok(())
         });
+    }
+
+    fn npm_command_error(stderr: &str) -> ToolCommandError {
+        ToolCommandError {
+            command: vec!["npm".to_string(), "install".to_string()],
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: stderr.to_string(),
+            failure: None,
+        }
+    }
+
+    const MISSING_TOKEN_STDERR: &str = "npm ERR! code E401\nnpm ERR! 401 Unauthorized - GET https://npm.pkg.github.com/@marschattha%2feslint-config-qlty-demo - authentication token not provided";
+    const BAD_TOKEN_STDERR: &str = "npm ERR! code E401\nnpm ERR! 401 Unauthorized - GET https://npm.pkg.github.com/@marschattha%2feslint-config-qlty-demo - unauthenticated: User cannot be authenticated with the token provided.";
+    const FORBIDDEN_STDERR: &str = "npm ERR! code E403\nnpm ERR! 403 403 Forbidden - GET https://npm.pkg.github.com/@marschattha%2feslint-config-qlty-demo";
+    const SCOPED_NOT_FOUND_STDERR: &str = "npm error code E404\nnpm error 404 Not Found - GET https://npm.pkg.github.com/@qltyverifydemo%2fdoes-not-exist\nnpm error 404  '@qltyverifydemo/does-not-exist@1.0.0' is not in this registry.";
+    const UNSCOPED_NOT_FOUND_STDERR: &str =
+        "npm ERR! code E404\nnpm ERR! 404  'left-padd@1.0.0' is not in this registry.";
+
+    #[test]
+    fn test_classify_install_failure_missing_token() {
+        with_node_package(|pkg, _, _| {
+            let failure = pkg
+                .classify_install_failure(&npm_command_error(MISSING_TOKEN_STDERR))
+                .unwrap();
+
+            assert_eq!(
+                failure.summary,
+                format!("npm registry authentication failed (see {BUILD_SECRETS_URL})")
+            );
+            assert!(matches!(
+                failure.kind,
+                InstallFailureKind::AuthenticationFailed
+            ));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_detect_npm_failure_bad_token() {
+        let failure = detect_npm_failure(&npm_command_error(BAD_TOKEN_STDERR)).unwrap();
+
+        assert!(matches!(
+            failure.kind,
+            InstallFailureKind::AuthenticationFailed
+        ));
+    }
+
+    #[test]
+    fn test_detect_npm_failure_forbidden_scoped() {
+        let failure = detect_npm_failure(&npm_command_error(FORBIDDEN_STDERR)).unwrap();
+
+        assert_eq!(
+            failure.summary,
+            format!("npm registry access was denied (see {BUILD_SECRETS_URL})")
+        );
+        assert!(matches!(failure.kind, InstallFailureKind::AccessDenied));
+    }
+
+    #[test]
+    fn test_detect_npm_failure_ignores_forbidden_unscoped() {
+        let stderr = "npm ERR! code E403\nnpm ERR! 403 403 Forbidden - GET https://registry.npmjs.org/left-pad - Package was removed for security reasons";
+
+        assert!(detect_npm_failure(&npm_command_error(stderr)).is_none());
+    }
+
+    #[test]
+    fn test_detect_npm_failure_scoped_not_found() {
+        let failure = detect_npm_failure(&npm_command_error(SCOPED_NOT_FOUND_STDERR)).unwrap();
+
+        assert_eq!(
+            failure.summary,
+            format!("npm package not found (it may be private; see {BUILD_SECRETS_URL})")
+        );
+        assert!(matches!(
+            failure.kind,
+            InstallFailureKind::PackageMaybePrivate
+        ));
+    }
+
+    #[test]
+    fn test_detect_npm_failure_ignores_unscoped_not_found() {
+        assert!(detect_npm_failure(&npm_command_error(UNSCOPED_NOT_FOUND_STDERR)).is_none());
+    }
+
+    #[test]
+    fn test_detect_npm_failure_ignores_unscoped_not_found_with_scoped_warning() {
+        let stderr = "npm warn deprecated @babel/polyfill@7.12.1: This package has been deprecated\nnpm ERR! code E404\nnpm ERR! 404  'left-padd@1.0.0' is not in this registry.";
+
+        assert!(detect_npm_failure(&npm_command_error(stderr)).is_none());
+    }
+
+    #[test]
+    fn test_detect_npm_failure_ignores_other_output() {
+        assert!(detect_npm_failure(&npm_command_error("error: linking failed")).is_none());
     }
 }

--- a/qlty-cli/src/ui/messages.rs
+++ b/qlty-cli/src/ui/messages.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use console::style;
 use qlty_check::Report;
 use qlty_types::analysis::v1::Message;
 
@@ -13,9 +14,14 @@ pub fn print_installation_error_messages(
         .collect();
 
     if !installation_error_messages.is_empty() {
-        writeln!(writer, "Installation errors found:")?;
+        writeln!(writer)?;
+        writeln!(
+            writer,
+            "{}",
+            style("Installation errors found:").red().bold()
+        )?;
         for message in &installation_error_messages {
-            writeln!(writer, "{}", message.message)?;
+            writeln!(writer, "  - {}", message.message)?;
         }
         writeln!(writer)?;
     }

--- a/qlty-cli/src/ui/messages.rs
+++ b/qlty-cli/src/ui/messages.rs
@@ -9,7 +9,7 @@ pub fn print_installation_error_messages(
     let installation_error_messages: Vec<&Message> = report
         .messages
         .iter()
-        .filter(|m| m.ty == "executor.install.error")
+        .filter(|m| m.ty.starts_with("executor.install."))
         .collect();
 
     if !installation_error_messages.is_empty() {

--- a/qlty-cli/tests/cmd/check/skip_errored_plugins_installation.stdout
+++ b/qlty-cli/tests/cmd/check/skip_errored_plugins_installation.stdout
@@ -3,6 +3,7 @@
 Plugin        Result  Message                      Debug File
 always_error  Error   Exited with code 1 in [..]s  .qlty/out/invoke-[..].yaml
 
+
 Installation errors found:
-Error installing tool gitleaks@8.24.2
+  - Error installing tool gitleaks@8.24.2
 


### PR DESCRIPTION
## What

Builds on #2803. When a plugin's npm install fails against a private registry, the build message (and `qlty check`'s terminal summary) now says *why* and links to the fix, instead of only echoing the npm output tail.

**Classification is a per-tool concern**: `Tool::classify_install_failure(&ToolCommandError) -> Option<InstallFailure>` is a default-`None` trait method, invoked by `run_command` at error-construction time and carried on `ToolCommandError.failure`. All npm knowledge lives in `tool/node.rs` next to the code that constructs the npm commands. Adding bundler/composer later = override the hook in their tool module.

**npm detection** (fixtures are verbatim captures from live failures against GitHub Packages):
- `E401` → "npm registry authentication failed (see docs link)" → `ty: executor.install.auth_error`
- `E403` → "npm registry access was denied (see docs link)" → `ty: executor.install.auth_error`
- `E404` → "npm package not found (it may be private; see docs link)" → `ty: executor.install.package_not_found`
- `E403`/`E404` only classify when a scoped `@owner/name` package is mentioned **on the failing status lines** — typo'd unscoped packages, public-registry security blocks, and incidental scoped mentions (e.g. `npm warn deprecated @babel/...`) stay generic (`executor.install.error`).

The distinct `ty` values make affected builds queryable in ClickHouse:
```sql
SELECT DISTINCT workspaceId, projectId, buildId FROM messages
WHERE ty IN ('executor.install.auth_error', 'executor.install.package_not_found')
```

**Terminal output** (second commit): install errors are matched by `executor.install.` ty prefix (the exact match would have hidden classified failures), and the section gets a blank line above, a red bold heading, and bulleted errors. `install_log_tail_lines()` is a per-tool knob for the INSTALL LOG banner (default 20 lines; npm's dense output lowers it to 10 so a retried install doesn't repeat the same error block).

## Example (live run, no token)

Build page message:
```
Error installing tool eslint@9.7.0: npm package not found (it may be private; see https://docs.qlty.sh/cloud/build-secrets)

Error installing eslint@9.7.0.
…
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/@marschattha%2feslint-config-qlty-demo - Not found
npm ERR! 404  '@marschattha/eslint-config-qlty-demo@1.0.0' is not in this registry.
…
```

`qlty check --skip-errored-plugins`:
```
Installation errors found:
  - Error installing tool eslint@9.7.0: npm package not found (it may be private; see https://docs.qlty.sh/cloud/build-secrets)
```

## Verification

- 231 qlty-check unit tests + trycmd CLI integration tests green; zero compiler warnings.
- Live end-to-end against a real private GitHub Packages dependency (qlty-build-secrets-demo): no token → classified message with docs link in both the exported jsonl and the terminal section; wrong token → auth classification; valid token via `${env.NPM_TOKEN}` → clean install, no message.
- Multi-agent code review ran over this diff; all confirmed findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)