### PR TITLE
feat(check): classify bundler and gem install failures

### DIFF
--- a/qlty-check/src/tool/ruby.rs
+++ b/qlty-check/src/tool/ruby.rs
@@ -4,7 +4,9 @@ mod sys;
 use super::command_builder::{default_command_builder, CommandBuilder};
 use super::ruby_source::RubySource;
 use super::{Tool, ToolType};
+use crate::tool::command_error::ToolCommandError;
 use crate::tool::download::Download;
+use crate::tool::install_failure::{InstallFailure, InstallFailureKind, BUILD_SECRETS_URL};
 use crate::tool::RuntimeTool;
 use crate::ui::{ProgressBar, ProgressTask};
 use anyhow::{Context, Result};
@@ -13,6 +15,7 @@ use qlty_analysis::join_path_string;
 use qlty_analysis::utils::fs::{path_to_native_string, path_to_string};
 use qlty_config::config::{Cpu, DownloadDef, System};
 use qlty_config::config::{OperatingSystem, PluginDef};
+use regex::Regex;
 use sha2::Digest;
 use std::collections::HashMap;
 use std::env::join_paths;
@@ -414,6 +417,38 @@ impl Tool for RubygemsPackage {
     fn plugin(&self) -> Option<PluginDef> {
         Some(self.plugin.clone())
     }
+
+    fn classify_install_failure(&self, error: &ToolCommandError) -> Option<InstallFailure> {
+        detect_rubygems_failure(error, self.package_file_declares_custom_source())
+    }
+}
+
+fn detect_rubygems_failure(
+    error: &ToolCommandError,
+    custom_gem_source: bool,
+) -> Option<InstallFailure> {
+    let output = format!("{}\n{}", error.stdout, error.stderr);
+
+    let auth_regex = Regex::new(
+        r"Authentication is required for|Bad username or password for|bad response Unauthorized 401|bad response Forbidden 403",
+    )
+    .unwrap();
+    if auth_regex.is_match(&output) {
+        return Some(InstallFailure {
+            kind: InstallFailureKind::AuthenticationFailed,
+            summary: format!("gem source authentication failed (see {BUILD_SECRETS_URL})"),
+        });
+    }
+
+    let not_found_regex = Regex::new(r"Could not find (a valid )?gem '").unwrap();
+    if custom_gem_source && not_found_regex.is_match(&output) {
+        return Some(InstallFailure {
+            kind: InstallFailureKind::PackageMaybePrivate,
+            summary: "gem not found (its custom Gemfile source is not used by Qlty)".to_string(),
+        });
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -422,6 +457,8 @@ pub mod test {
     use crate::{
         tool::{
             command_builder::test::{reroute_tools_root, stub_cmd, ENV_LOCK},
+            command_error::ToolCommandError,
+            install_failure::BUILD_SECRETS_URL,
             ruby::sys::platform,
             ruby_source::RubySource,
         },
@@ -566,5 +603,90 @@ pub mod test {
             }
             Ok(())
         });
+    }
+
+    fn ruby_command_error(stderr: &str) -> ToolCommandError {
+        ToolCommandError {
+            command: vec!["ruby".to_string(), "-S".to_string(), "bundle".to_string()],
+            exit_code: 17,
+            stdout: String::new(),
+            stderr: stderr.to_string(),
+            failure: None,
+        }
+    }
+
+    const AUTH_REQUIRED_STDERR: &str = "Authentication is required for rubygems.pkg.github.com.\nPlease supply credentials for this source. You can do this by running:\n`bundle config set --global rubygems.pkg.github.com username:password`\nor by storing the credentials in the `BUNDLE_RUBYGEMS__PKG__GITHUB__COM`\nenvironment variable";
+    const BAD_CREDENTIALS_STDERR: &str = "Bad username or password for rubygems.pkg.github.com.\nPlease double-check your credentials and correct them.";
+    const GEM_UNAUTHORIZED_STDERR: &str = "ERROR:  Could not find a valid gem 'some-gem' (= 1.0.0), here is why:\n          Unable to download data from https://rubygems.pkg.github.com/marschattha/ - bad response Unauthorized 401 (https://rubygems.pkg.github.com/marschattha/specs.4.8.gz)";
+    const NOT_FOUND_STDERR: &str = "Could not find gem 'qlty-private-gem-xyz (= 1.0.0)' in rubygems\nrepository https://rubygems.org/ or installed locally.";
+
+    #[test]
+    fn test_detect_rubygems_failure_auth_required() {
+        let failure =
+            super::detect_rubygems_failure(&ruby_command_error(AUTH_REQUIRED_STDERR), false)
+                .unwrap();
+
+        assert_eq!(
+            failure.summary,
+            format!("gem source authentication failed (see {BUILD_SECRETS_URL})")
+        );
+        assert!(matches!(
+            failure.kind,
+            crate::tool::install_failure::InstallFailureKind::AuthenticationFailed
+        ));
+    }
+
+    #[test]
+    fn test_detect_rubygems_failure_bad_credentials() {
+        let failure =
+            super::detect_rubygems_failure(&ruby_command_error(BAD_CREDENTIALS_STDERR), false)
+                .unwrap();
+
+        assert!(matches!(
+            failure.kind,
+            crate::tool::install_failure::InstallFailureKind::AuthenticationFailed
+        ));
+    }
+
+    #[test]
+    fn test_detect_rubygems_failure_unauthorized_takes_precedence_over_not_found() {
+        let failure =
+            super::detect_rubygems_failure(&ruby_command_error(GEM_UNAUTHORIZED_STDERR), true)
+                .unwrap();
+
+        assert!(matches!(
+            failure.kind,
+            crate::tool::install_failure::InstallFailureKind::AuthenticationFailed
+        ));
+    }
+
+    #[test]
+    fn test_detect_rubygems_failure_not_found_with_custom_source() {
+        let failure =
+            super::detect_rubygems_failure(&ruby_command_error(NOT_FOUND_STDERR), true).unwrap();
+
+        assert_eq!(
+            failure.summary,
+            "gem not found (its custom Gemfile source is not used by Qlty)"
+        );
+        assert!(matches!(
+            failure.kind,
+            crate::tool::install_failure::InstallFailureKind::PackageMaybePrivate
+        ));
+    }
+
+    #[test]
+    fn test_detect_rubygems_failure_ignores_not_found_without_custom_source() {
+        assert!(
+            super::detect_rubygems_failure(&ruby_command_error(NOT_FOUND_STDERR), false).is_none()
+        );
+    }
+
+    #[test]
+    fn test_detect_rubygems_failure_ignores_other_output() {
+        assert!(
+            super::detect_rubygems_failure(&ruby_command_error("Bundler::GemspecError"), true)
+                .is_none()
+        );
     }
 }

--- a/qlty-check/src/tool/ruby/gemfile.rs
+++ b/qlty-check/src/tool/ruby/gemfile.rs
@@ -32,7 +32,10 @@ impl RubyGemfile {
 
         contents.lines().any(|line| {
             let line = line.trim();
-            line.starts_with("source ") && !line.contains("rubygems.org")
+            line.starts_with("source")
+                && line["source".len()..].starts_with([' ', '('])
+                && !line.contains("rubygems.org")
+                && !line.contains(":rubygems")
         })
     }
 
@@ -490,6 +493,34 @@ mod test {
             std::fs::write(
                 &req_file,
                 "source 'https://gems.example.com'\ngem 'tool', '1.0.0'",
+            )
+            .unwrap();
+            pkg.plugin.package_file = Some(req_file.to_str().unwrap().into());
+
+            assert!(pkg.package_file_declares_custom_source());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_package_file_declares_custom_source_rubygems_symbol() {
+        with_rubygems_package(|pkg, temp_path, _| {
+            let req_file = temp_path.path().join("Gemfile");
+            std::fs::write(&req_file, "source :rubygems\ngem 'tool', '1.0.0'").unwrap();
+            pkg.plugin.package_file = Some(req_file.to_str().unwrap().into());
+
+            assert!(!pkg.package_file_declares_custom_source());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_package_file_declares_custom_source_parenthesized() {
+        with_rubygems_package(|pkg, temp_path, _| {
+            let req_file = temp_path.path().join("Gemfile");
+            std::fs::write(
+                &req_file,
+                "source('https://gems.example.com')\ngem 'tool', '1.0.0'",
             )
             .unwrap();
             pkg.plugin.package_file = Some(req_file.to_str().unwrap().into());

--- a/qlty-check/src/tool/ruby/gemfile.rs
+++ b/qlty-check/src/tool/ruby/gemfile.rs
@@ -1,13 +1,11 @@
 use super::RubygemsPackage;
-use crate::tool::finalize_installation_from_cmd_result;
-use crate::tool::installations::initialize_installation;
 use crate::ui::ProgressBar;
 use crate::{tool::Tool, ui::ProgressTask};
 use anyhow::{bail, Result};
 use itertools::Itertools;
 use qlty_analysis::{join_path_string, utils::fs::path_to_native_string};
 use std::{collections::HashMap, path::PathBuf};
-use tracing::{debug, info};
+use tracing::debug;
 
 pub type RubyGemfile = RubygemsPackage;
 
@@ -21,33 +19,21 @@ impl RubyGemfile {
                 .env_remove("RUBYOPT"), // having RUBYOPT here will throw off bundle install
         )?;
 
-        let list_command = self
-            .cmd
-            .build("ruby", vec!["-S", "bundle", "list"])
-            .full_env(self.env()?)
-            .dir(self.directory())
-            .stderr_capture()
-            .stdout_capture()
-            .unchecked();
+        self.run_command(self.cmd.build("ruby", vec!["-S", "bundle", "list"]))
+    }
 
-        let script = format!("{:?}", list_command);
-        debug!(script);
+    pub fn package_file_declares_custom_source(&self) -> bool {
+        let Some(package_file) = self.plugin.package_file.as_ref() else {
+            return false;
+        };
+        let Ok(contents) = std::fs::read_to_string(package_file) else {
+            return false;
+        };
 
-        let mut installation = initialize_installation(self)?;
-        let result = list_command.run();
-        let _ = finalize_installation_from_cmd_result(self, &result, &mut installation, script);
-
-        let output = result?;
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        info!("ruby -S bundle list list stdout: {}", stdout);
-        info!("ruby -S bundle list list stderr: {}", stderr);
-
-        if !output.status.success() {
-            bail!("Failed to run: ruby -S bundle list");
-        }
-
-        Ok(())
+        contents.lines().any(|line| {
+            let line = line.trim();
+            line.starts_with("source ") && !line.contains("rubygems.org")
+        })
     }
 
     pub fn copy_package_file(&self, task: &ProgressTask) -> Result<()> {
@@ -493,6 +479,48 @@ mod test {
                 "Expected lock file NOT to be copied"
             );
 
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_package_file_declares_custom_source() {
+        with_rubygems_package(|pkg, temp_path, _| {
+            let req_file = temp_path.path().join("Gemfile");
+            std::fs::write(
+                &req_file,
+                "source 'https://gems.example.com'\ngem 'tool', '1.0.0'",
+            )
+            .unwrap();
+            pkg.plugin.package_file = Some(req_file.to_str().unwrap().into());
+
+            assert!(pkg.package_file_declares_custom_source());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_package_file_declares_custom_source_rubygems() {
+        with_rubygems_package(|pkg, temp_path, _| {
+            let req_file = temp_path.path().join("Gemfile");
+            std::fs::write(
+                &req_file,
+                "source 'https://rubygems.org'\ngem 'tool', '1.0.0'",
+            )
+            .unwrap();
+            pkg.plugin.package_file = Some(req_file.to_str().unwrap().into());
+
+            assert!(!pkg.package_file_declares_custom_source());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_package_file_declares_custom_source_without_package_file() {
+        with_rubygems_package(|pkg, _, _| {
+            pkg.plugin.package_file = None;
+
+            assert!(!pkg.package_file_declares_custom_source());
             Ok(())
         });
     }


### PR DESCRIPTION
## What

Follows #2816 (npm): `RubygemsPackage` now overrides `classify_install_failure`, covering both the `gem install` and bundler (`package_file`) install paths.

**Detection** (fixtures are verbatim captures from live bundler 2.6 / gem 3.5 failures against GitHub Packages and rubygems.org):

- **Auth failures** — bundler's `Authentication is required for …` / `Bad username or password for …`, gem's `bad response Unauthorized 401` (and the `Forbidden 403` twin) → `"gem source authentication failed (see https://docs.qlty.sh/cloud/build-secrets)"`, `ty: executor.install.auth_error`. Checked **before** not-found because gem's 401 output contains both signatures.
- **Not-found with a custom source** — Qlty rewrites plugin Gemfiles to `source 'https://rubygems.org'` and drops custom `source` lines, so a gem that only exists on a private source fails as `Could not find gem '…'`. When the *original* package file declares a non-rubygems.org source (`package_file_declares_custom_source`, a strong signal the user intended a custom source), the failure classifies as `"gem not found (its custom Gemfile source is not used by Qlty)"`, `ty: executor.install.package_not_found`. No build-secrets link on this one — a secret can't fix a stripped source; the message states the actual limitation.
- **Plain typos stay generic** — not-found without a custom source declaration is not classified.

**`bundle list` via `run_command`** — the second install step of `gemfile_install` hand-rolled `run_command`'s body and bailed with a bare string; it now goes through `run_command` like `bundle install` already did, so its failures also carry captured output and flow through classification. Its output still lands in the install log (success and failure); the redundant `info!` echo is gone.

## Verified on a sample repo (rubocop plugin, real installs)

| Scenario | Result |
|---|---|
| Gemfile with custom source + gem only on it | `ty: executor.install.package_not_found`, message `Error installing tool rubocop@bundled: gem not found (its custom Gemfile source is not used by Qlty)` |
| Valid rubygems.org Gemfile | clean install through both commands, rubocop runs and reports issues |
| Typo'd gem, no custom source | generic `executor.install.error` with the bundler output tail |

Plus 9 unit tests on the live-captured fixtures (240 total green).

Note: bundler auth failures are currently unreachable through Qlty itself (custom sources are stripped before bundler runs) — the auth detection is future-proofing for when custom sources + build secrets are supported, and covers `gem install` against authenticated sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)