### PR TITLE
feat(check): classify npm workspace-protocol failures and surface install error causes

### DIFF
--- a/qlty-check/src/executor/install_error.rs
+++ b/qlty-check/src/executor/install_error.rs
@@ -37,7 +37,7 @@ fn install_error_details(error: &Error, command_error: Option<&ToolCommandError>
         }
     }
 
-    error.to_string()
+    format!("{error:#}")
 }
 
 #[cfg(test)]
@@ -114,6 +114,7 @@ mod test {
             InstallFailureKind::AuthenticationFailed,
             InstallFailureKind::AccessDenied,
             InstallFailureKind::PackageMaybePrivate,
+            InstallFailureKind::UnsupportedDependencyProtocol,
         ] {
             assert!(kind.message_ty().starts_with("executor.install."));
         }
@@ -135,6 +136,19 @@ mod test {
         assert_eq!(
             message.details,
             r#"Command ["npm", "install"] exited with code 1"#
+        );
+    }
+
+    #[test]
+    fn details_without_command_error_include_the_cause_chain() {
+        let error =
+            anyhow!("No package file provided").context("Error installing rubocop@bundled.");
+
+        let message = install_error_message("rubocop", &error);
+
+        assert_eq!(
+            message.details,
+            "Error installing rubocop@bundled.: No package file provided"
         );
     }
 

--- a/qlty-check/src/tool/install_failure.rs
+++ b/qlty-check/src/tool/install_failure.rs
@@ -11,6 +11,7 @@ pub enum InstallFailureKind {
     AuthenticationFailed,
     AccessDenied,
     PackageMaybePrivate,
+    UnsupportedDependencyProtocol,
 }
 
 impl InstallFailureKind {
@@ -20,6 +21,9 @@ impl InstallFailureKind {
                 "executor.install.auth_error"
             }
             InstallFailureKind::PackageMaybePrivate => "executor.install.package_not_found",
+            InstallFailureKind::UnsupportedDependencyProtocol => {
+                "executor.install.unsupported_protocol"
+            }
         }
     }
 }

--- a/qlty-check/src/tool/node.rs
+++ b/qlty-check/src/tool/node.rs
@@ -271,12 +271,16 @@ fn unsupported_protocol_summary(output: &str) -> String {
     let protocol = Regex::new(r#"Unsupported URL Type "([^"]+)""#)
         .unwrap()
         .captures(output)
-        .and_then(|captures| captures.get(1))
-        .map_or("workspace:", |protocol| protocol.as_str());
+        .and_then(|captures| captures.get(1));
 
-    format!(
-        "npm cannot install \"{protocol}\" dependencies (pnpm/yarn workspace protocols are not supported)"
-    )
+    match protocol {
+        Some(protocol) => format!(
+            "npm cannot install \"{}\" dependencies (pnpm/yarn workspace protocols are not supported)",
+            protocol.as_str()
+        ),
+        None => "npm cannot install this package file (it uses an unsupported dependency protocol)"
+            .to_string(),
+    }
 }
 
 // Unscoped failures are usually typos, yanked versions, or public-registry
@@ -596,6 +600,18 @@ pub mod test {
             failure.kind,
             InstallFailureKind::UnsupportedDependencyProtocol
         ));
+    }
+
+    #[test]
+    fn test_detect_npm_failure_unsupported_protocol_without_url_type_line() {
+        let stderr = "npm error code EUNSUPPORTEDPROTOCOL";
+
+        let failure = detect_npm_failure(&npm_command_error(stderr)).unwrap();
+
+        assert_eq!(
+            failure.summary,
+            "npm cannot install this package file (it uses an unsupported dependency protocol)"
+        );
     }
 
     #[test]

--- a/qlty-check/src/tool/node.rs
+++ b/qlty-check/src/tool/node.rs
@@ -240,13 +240,18 @@ impl Tool for NodePackage {
 fn detect_npm_failure(error: &ToolCommandError) -> Option<InstallFailure> {
     let output = format!("{}\n{}", error.stdout, error.stderr);
 
-    let code_regex = Regex::new(r"npm (?:ERR!|error) code (E401|E403|E404)").unwrap();
+    let code_regex =
+        Regex::new(r"npm (?:ERR!|error) code (E401|E403|E404|EUNSUPPORTEDPROTOCOL)").unwrap();
     let code = code_regex.captures(&output)?.get(1)?.as_str();
 
     let failure = match code {
         "E401" => InstallFailure {
             kind: InstallFailureKind::AuthenticationFailed,
             summary: format!("npm registry authentication failed (see {BUILD_SECRETS_URL})"),
+        },
+        "EUNSUPPORTEDPROTOCOL" => InstallFailure {
+            kind: InstallFailureKind::UnsupportedDependencyProtocol,
+            summary: unsupported_protocol_summary(&output),
         },
         "E403" if mentions_scoped_package(&output, "403") => InstallFailure {
             kind: InstallFailureKind::AccessDenied,
@@ -260,6 +265,18 @@ fn detect_npm_failure(error: &ToolCommandError) -> Option<InstallFailure> {
     };
 
     Some(failure)
+}
+
+fn unsupported_protocol_summary(output: &str) -> String {
+    let protocol = Regex::new(r#"Unsupported URL Type "([^"]+)""#)
+        .unwrap()
+        .captures(output)
+        .and_then(|captures| captures.get(1))
+        .map_or("workspace:", |protocol| protocol.as_str());
+
+    format!(
+        "npm cannot install \"{protocol}\" dependencies (pnpm/yarn workspace protocols are not supported)"
+    )
 }
 
 // Unscoped failures are usually typos, yanked versions, or public-registry
@@ -563,6 +580,22 @@ pub mod test {
         let stderr = "npm warn deprecated @babel/polyfill@7.12.1: This package has been deprecated\nnpm ERR! code E404\nnpm ERR! 404  'left-padd@1.0.0' is not in this registry.";
 
         assert!(detect_npm_failure(&npm_command_error(stderr)).is_none());
+    }
+
+    #[test]
+    fn test_detect_npm_failure_unsupported_protocol() {
+        let stderr = "npm warn using --force Recommended protections disabled.\nnpm error code EUNSUPPORTEDPROTOCOL\nnpm error Unsupported URL Type \"workspace:\": workspace:*";
+
+        let failure = detect_npm_failure(&npm_command_error(stderr)).unwrap();
+
+        assert_eq!(
+            failure.summary,
+            "npm cannot install \"workspace:\" dependencies (pnpm/yarn workspace protocols are not supported)"
+        );
+        assert!(matches!(
+            failure.kind,
+            InstallFailureKind::UnsupportedDependencyProtocol
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## What

Two follow-ups to #2816/#2817, both driven by auditing the production `messages` residual after the 0.634/0.635 rollout.

### 1. Include the cause chain in install error details

Of the recent install-error messages carrying real information, ~70% showed *nothing* — e.g. `Error installing tool rubocop@bundled` with empty details. That happens when the failure has no `ToolCommandError` in its chain (package-file staging errors like gemspec interpolation or Gemfile copying): the details fallback was `error.to_string()`, which is only the outermost context. The fallback now uses anyhow's alternate format (`{error:#}`), so those messages read e.g. `Error installing rubocop@bundled.: No package file provided`. Paths with command output are unchanged.

### 2. Classify npm `EUNSUPPORTEDPROTOCOL` failures

The most common informative npm failure in production (ahead of all auth failures so far): a pnpm/yarn workspace monorepo's package file contains `workspace:*`/`catalog:` dependencies, and npm — which Qlty installs with — rejects the file outright. To the user this reads as a broken installer; their own CI (pnpm) installs fine.

New message, with the offending protocol extracted from npm's output:
```
Error installing tool eslint@9.7.0: npm cannot install "workspace:" dependencies (pnpm/yarn workspace protocols are not supported)
```
ty: `executor.install.unsupported_protocol` — so the demand for pnpm/yarn support becomes measurable:
```sql
SELECT uniqExact(projectId) FROM messages WHERE ty = 'executor.install.unsupported_protocol'
```
No build-secrets link on this one — it is not an auth problem; the remedy is a linter-only package file without workspace deps.

## Verification

- Fixture captured from a live local `npm install` against a `workspace:*` dependency.
- End-to-end: a real `qlty build` against a package file with a workspace dep produces the classified message above.
- 244 unit tests + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)