### PR TITLE
feat(config): merge versioned driver definitions by version_matcher

### DIFF
--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -1432,4 +1432,54 @@ mod test {
         assert_eq!(driver.prepare_script, Some("npm install".to_string()));
         assert_eq!(driver.script, "mylint ${target}");
     }
+
+    #[test]
+    fn test_versioned_drivers_with_same_version_matcher_are_merged() {
+        let sources = toml! {
+            config_version = "0"
+
+            [plugins.definitions.mylint]
+            file_types = ["ALL"]
+
+            [[plugins.definitions.mylint.drivers.lint.version]]
+            version_matcher = "<2.0.0"
+            script = "mylint-legacy ${target}"
+            success_codes = [0]
+            output = "pass_fail"
+
+            [[plugins.definitions.mylint.drivers.lint.version]]
+            version_matcher = ">=2.0.0"
+            script = "mylint ${target}"
+            success_codes = [0]
+            output = "pass_fail"
+        };
+        let qlty_config = toml! {
+            config_version = "0"
+
+            [[plugins.definitions.mylint.drivers.lint.version]]
+            version_matcher = ">=2.0.0"
+            prepare_script = "npm install"
+        };
+
+        let config =
+            Builder::full_config(toml::Value::Table(sources), toml::Value::Table(qlty_config))
+                .unwrap();
+
+        let driver = &config.plugins.definitions["mylint"].drivers["lint"];
+        assert_eq!(driver.version.len(), 2);
+        assert_eq!(
+            driver.version[0].version_matcher,
+            Some("<2.0.0".to_string())
+        );
+        assert_eq!(driver.version[0].prepare_script, None);
+        assert_eq!(
+            driver.version[1].version_matcher,
+            Some(">=2.0.0".to_string())
+        );
+        assert_eq!(
+            driver.version[1].prepare_script,
+            Some("npm install".to_string())
+        );
+        assert_eq!(driver.version[1].script, "mylint ${target}");
+    }
 }

--- a/qlty-config/src/toml_merge.rs
+++ b/qlty-config/src/toml_merge.rs
@@ -63,7 +63,16 @@ impl TomlMerge {
             (Value::Datetime(_), Value::Datetime(inner)) => Ok(Value::Datetime(inner)),
             (Value::Array(mut existing), Value::Array(inner)) => {
                 if existing.iter().all(|v| v.is_table()) && inner.iter().all(|v| v.is_table()) {
-                    existing.extend(inner);
+                    for value in inner {
+                        match Self::version_matcher_position(&existing, &value) {
+                            Some(index) => {
+                                let index_path = format!("{path}[{index}]");
+                                existing[index] =
+                                    Self::merge_inner(existing[index].clone(), value, &index_path)?;
+                            }
+                            None => existing.push(value),
+                        }
+                    }
                     Ok(Value::Array(existing))
                 } else {
                     let extender = Value::String("...".to_string());
@@ -81,6 +90,23 @@ impl TomlMerge {
             }
             (v, o) => Err(Error::new(path.to_owned(), v.type_str(), o.type_str())),
         }
+    }
+
+    // Tables in arrays are opaque to the key-based table merge, so entries
+    // sharing a version_matcher (versioned driver definitions) are merged by
+    // matcher instead of appended, allowing later configs to override them.
+    fn version_matcher_position(existing: &[Value], value: &Value) -> Option<usize> {
+        let matcher = Self::version_matcher(value)?;
+
+        existing
+            .iter()
+            .position(|existing_value| Self::version_matcher(existing_value) == Some(matcher))
+    }
+
+    fn version_matcher(value: &Value) -> Option<&str> {
+        value
+            .get("version_matcher")
+            .and_then(|value| value.as_str())
     }
 
     /// Merges two toml values into a single one.
@@ -212,5 +238,105 @@ mod test {
         "#;
 
         should_match!(first, second, result);
+    }
+
+    #[test]
+    fn merging_array_of_tables_with_same_version_matcher() {
+        let first = r#"
+        [[version]]
+        version_matcher = ">=2.0.0"
+        script = "mylint ${target}"
+        max_batch = 40
+
+        [[version]]
+        version_matcher = "<2.0.0"
+        script = "mylint-legacy ${target}"
+        "#;
+        let second = r#"
+        [[version]]
+        version_matcher = ">=2.0.0"
+        prepare_script = "npm install"
+        max_batch = 64
+        "#;
+        let result = r#"
+        [[version]]
+        version_matcher = ">=2.0.0"
+        script = "mylint ${target}"
+        prepare_script = "npm install"
+        max_batch = 64
+
+        [[version]]
+        version_matcher = "<2.0.0"
+        script = "mylint-legacy ${target}"
+        "#;
+
+        should_match!(first, second, result);
+    }
+
+    #[test]
+    fn merging_array_of_tables_with_different_version_matcher() {
+        let first = r#"
+        [[version]]
+        version_matcher = ">=2.0.0"
+        script = "mylint ${target}"
+        "#;
+        let second = r#"
+        [[version]]
+        version_matcher = ">=3.0.0"
+        script = "mylint-next ${target}"
+        "#;
+        let result = r#"
+        [[version]]
+        version_matcher = ">=2.0.0"
+        script = "mylint ${target}"
+
+        [[version]]
+        version_matcher = ">=3.0.0"
+        script = "mylint-next ${target}"
+        "#;
+
+        should_match!(first, second, result);
+    }
+
+    #[test]
+    fn merging_array_of_tables_without_version_matcher_in_existing() {
+        let first = r#"
+        [[version]]
+        script = "mylint ${target}"
+        "#;
+        let second = r#"
+        [[version]]
+        version_matcher = ">=2.0.0"
+        script = "mylint-next ${target}"
+        "#;
+        let result = r#"
+        [[version]]
+        script = "mylint ${target}"
+
+        [[version]]
+        version_matcher = ">=2.0.0"
+        script = "mylint-next ${target}"
+        "#;
+
+        should_match!(first, second, result);
+    }
+
+    #[test]
+    fn merging_array_of_tables_with_incompatible_version_matcher_values() {
+        assert_eq!(
+            should_fail!(
+                r#"
+                [[version]]
+                version_matcher = ">=2.0.0"
+                script = "mylint ${target}"
+                "#,
+                r#"
+                [[version]]
+                version_matcher = ">=2.0.0"
+                script = 42
+                "#,
+            ),
+            Error::new("$.version[0].script".to_owned(), "string", "integer")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Companion to #2822. Allows a `[[plugins.definitions.X.drivers.Y.version]]` block in qlty.toml (or a downstream source) to override individual fields of a specific versioned driver entry, instead of being silently unreachable.

Previously, `TomlMerge` always appended array-of-table entries. Combined with first-match-wins driver version matching — where source entries are merged before user config — a user-supplied versioned entry could never be selected when a source matcher already covered the same version range.

## Change

In `TomlMerge`, when merging arrays of tables, an incoming entry whose `version_matcher` exactly matches an existing entry's is now deep-merged into it (incoming values win, standard merge rules apply to nested values), keeping its original position so match order is preserved. Entries without a `version_matcher`, or with no exact match, keep the append behavior — `[[plugin]]`, `[[source]]`, etc. are unaffected since versioned driver definitions are the only arrays of tables using that key.

This enables per-version surgical overrides:

```toml
[[plugins.definitions.eslint.drivers.lint.version]]
version_matcher = ">=9.0.0"
prepare_script = "npm install"
```

Notes:
- The matcher must match the source's string verbatim (`">=9.0.0"` ≠ `">=9"`); a non-matching string degrades to today's append behavior.
- Composes with #2822, which overlays outer driver fields onto all versioned entries; this PR covers targeting a single version range.

## Tests

- `toml_merge` unit tests: same-matcher entries merge (incoming wins, position preserved), different matchers append, existing entries without matchers append, incompatible value types error with an indexed path
- Builder-level test through `full_config` (sources + user config) verifying a user's `[[...version]]` block merges into the source's matching entry and other entries are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)