### PR TITLE
feat(check): bump managed node runtime to 22.23.1 LTS

### DIFF
--- a/qlty-check/src/tool/tool_builder.rs
+++ b/qlty-check/src/tool/tool_builder.rs
@@ -146,7 +146,7 @@ impl ToolBuilder<'_> {
     fn latest_runtime_version(runtime: &Runtime) -> Option<String> {
         match runtime {
             Runtime::Go => Some("1.22.0".to_owned()),
-            Runtime::Node => Some("21.7.3".to_owned()),
+            Runtime::Node => Some("22.23.1".to_owned()),
             Runtime::Python => Some("3.11.7".to_owned()),
             Runtime::Ruby => Some("3.3.7".to_owned()),
             Runtime::Rust => Some("1.77.2".to_owned()),


### PR DESCRIPTION
## Summary

Bumps the managed Node runtime from 21.7.3 (odd-numbered, EOL, non-LTS) to 22.23.1 (latest 22 LTS "Jod"). Closes #2814.

Node 21 is a short-lived non-LTS line that the npm ecosystem deliberately excludes: engine ranges target even LTS lines (`^20.19 || ^22.12 || >=24`), and npm silently skips optional dependencies — including native bindings — whose `engines` exclude the running node. This blocked eslint 10, knip 6, oxlint 1.x, and prisma 7.

The download URLs in `qlty-check/src/tool/node.rs` are version-templated, so this is a one-line change. The plugin promotions this unblocks follow in stacked PRs: #2825 (eslint, oxc, prisma) and #2826 (knip, which also needs a parser change).

## Test results

- Full node-linter jest matrix on node 22.23.1: 11/11 suites, 24 tests, 24 snapshots passed — every fixture at every historical snapshot version (back to eslint 8.10.0, prettier 2.6.2) runs unmodified on the new runtime
- `cargo test`: 1087 passed, 0 failed

## Test plan

- [ ] All linter tests pass in CI (including windows-2022)

🤖 Generated with [Claude Code](https://claude.com/claude-code)