### PR TITLE
fix(check): honor package-lock.json when installing from package_file

### DIFF
--- a/qlty-check/src/tool/node.rs
+++ b/qlty-check/src/tool/node.rs
@@ -172,11 +172,7 @@ impl Tool for NodePackage {
 
         self.run_command(self.cmd.build(
             NPM_COMMAND,
-            vec![
-                "install",
-                "--force",
-                format!("{}@{}", name, version).as_str(),
-            ],
+            vec!["install", "--force", format!("{name}@{version}").as_str()],
         ))
     }
 
@@ -195,10 +191,16 @@ impl Tool for NodePackage {
             .as_str(),
         );
 
-        self.run_command(
-            self.cmd
-                .build(NPM_COMMAND, vec!["install", "--force", "--no-package-lock"]),
-        )
+        let staged_lock_file = Path::new(&self.directory()).join("package-lock.json");
+        let mut arguments = vec!["install", "--force"];
+
+        // Honor the staged lock file when present; --no-package-lock would
+        // make npm ignore it and resolve latest matching versions instead
+        if !staged_lock_file.exists() {
+            arguments.push("--no-package-lock");
+        }
+
+        self.run_command(self.cmd.build(NPM_COMMAND, arguments))
     }
 
     fn extra_env_paths(&self) -> Result<Vec<String>> {
@@ -396,6 +398,67 @@ pub mod test {
                 json_contents,
                 json!({"dependencies":{"other": "1.0.0", "test":"1.0.0"}})
             );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn node_package_install_with_package_file_and_lock_file() {
+        with_node_package(|pkg, temp_path, list| {
+            let pkg_file = temp_path.path().join("package.json");
+            std::fs::write(&pkg_file, r#"{"dependencies":{"other":"2.0.0"}}"#)?;
+
+            let lock_file = temp_path.path().join("package-lock.json");
+            std::fs::write(
+                &lock_file,
+                r#"{"name":"lock-test","lockfileVersion":3,"packages":{}}"#,
+            )?;
+
+            pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            reroute_tools_root(&temp_path, pkg);
+
+            pkg.install(&new_task())?;
+            assert_eq!(
+                list.lock().unwrap().clone(),
+                [
+                    vec![NPM_COMMAND, "install", "--force", "test@1.0.0"],
+                    vec![NPM_COMMAND, "install", "--force"]
+                ]
+            );
+
+            let staged_lock_file = Path::new(&pkg.directory()).join("package-lock.json");
+            assert!(staged_lock_file.exists());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn node_package_install_with_lock_file_and_package_filters() {
+        with_node_package(|pkg, temp_path, list| {
+            let pkg_file = temp_path.path().join("package.json");
+            std::fs::write(&pkg_file, r#"{"dependencies":{"other":"2.0.0"}}"#)?;
+
+            let lock_file = temp_path.path().join("package-lock.json");
+            std::fs::write(
+                &lock_file,
+                r#"{"name":"lock-test","lockfileVersion":3,"packages":{}}"#,
+            )?;
+
+            pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            pkg.plugin.package_filters = vec![pkg.name.clone()];
+            reroute_tools_root(&temp_path, pkg);
+
+            pkg.install(&new_task())?;
+            assert_eq!(
+                list.lock().unwrap().clone(),
+                [
+                    [NPM_COMMAND, "install", "--force", "test@1.0.0"],
+                    [NPM_COMMAND, "install", "--force", "--no-package-lock"]
+                ]
+            );
+
+            let staged_lock_file = Path::new(&pkg.directory()).join("package-lock.json");
+            assert!(!staged_lock_file.exists());
             Ok(())
         });
     }

--- a/qlty-check/src/tool/node.rs
+++ b/qlty-check/src/tool/node.rs
@@ -177,7 +177,7 @@ impl Tool for NodePackage {
     }
 
     fn package_file_install(&self, task: &ProgressTask) -> Result<()> {
-        let lock_file_staged = self.update_package_json(&self.name, &self.plugin.package_file)?;
+        let lock_file_staged = self.update_package_json(&self.name)?;
         task.set_dim_message(
             format!(
                 "{} install {}",

--- a/qlty-check/src/tool/node.rs
+++ b/qlty-check/src/tool/node.rs
@@ -177,7 +177,7 @@ impl Tool for NodePackage {
     }
 
     fn package_file_install(&self, task: &ProgressTask) -> Result<()> {
-        self.update_package_json(&self.name, &self.plugin.package_file)?;
+        let lock_file_staged = self.update_package_json(&self.name, &self.plugin.package_file)?;
         task.set_dim_message(
             format!(
                 "{} install {}",
@@ -191,12 +191,13 @@ impl Tool for NodePackage {
             .as_str(),
         );
 
-        let staged_lock_file = Path::new(&self.directory()).join("package-lock.json");
         let mut arguments = vec!["install", "--force"];
 
-        // Honor the staged lock file when present; --no-package-lock would
-        // make npm ignore it and resolve latest matching versions instead
-        if !staged_lock_file.exists() {
+        // Honor the user's lock file when one was staged; --no-package-lock
+        // would make npm ignore it and resolve latest matching versions
+        // instead. The flag is kept otherwise so npm does not consult the
+        // lock file it generated during the initial tool installation.
+        if !lock_file_staged {
             arguments.push("--no-package-lock");
         }
 
@@ -428,6 +429,33 @@ pub mod test {
 
             let staged_lock_file = Path::new(&pkg.directory()).join("package-lock.json");
             assert!(staged_lock_file.exists());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn node_package_install_ignores_leftover_staging_lock_file() {
+        with_node_package(|pkg, temp_path, list| {
+            let pkg_file = temp_path.path().join("package.json");
+            std::fs::write(&pkg_file, r#"{"dependencies":{"other":"2.0.0"}}"#)?;
+
+            pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            reroute_tools_root(&temp_path, pkg);
+
+            let staged_lock_file = Path::new(&pkg.directory()).join("package-lock.json");
+            std::fs::write(
+                &staged_lock_file,
+                r#"{"name":"tool","lockfileVersion":3,"packages":{}}"#,
+            )?;
+
+            pkg.install(&new_task())?;
+            assert_eq!(
+                list.lock().unwrap().clone(),
+                [
+                    [NPM_COMMAND, "install", "--force", "test@1.0.0"],
+                    [NPM_COMMAND, "install", "--force", "--no-package-lock"]
+                ]
+            );
             Ok(())
         });
     }

--- a/qlty-check/src/tool/node/package_json.rs
+++ b/qlty-check/src/tool/node/package_json.rs
@@ -22,11 +22,12 @@ impl PackageJson {
         }
     }
 
+    // Returns whether the user's lock file was copied into the staging directory
     pub fn update_package_json(
         &self,
         tool_name: &str,
         package_file: &Option<String>,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let user_file_contents =
             std::fs::read_to_string(self.plugin.package_file.as_deref().unwrap_or_default())?;
         let mut user_json = serde_json::from_str::<Value>(&user_file_contents)?;
@@ -66,6 +67,8 @@ impl PackageJson {
         let final_package_file = serde_json::to_string_pretty(&user_json)?;
         debug!("Writing {} package.json: {}", tool_name, final_package_file);
 
+        let mut lock_file_staged = false;
+
         if self.plugin.package_filters.is_empty() {
             if let Some(package_file) = &self.plugin.package_file {
                 let package_file_path = PathBuf::from(package_file);
@@ -82,6 +85,7 @@ impl PackageJson {
                             staging_lock_file.display()
                         );
                         std::fs::copy(lock_file, staging_lock_file)?;
+                        lock_file_staged = true;
                     }
                 }
             }
@@ -89,7 +93,7 @@ impl PackageJson {
 
         std::fs::write(staged_file, final_package_file)?;
 
-        Ok(())
+        Ok(lock_file_staged)
     }
 
     // Filter out any dependencies that don't seem related to the plugin
@@ -115,7 +119,7 @@ impl PackageJson {
                 let path = PathBuf::from(package_file.clone().unwrap_or_default());
                 let parent_path = path.parent().unwrap().to_str().unwrap();
                 *value =
-                    Value::from(version_string.replace("file:", &format!("file:{}/", parent_path)));
+                    Value::from(version_string.replace("file:", &format!("file:{parent_path}/")));
             }
         }
     }

--- a/qlty-check/src/tool/node/package_json.rs
+++ b/qlty-check/src/tool/node/package_json.rs
@@ -22,7 +22,8 @@ impl PackageJson {
         }
     }
 
-    // Returns whether the user's lock file was copied into the staging directory
+    // Returns whether the repository's package-lock.json was copied into the
+    // staging directory, which only happens when package_filters is empty
     pub fn update_package_json(
         &self,
         tool_name: &str,

--- a/qlty-check/src/tool/node/package_json.rs
+++ b/qlty-check/src/tool/node/package_json.rs
@@ -24,11 +24,7 @@ impl PackageJson {
 
     // Returns whether the repository's package-lock.json was copied into the
     // staging directory, which only happens when package_filters is empty
-    pub fn update_package_json(
-        &self,
-        tool_name: &str,
-        package_file: &Option<String>,
-    ) -> Result<bool> {
+    pub fn update_package_json(&self, tool_name: &str) -> Result<bool> {
         let user_file_contents =
             std::fs::read_to_string(self.plugin.package_file.as_deref().unwrap_or_default())?;
         let mut user_json = serde_json::from_str::<Value>(&user_file_contents)?;
@@ -52,7 +48,7 @@ impl PackageJson {
             // clear out unrelated deps
             if let Some(dependencies) = root_object.get_mut("dependencies") {
                 self.remove_unrelated_dependencies(dependencies, tool_name);
-                Self::update_file_dependencies(dependencies, package_file);
+                Self::update_file_dependencies(dependencies, &self.plugin.package_file);
             }
         }
 
@@ -206,7 +202,7 @@ mod test {
                 let stage_path = Path::new(&pkg.directory()).join("package.json");
                 std::fs::write(&stage_path, r#"{"dependencies":{"eslint":"1.0.0"}}"#)?;
 
-                pkg.update_package_json("eslint", &Some("package.json".to_string()))?;
+                pkg.update_package_json("eslint")?;
 
                 assert_eq!(
                     std::fs::read_to_string(&stage_path)?
@@ -258,7 +254,7 @@ mod test {
                 let stage_path = Path::new(&pkg.directory()).join("package.json");
                 std::fs::write(&stage_path, r#"{"dependencies":{"eslint":"1.0.0"}}"#)?;
 
-                pkg.update_package_json("eslint", &Some("package.json".to_string()))?;
+                pkg.update_package_json("eslint")?;
 
                 assert_eq!(
                     std::fs::read_to_string(&stage_path)?
@@ -296,13 +292,20 @@ mod test {
             let stage_path = Path::new(&pkg.directory()).join("package.json");
             std::fs::write(&stage_path, r#"{"dependencies":{"eslint":"1.0.0"}}"#)?;
 
-            pkg.update_package_json("eslint", &Some("/Some/Path/to/package.json".to_string()))?;
+            pkg.update_package_json("eslint")?;
 
+            let expected_file_dependency = user_package_file
+                .parent()
+                .unwrap()
+                .join("packages/eslint-plugin");
             assert_eq!(
                 std::fs::read_to_string(&stage_path)?
                     .replace('\n', "")
                     .replace(' ', ""),
-                "{\"dependencies\":{\"eslint\":\"1.0.0\",\"eslint-plugin\":\"file:/Some/Path/to/packages/eslint-plugin\"}}".to_string()
+                format!(
+                    "{{\"dependencies\":{{\"eslint\":\"1.0.0\",\"eslint-plugin\":\"file:{}\"}}}}",
+                    expected_file_dependency.display()
+                )
             );
 
             Ok(())
@@ -347,7 +350,7 @@ mod test {
             let stage_path = Path::new(&pkg.directory()).join("package.json");
             std::fs::write(&stage_path, r#"{"dependencies":{"eslint":"1.0.0"}}"#)?;
 
-            pkg.update_package_json("eslint", &Some("package.json".to_string()))?;
+            pkg.update_package_json("eslint")?;
 
             // Verify lock file was copied
             let staged_lock_file = Path::new(&pkg.directory()).join("package-lock.json");
@@ -401,7 +404,7 @@ mod test {
             let stage_path = Path::new(&pkg.directory()).join("package.json");
             std::fs::write(&stage_path, r#"{"dependencies":{"eslint":"1.0.0"}}"#)?;
 
-            pkg.update_package_json("eslint", &Some("package.json".to_string()))?;
+            pkg.update_package_json("eslint")?;
 
             // Verify lock file was not copied
             let staged_lock_file = Path::new(&pkg.directory()).join("package-lock.json");

--- a/qlty-check/src/tool/node/package_json.rs
+++ b/qlty-check/src/tool/node/package_json.rs
@@ -304,7 +304,7 @@ mod test {
                     .replace(' ', ""),
                 format!(
                     "{{\"dependencies\":{{\"eslint\":\"1.0.0\",\"eslint-plugin\":\"file:{}\"}}}}",
-                    expected_file_dependency.display()
+                    path_to_string(expected_file_dependency)
                 )
             );
 


### PR DESCRIPTION
## Summary

Fixes a user-reported bug where `package-lock.json` was not honored when installing node-based linters with `package_file`, contradicting the [documented behavior](https://docs.qlty.sh/cli/linter-extensions#lock-files) ("When using `package_file`, Qlty respects the locked versions for reliability").

## Problem

Since #1658, `update_package_json` copies the repo's `package-lock.json` into the tool staging directory (when `package_file` is set and no `package_filters` are configured). However, `package_file_install` then runs `npm install --force --no-package-lock` — and npm's `--no-package-lock` flag makes npm **ignore** lockfiles during install. The flag predates the lockfile-copy feature and was never removed, so the copied lockfile had no effect and npm resolved the latest versions matching the `package.json` semver ranges.

**Repro:** a repo with `"eslint": "^8.0.0"` in `package.json`, a lockfile pinning eslint to `8.0.0`, and `package_file = "package.json"` in `qlty.toml` installed eslint **8.57.1** instead of the locked **8.0.0**.

## Fix

Drop `--no-package-lock` from the install command when a lockfile was staged. The flag is kept when no lockfile is present, and in the `package_filters` case, where no lockfile is copied since the filtered `package.json` would conflict with the full lockfile (also matches the documented behavior: "When using `package_file` with `package_filters`, the lock files are ignored").

## Testing

- New unit tests: lockfile staged → flag dropped; `package_filters` with lockfile → lockfile not staged, flag kept
- Verified end-to-end with the repro above: eslint now installs at the locked `8.0.0`
- Full workspace test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)