### PR TITLE
fix(check): honor composer.lock when installing from package_file

### DIFF
--- a/qlty-check/src/tool/php.rs
+++ b/qlty-check/src/tool/php.rs
@@ -264,6 +264,37 @@ pub mod test {
         Progress::new(true, 1).task("PREFIX", "message")
     }
 
+    fn failing_install_cmd(list: Arc<Mutex<Vec<Vec<String>>>>) -> Box<dyn CommandBuilder> {
+        #[derive(Debug)]
+        struct FailingInstallCommandBuilder {
+            list: Arc<Mutex<Vec<Vec<String>>>>,
+        }
+        impl CommandBuilder for FailingInstallCommandBuilder {
+            fn build(&self, bin: &str, args: Vec<&str>) -> duct::Expression {
+                let failing = args.contains(&"install");
+                let mut pushed_list = vec![bin];
+                pushed_list.extend(args);
+                self.list
+                    .lock()
+                    .unwrap()
+                    .push(pushed_list.iter().map(|s| s.to_string()).collect());
+
+                if failing {
+                    crate::tool::command_builder::Command::new(None, "exit 1").cmd
+                } else {
+                    crate::tool::command_builder::Command::new(None, "exit 0").cmd
+                }
+            }
+
+            fn clone_box(&self) -> Box<dyn CommandBuilder> {
+                Box::new(FailingInstallCommandBuilder {
+                    list: Arc::clone(&self.list),
+                })
+            }
+        }
+        Box::new(FailingInstallCommandBuilder { list })
+    }
+
     #[test]
     fn php_package_install_no_package_file() {
         with_php_package(|pkg, _, list| {
@@ -363,10 +394,10 @@ pub mod test {
     }
 
     #[test]
-    fn php_package_file_install_with_lock_file_missing_package() {
+    fn php_package_file_install_falls_back_to_update_when_install_fails() {
         with_php_package(|pkg, temp_path, list| {
             let pkg_file = temp_path.path().join("composer.json");
-            std::fs::write(&pkg_file, r#"{"require":{"other":"1.0.0"}}"#)?;
+            std::fs::write(&pkg_file, r#"{"require":{"test":"1.0.0"}}"#)?;
 
             let lock_file = temp_path.path().join("composer.lock");
             std::fs::write(
@@ -375,10 +406,11 @@ pub mod test {
             )?;
 
             pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            pkg.cmd = failing_install_cmd(list.clone());
             reroute_tools_root(&temp_path, pkg);
 
             let composer = Composer {
-                cmd: stub_cmd(list.clone()),
+                cmd: failing_install_cmd(list.clone()),
             };
 
             pkg.package_file_install(&new_task())?;
@@ -391,6 +423,17 @@ pub mod test {
                         "copy('https://getcomposer.org/installer', 'composer-setup.php');"
                     ],
                     vec!["php", "composer-setup.php"],
+                    vec![
+                        "php",
+                        &path_to_native_string(format!(
+                            "{}/.qlty/cache/tools/composer/{}/composer.phar",
+                            temp_path.path().display(),
+                            composer.directory_name()
+                        )),
+                        "install",
+                        "--no-interaction",
+                        "--ignore-platform-reqs"
+                    ],
                     vec![
                         "php",
                         &path_to_native_string(format!(

--- a/qlty-check/src/tool/php.rs
+++ b/qlty-check/src/tool/php.rs
@@ -78,7 +78,7 @@ impl Php {
             .stderr_to_stdout()
             .stdout_capture();
 
-        let script = format!("{:?}", cmd);
+        let script = format!("{cmd:?}");
         debug!(script);
 
         let mut installation = initialize_installation(self)?;
@@ -149,17 +149,14 @@ impl Tool for PhpPackage {
     }
 
     fn package_install(&self, task: &ProgressTask, name: &str, version: &str) -> Result<()> {
-        task.set_dim_message(&format!("Installing {}", name));
+        task.set_dim_message(&format!("Installing {name}"));
         let composer = Composer {
             cmd: default_command_builder(),
         };
 
         let composer_phar = PathBuf::from(composer.directory()).join("composer.phar");
         let composer_path = composer_phar.to_str().with_context(|| {
-            format!(
-                "Failed to convert composer path to string: {:?}",
-                composer_phar
-            )
+            format!("Failed to convert composer path to string: {composer_phar:?}")
         })?;
 
         self.run_command(self.cmd.build(
@@ -168,7 +165,7 @@ impl Tool for PhpPackage {
                 &path_to_native_string(composer_path),
                 "require",
                 "--no-interaction",
-                format!("{}:{}", name, version).as_str(),
+                format!("{name}:{version}").as_str(),
             ],
         ))
     }
@@ -284,6 +281,148 @@ pub mod test {
             std::fs::write(&pkg_file, r#"{}"#)?;
 
             pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            reroute_tools_root(&temp_path, pkg);
+
+            let composer = Composer {
+                cmd: stub_cmd(list.clone()),
+            };
+
+            pkg.package_file_install(&new_task())?;
+            assert_eq!(
+                list.lock().unwrap().clone(),
+                [
+                    vec![
+                        "php",
+                        "-r",
+                        "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+                    ],
+                    vec!["php", "composer-setup.php"],
+                    vec![
+                        "php",
+                        &path_to_native_string(format!(
+                            "{}/.qlty/cache/tools/composer/{}/composer.phar",
+                            temp_path.path().display(),
+                            composer.directory_name()
+                        )),
+                        "update",
+                        "--no-interaction",
+                        "--ignore-platform-reqs"
+                    ]
+                ]
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn php_package_file_install_with_lock_file() {
+        with_php_package(|pkg, temp_path, list| {
+            let pkg_file = temp_path.path().join("composer.json");
+            std::fs::write(&pkg_file, r#"{"require":{"test":"1.0.0"}}"#)?;
+
+            let lock_file = temp_path.path().join("composer.lock");
+            std::fs::write(
+                &lock_file,
+                r#"{"packages":[{"name":"test","version":"1.0.0"}]}"#,
+            )?;
+
+            pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            reroute_tools_root(&temp_path, pkg);
+
+            let composer = Composer {
+                cmd: stub_cmd(list.clone()),
+            };
+
+            pkg.package_file_install(&new_task())?;
+            assert_eq!(
+                list.lock().unwrap().clone(),
+                [
+                    vec![
+                        "php",
+                        "-r",
+                        "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+                    ],
+                    vec!["php", "composer-setup.php"],
+                    vec![
+                        "php",
+                        &path_to_native_string(format!(
+                            "{}/.qlty/cache/tools/composer/{}/composer.phar",
+                            temp_path.path().display(),
+                            composer.directory_name()
+                        )),
+                        "install",
+                        "--no-interaction",
+                        "--ignore-platform-reqs"
+                    ]
+                ]
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn php_package_file_install_with_lock_file_missing_package() {
+        with_php_package(|pkg, temp_path, list| {
+            let pkg_file = temp_path.path().join("composer.json");
+            std::fs::write(&pkg_file, r#"{"require":{"other":"1.0.0"}}"#)?;
+
+            let lock_file = temp_path.path().join("composer.lock");
+            std::fs::write(
+                &lock_file,
+                r#"{"packages":[{"name":"other","version":"1.0.0"}]}"#,
+            )?;
+
+            pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            reroute_tools_root(&temp_path, pkg);
+
+            let composer = Composer {
+                cmd: stub_cmd(list.clone()),
+            };
+
+            pkg.package_file_install(&new_task())?;
+            assert_eq!(
+                list.lock().unwrap().clone(),
+                [
+                    vec![
+                        "php",
+                        "-r",
+                        "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+                    ],
+                    vec!["php", "composer-setup.php"],
+                    vec![
+                        "php",
+                        &path_to_native_string(format!(
+                            "{}/.qlty/cache/tools/composer/{}/composer.phar",
+                            temp_path.path().display(),
+                            composer.directory_name()
+                        )),
+                        "update",
+                        "--no-interaction",
+                        "--ignore-platform-reqs"
+                    ]
+                ]
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn php_package_file_install_with_lock_file_and_package_filters() {
+        with_php_package(|pkg, temp_path, list| {
+            let pkg_file = temp_path.path().join("composer.json");
+            std::fs::write(&pkg_file, r#"{"require":{"test":"1.0.0"}}"#)?;
+
+            let lock_file = temp_path.path().join("composer.lock");
+            std::fs::write(
+                &lock_file,
+                r#"{"packages":[{"name":"test","version":"1.0.0"}]}"#,
+            )?;
+
+            pkg.plugin.package_file = Some(pkg_file.to_str().unwrap().to_string());
+            pkg.plugin.package_filters = vec!["test".to_string()];
             reroute_tools_root(&temp_path, pkg);
 
             let composer = Composer {

--- a/qlty-check/src/tool/php/composer.rs
+++ b/qlty-check/src/tool/php/composer.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use sha2::Digest;
 use std::env::split_paths;
 use std::path::PathBuf;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use super::PhpPackage;
 
@@ -74,20 +74,33 @@ impl Composer {
     pub fn install_package_file(&self, php_package: &PhpPackage) -> Result<()> {
         info!("Installing composer package file");
         let lock_file_staged = Self::update_composer_json(php_package)?;
+
+        // `composer install` honors the staged lock file while `composer update`
+        // re-resolves and rewrites it. Install hard-errors when the lock file
+        // cannot satisfy composer.json (e.g. a stale lock file in the
+        // repository, or the tool missing from it), so fall back to update
+        // rather than failing the installation.
+        if lock_file_staged {
+            match self.run_composer_subcommand(php_package, "install") {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    warn!(
+                        "composer install with the staged lock file failed ({}), \
+                        falling back to composer update",
+                        err
+                    );
+                }
+            }
+        }
+
+        self.run_composer_subcommand(php_package, "update")
+    }
+
+    fn run_composer_subcommand(&self, php_package: &PhpPackage, subcommand: &str) -> Result<()> {
         let composer_phar = PathBuf::from(self.directory()).join("composer.phar");
         let composer_path = composer_phar.to_str().with_context(|| {
             format!("Failed to convert composer path to string: {composer_phar:?}")
         })?;
-
-        // `composer install` honors the staged lock file while `composer update`
-        // re-resolves and rewrites it. Install only installs packages recorded
-        // in the lock file, so fall back to update when the tool is absent
-        // from it since install would not add it.
-        let subcommand = if lock_file_staged && Self::lock_file_contains_package(php_package) {
-            "install"
-        } else {
-            "update"
-        };
 
         let cmd = self
             .cmd
@@ -144,32 +157,6 @@ impl Composer {
         }
 
         serde_json::to_string_pretty(&lock_json).ok()
-    }
-
-    fn lock_file_contains_package(php_package: &PhpPackage) -> bool {
-        let Some(package_name) = php_package.plugin.package.as_deref() else {
-            return false;
-        };
-
-        let lock_file = PathBuf::from(php_package.directory()).join("composer.lock");
-        let Ok(contents) = std::fs::read_to_string(&lock_file) else {
-            return false;
-        };
-        let Ok(lock_json) = serde_json::from_str::<Value>(&contents) else {
-            debug!("Failed to parse staged lock file {:?}", lock_file);
-            return false;
-        };
-
-        ["packages", "packages-dev"].iter().any(|section| {
-            lock_json
-                .get(section)
-                .and_then(|packages| packages.as_array())
-                .is_some_and(|packages| {
-                    packages.iter().any(|package| {
-                        package.get("name").and_then(|name| name.as_str()) == Some(package_name)
-                    })
-                })
-        })
     }
 
     // Filter out any dependencies that don't seem related to the plugin

--- a/qlty-check/src/tool/php/composer.rs
+++ b/qlty-check/src/tool/php/composer.rs
@@ -73,14 +73,21 @@ impl Tool for Composer {
 impl Composer {
     pub fn install_package_file(&self, php_package: &PhpPackage) -> Result<()> {
         info!("Installing composer package file");
-        Self::update_composer_json(php_package)?;
+        let lock_file_staged = Self::update_composer_json(php_package)?;
         let composer_phar = PathBuf::from(self.directory()).join("composer.phar");
         let composer_path = composer_phar.to_str().with_context(|| {
-            format!(
-                "Failed to convert composer path to string: {:?}",
-                composer_phar
-            )
+            format!("Failed to convert composer path to string: {composer_phar:?}")
         })?;
+
+        // `composer install` honors the staged lock file while `composer update`
+        // re-resolves and rewrites it. Install only installs packages recorded
+        // in the lock file, so fall back to update when the tool is absent
+        // from it since install would not add it.
+        let subcommand = if lock_file_staged && Self::lock_file_contains_package(php_package) {
+            "install"
+        } else {
+            "update"
+        };
 
         let cmd = self
             .cmd
@@ -88,7 +95,7 @@ impl Composer {
                 "php",
                 vec![
                     &path_to_native_string(composer_path),
-                    "update",
+                    subcommand,
                     "--no-interaction",
                     "--ignore-platform-reqs",
                 ],
@@ -99,7 +106,7 @@ impl Composer {
             .stdout_capture()
             .unchecked(); // Capture output for debugging
 
-        let script = format!("{:?}", cmd);
+        let script = format!("{cmd:?}");
         debug!(script);
 
         let mut installation = initialize_installation(php_package)?;
@@ -113,6 +120,56 @@ impl Composer {
         }
 
         Ok(())
+    }
+
+    // The staged composer.json has require-dev collapsed into require, so the
+    // staged lock file must record dev packages as regular packages for
+    // `composer install` to accept required packages locked as dev
+    fn collapse_dev_packages(lock_contents: &str) -> Option<String> {
+        let mut lock_json = serde_json::from_str::<Value>(lock_contents).ok()?;
+        let root = lock_json.as_object_mut()?;
+
+        let dev_packages = match root.get_mut("packages-dev") {
+            Some(value) => std::mem::replace(value, Value::Array(vec![])),
+            None => return serde_json::to_string_pretty(&lock_json).ok(),
+        };
+
+        if let Value::Array(dev_packages) = dev_packages {
+            match root.get_mut("packages") {
+                Some(Value::Array(packages)) => packages.extend(dev_packages),
+                _ => {
+                    root.insert("packages".to_string(), Value::Array(dev_packages));
+                }
+            }
+        }
+
+        serde_json::to_string_pretty(&lock_json).ok()
+    }
+
+    fn lock_file_contains_package(php_package: &PhpPackage) -> bool {
+        let Some(package_name) = php_package.plugin.package.as_deref() else {
+            return false;
+        };
+
+        let lock_file = PathBuf::from(php_package.directory()).join("composer.lock");
+        let Ok(contents) = std::fs::read_to_string(&lock_file) else {
+            return false;
+        };
+        let Ok(lock_json) = serde_json::from_str::<Value>(&contents) else {
+            debug!("Failed to parse staged lock file {:?}", lock_file);
+            return false;
+        };
+
+        ["packages", "packages-dev"].iter().any(|section| {
+            lock_json
+                .get(section)
+                .and_then(|packages| packages.as_array())
+                .is_some_and(|packages| {
+                    packages.iter().any(|package| {
+                        package.get("name").and_then(|name| name.as_str()) == Some(package_name)
+                    })
+                })
+        })
     }
 
     // Filter out any dependencies that don't seem related to the plugin
@@ -171,7 +228,9 @@ impl Composer {
         Ok(serde_json::to_string_pretty(&composer_json)?)
     }
 
-    fn update_composer_json(php_package: &PhpPackage) -> Result<()> {
+    // Returns whether the repository's composer.lock was copied into the
+    // staging directory, which only happens when package_filters is empty
+    fn update_composer_json(php_package: &PhpPackage) -> Result<bool> {
         let install_dir = PathBuf::from(php_package.directory());
         let package_file_contents = Self::filter_composer(php_package)?;
         let user_json = serde_json::from_str::<Value>(&package_file_contents)?;
@@ -201,6 +260,8 @@ impl Composer {
 
         std::fs::write(staged_file, final_composer_file)?;
 
+        let mut lock_file_staged = false;
+
         if php_package.plugin.package_filters.is_empty() {
             let package_file = php_package
                 .plugin
@@ -218,12 +279,16 @@ impl Composer {
                         "Copying lock file from {:?} to {:?}",
                         lock_file, staging_lock_file
                     );
-                    std::fs::copy(lock_file, staging_lock_file)?;
+                    let lock_contents = std::fs::read_to_string(&lock_file)?;
+                    let staged_lock_contents =
+                        Self::collapse_dev_packages(&lock_contents).unwrap_or(lock_contents);
+                    std::fs::write(staging_lock_file, staged_lock_contents)?;
+                    lock_file_staged = true;
                 }
             }
         }
 
-        Ok(())
+        Ok(lock_file_staged)
     }
 }
 
@@ -458,6 +523,60 @@ pub mod test {
             assert!(
                 lock_content.contains("phpstan/phpstan"),
                 "Lock file contents are incorrect"
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_lock_file_staged_with_dev_packages_collapsed() {
+        with_php_package(|pkg, tempdir, _| {
+            let parent_dir = tempdir.path().join("project");
+            std::fs::create_dir_all(&parent_dir)?;
+
+            let user_composer_file = parent_dir.join("composer.json");
+            let composer_contents = r#"{
+                "require-dev": {
+                    "phpstan/phpstan": "^1.10.0"
+                }
+            }"#;
+            std::fs::write(&user_composer_file, composer_contents)?;
+
+            let lock_file = parent_dir.join("composer.lock");
+            let lock_contents = r#"{
+                "packages": [{
+                    "name": "other/package",
+                    "version": "2.0.0"
+                }],
+                "packages-dev": [{
+                    "name": "phpstan/phpstan",
+                    "version": "1.10.35"
+                }]
+            }"#;
+            std::fs::write(&lock_file, lock_contents)?;
+
+            pkg.plugin.package_file = Some(path_to_string(&user_composer_file));
+            reroute_tools_root(tempdir, pkg);
+
+            let install_dir = PathBuf::from(pkg.directory());
+            std::fs::create_dir_all(&install_dir)?;
+
+            Composer::update_composer_json(pkg)?;
+
+            let staged_lock_file = install_dir.join("composer.lock");
+            let staged_lock =
+                serde_json::from_str::<Value>(&std::fs::read_to_string(&staged_lock_file)?)?;
+
+            assert_eq!(
+                staged_lock,
+                serde_json::json!({
+                    "packages": [
+                        { "name": "other/package", "version": "2.0.0" },
+                        { "name": "phpstan/phpstan", "version": "1.10.35" }
+                    ],
+                    "packages-dev": []
+                })
             );
 
             Ok(())

--- a/qlty-check/src/tool/php/composer.rs
+++ b/qlty-check/src/tool/php/composer.rs
@@ -129,7 +129,11 @@ impl Composer {
 
         let output = result?;
         if output.status.code() != Some(0) {
-            bail!("Failed to install composer package file");
+            bail!(
+                "composer {} exited with code {:?} (see installation logs for details)",
+                subcommand,
+                output.status.code()
+            );
         }
 
         Ok(())
@@ -263,7 +267,7 @@ impl Composer {
                 if lock_file.exists() {
                     let staging_lock_file = install_dir.join("composer.lock");
                     debug!(
-                        "Copying lock file from {:?} to {:?}",
+                        "Staging lock file from {:?} to {:?} with dev packages collapsed",
                         lock_file, staging_lock_file
                     );
                     let lock_contents = std::fs::read_to_string(&lock_file)?;


### PR DESCRIPTION
## Summary

PHP counterpart to #2829: `composer.lock` was not honored when installing PHP linters with `package_file`, contradicting the [documented behavior](https://docs.qlty.sh/cli/linter-extensions#lock-files) ("When using `package_file`, Qlty respects the locked versions for reliability").

## Problem

Since #1658, `update_composer_json` copies the repo's `composer.lock` into the tool staging directory (when no `package_filters` are configured), but the package file was then installed with `composer update --no-interaction --ignore-platform-reqs` — and `composer update` re-resolves dependencies and rewrites the lock, ignoring the locked versions entirely.

**Repro:** a repo with `"squizlabs/php_codesniffer": "^3.8"` in `composer.json`, a lockfile pinning `3.8.0`, and `package_file = "composer.json"` in `qlty.toml` installed phpcs **3.13.5** instead of the locked **3.8.0**.

## Fix

When the repository's `composer.lock` was staged, attempt `composer install` (which installs exactly what the lock records). If it fails — a stale lock, a missing package, a constraint mismatch, anything composer's lock validation rejects — fall back to `composer update` with a warning, restoring the previous behavior at the cost of one fast-failing composer run.

One wrinkle: qlty collapses `require-dev` into `require` in the staged composer.json, but `composer install` validates required prod packages against the lock's prod section — so a tool locked under `packages-dev` (the common case for linters) would hard-error with "Required package ... is not present in the lock file". The staged lock therefore gets the same treatment: `packages-dev` entries are collapsed into `packages`.

## Testing

- New unit tests: lock staged → `composer install`; install failure → falls back to `composer update`; `package_filters` set → lock not staged, `composer update` only; dev packages collapsed in the staged lock
- Verified end-to-end: locked phpcs 3.8.0 installs (including when locked under `require-dev`); a stale lock (constraint `^3.9` vs locked `3.8.0`) falls back to update and succeeds; without a lockfile, behavior is unchanged
- phpstan, php-codesniffer, and php-cs-fixer plugin test suites pass locally
- Full qlty-check test suite passes (249 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)