### PR TITLE
feat(release): add pre-release channel to release promotion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,5 +134,6 @@ jobs:
     uses: ./.github/workflows/release_promote.yml
     with:
       version: ${{ needs.release.outputs.tag }}
+      channel: canary
     secrets:
       QLTY_RELEASE_AWS_ROLE_ARN: ${{ secrets.QLTY_RELEASE_AWS_ROLE_ARN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,6 @@ jobs:
     uses: ./.github/workflows/release_promote.yml
     with:
       version: ${{ needs.release.outputs.tag }}
-      channel: canary
+      channel: pre-release
     secrets:
       QLTY_RELEASE_AWS_ROLE_ARN: ${{ secrets.QLTY_RELEASE_AWS_ROLE_ARN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,10 @@ on:
       workflow_run_id:
         required: true
         type: string
-      channel:
+      pre-release:
         required: false
-        type: string
-        default: latest
+        type: boolean
+        default: false
     secrets:
       QLTY_APP_PRIVATE_KEY:
         required: true
@@ -138,6 +138,6 @@ jobs:
     uses: ./.github/workflows/release_promote.yml
     with:
       version: ${{ needs.release.outputs.tag }}
-      channel: ${{ inputs.channel }}
+      channel: ${{ inputs.pre-release && 'pre-release' || 'latest' }}
     secrets:
       QLTY_RELEASE_AWS_ROLE_ARN: ${{ secrets.QLTY_RELEASE_AWS_ROLE_ARN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
       workflow_run_id:
         required: true
         type: string
+      channel:
+        required: false
+        type: string
+        default: latest
     secrets:
       QLTY_APP_PRIVATE_KEY:
         required: true
@@ -134,6 +138,6 @@ jobs:
     uses: ./.github/workflows/release_promote.yml
     with:
       version: ${{ needs.release.outputs.tag }}
-      channel: pre-release
+      channel: ${{ inputs.channel }}
     secrets:
       QLTY_RELEASE_AWS_ROLE_ARN: ${{ secrets.QLTY_RELEASE_AWS_ROLE_ARN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       pre-release:
         required: false
         type: boolean
-        default: false
+        default: true
     secrets:
       QLTY_APP_PRIVATE_KEY:
         required: true

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -69,7 +69,7 @@ jobs:
             echo "Unknown channel: $CHANNEL" >&2
             exit 1
           fi
-          aws s3 cp --recursive ${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/v${VERSION#v}/ ${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/${CHANNEL}/
+          aws s3 cp --recursive "${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/v${VERSION#v}/" "${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/${CHANNEL}/"
         env:
           INPUTS_VERSION: ${{ inputs.version }}
           INPUTS_CHANNEL: ${{ inputs.channel }}

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -13,7 +13,7 @@ on:
         type: choice
         options:
           - latest
-          - canary
+          - pre-release
         default: latest
   workflow_call:
     inputs:
@@ -65,7 +65,7 @@ jobs:
         run: |
           VERSION="${INPUTS_VERSION}"
           CHANNEL="${INPUTS_CHANNEL}"
-          if [ "$CHANNEL" != "latest" ] && [ "$CHANNEL" != "canary" ]; then
+          if [ "$CHANNEL" != "latest" ] && [ "$CHANNEL" != "pre-release" ]; then
             echo "Unknown channel: $CHANNEL" >&2
             exit 1
           fi

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -1,14 +1,26 @@
-name: Promote a Release to Latest
+name: Promote a Release
+run-name: Promote ${{ inputs.version }} to ${{ inputs.channel }}
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "The version to promote as latest (e.g. v1.0.0)"
+        description: "The version to promote (e.g. v1.0.0)"
         required: true
         type: string
+      channel:
+        description: "The channel to promote the version to"
+        required: true
+        type: choice
+        options:
+          - latest
+          - canary
+        default: latest
   workflow_call:
     inputs:
       version:
+        required: true
+        type: string
+      channel:
         required: true
         type: string
     secrets:
@@ -52,7 +64,13 @@ jobs:
       - name: Upload to S3
         run: |
           VERSION="${INPUTS_VERSION}"
-          aws s3 cp --recursive ${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/v${VERSION#v}/ ${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/latest/
+          CHANNEL="${INPUTS_CHANNEL}"
+          if [ "$CHANNEL" != "latest" ] && [ "$CHANNEL" != "canary" ]; then
+            echo "Unknown channel: $CHANNEL" >&2
+            exit 1
+          fi
+          aws s3 cp --recursive ${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/v${VERSION#v}/ ${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/${CHANNEL}/
         env:
           INPUTS_VERSION: ${{ inputs.version }}
+          INPUTS_CHANNEL: ${{ inputs.channel }}
           VARS_QLTY_RELEASE_AWS_S3_DESTINATION: ${{ vars.QLTY_RELEASE_AWS_S3_DESTINATION }}


### PR DESCRIPTION
## Summary

Adds a `pre-release` channel alongside `latest` in the `qlty-releases` S3 bucket.

- `release_promote.yml` is parameterized with a `channel` input (`latest` | `pre-release`), copying the versioned folder to `${DEST}/${channel}/` with a guard rejecting unknown channel values. Manual dispatch shows a channel dropdown defaulting to `latest`.
- `release.yml` accepts an optional boolean `pre-release` input (default `true`) and translates it to the channel when calling the promotion workflow. With the default, releases auto-promote to **pre-release only**; promoting to `latest` becomes a deliberate step via the **Promote a Release** workflow_dispatch (or a caller passing `pre-release: false`).

## Infra notes (no terraform changes needed)

- The `qlty-releases` bucket policy and the GitHub Actions uploader IAM policy grant bucket-wide access with no prefix scoping, and there is no CloudFront in front of the bucket, so the `pre-release/` prefix works with zero infra changes.
- The OIDC role allowlist pins workflow files, and `release_promote.yml@refs/heads/main` is already allowed — reusing the existing workflow file avoids any change in `qlty-cloud`.

## Out of scope

- No installer (`install.sh`/`install.ps1`) channel support; pre-release binaries are reachable at `.../qlty/pre-release/qlty-<target>.tar.xz`.
- No `qlty upgrade` changes; `QLTY_UPDATE_MANIFEST_URL` can already point at `pre-release/dist-manifest.json`.

## Test plan

- [x] `actionlint` on both workflows (only pre-existing `macos-15` label warning)
- [x] `qlty check` (only pre-existing checkov CKV_GHA_7 finding, present on main)
- [ ] After merge: dispatch **Promote a Release** with an existing version and `channel: pre-release`; verify `qlty/pre-release/dist-manifest.json` appears and `latest/` is untouched (OIDC trust is pinned to `refs/heads/main`, so this can't be exercised from a branch)
- [ ] Next release: verify it lands in `pre-release/` only, then dispatch `channel: latest` and verify `latest/` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
