### PR TITLE
Prevent filtered checks from polluting the issue cache

### DIFF
--- a/qlty-check/src/cache.rs
+++ b/qlty-check/src/cache.rs
@@ -1,6 +1,7 @@
 use crate::planner::config_files::PluginConfigFile;
 use crate::planner::target::Target;
 use crate::tool::Tool;
+use crate::CheckFilter;
 use anyhow::{Context, Result};
 use git2::{Repository, Status};
 use itertools::Itertools;
@@ -104,6 +105,7 @@ struct InvocationCacheKey {
     tool: Box<dyn Tool>,
     plugin: Arc<PluginDef>,
     driver_name: String,
+    filters: Vec<CheckFilter>,
     affects_cache: HashMap<PathBuf, String>,
     configs: Arc<Vec<PluginConfigFile>>,
 }
@@ -247,6 +249,10 @@ impl InvocationCacheKey {
         digest.add("tool", &self.tool.directory());
         digest.add("driver_name", &self.driver_name);
 
+        for filter in &self.filters {
+            digest.add(&format!("check.filter.{filter}"), "true");
+        }
+
         for config in self.configs.clone().iter().sorted() {
             digest.add(&config.path.to_string_lossy(), &config.contents);
         }
@@ -264,6 +270,7 @@ impl IssuesCacheKey {
         tool: Box<dyn Tool>,
         plugin: Arc<PluginDef>,
         driver_name: String,
+        filters: Vec<CheckFilter>,
         configs: Arc<Vec<PluginConfigFile>>,
         affects_cache: Vec<String>,
     ) -> Self {
@@ -290,6 +297,7 @@ impl IssuesCacheKey {
                 tool: tool.clone(),
                 plugin: plugin.clone(),
                 driver_name,
+                filters,
                 affects_cache: cache_busters,
                 configs,
             }

--- a/qlty-check/src/executor/invocation_result.rs
+++ b/qlty-check/src/executor/invocation_result.rs
@@ -497,6 +497,7 @@ impl InvocationResult {
             self.plan.tool.clone(),
             Arc::new(self.plan.plugin.clone()),
             self.invocation.driver_name.clone(),
+            self.plan.settings.filters.clone(),
             Arc::new(configs.clone()),
             self.plan.plugin.affects_cache.clone(),
         );

--- a/qlty-check/src/planner/driver.rs
+++ b/qlty-check/src/planner/driver.rs
@@ -162,6 +162,7 @@ impl DriverPlanner {
             self.tool.clone(),
             Arc::new(self.plugin.clone()),
             self.driver_name.clone(),
+            self.settings.filters.clone(),
             Arc::new(self.plugin_configs.clone()),
             self.plugin.affects_cache.clone(),
         );

--- a/qlty-cli/tests/cmd.rs
+++ b/qlty-cli/tests/cmd.rs
@@ -1,7 +1,39 @@
 use crate::helpers::{
     setup_and_run_diff_test_cases, setup_and_run_test_cases, setup_and_run_test_cases_without_git,
 };
+use indoc::indoc;
+use qlty_config::Library;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
 use trycmd::TestCases;
+
+struct CacheCleanup(PathBuf);
+
+impl Drop for CacheCleanup {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn run_qlty(root: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_qlty"))
+        .current_dir(root)
+        .env("QLTY_TELEMETRY", "off")
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn command_output(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
 
 #[test]
 fn version_tests() {
@@ -28,6 +60,87 @@ fn check_tests() {
     // only run .toml files in check directory
     // prevent running toml files from *.in
     setup_and_run_test_cases("tests/cmd/check/*.toml");
+}
+
+#[test]
+fn filtered_check_does_not_pollute_unfiltered_issue_cache() {
+    let fixture = tempfile::tempdir().unwrap();
+    let root = fixture.path();
+    fs::create_dir_all(root.join(".qlty")).unwrap();
+    fs::write(
+        root.join(".gitignore"),
+        ".qlty/logs\n.qlty/out\n.qlty/results\n.qlty/sources\n.qlty/tmp\n",
+    )
+    .unwrap();
+    fs::write(root.join("sample.js"), "const answer = 42;\n").unwrap();
+    fs::write(
+        root.join(".qlty/qlty.toml"),
+        indoc! {r#"
+            config_version = "0"
+
+            [plugins.definitions.cache-repro]
+            file_types = ["javascript"]
+            known_good_version = "1.0.0"
+
+            [plugins.definitions.cache-repro.drivers.lint]
+            script = "echo sample.js:1 LINT: reproducible lint issue"
+            success_codes = [0]
+            output = "stdout"
+            output_format = "regex"
+            output_regex = '((?P<path>.*):(?P<line>-?\d+) (?P<code>\S+): (?P<message>.+))'
+            output_level = "high"
+            cache_results = true
+
+            [plugins.definitions.cache-repro.drivers.format]
+            script = "exit 0"
+            success_codes = [0]
+            output = "rewrite"
+            driver_type = "formatter"
+
+            [[plugin]]
+            name = "cache-repro"
+            version = "1.0.0"
+        "#},
+    )
+    .unwrap();
+
+    let _repository = qlty_test_utilities::git::init(root);
+    let cache_directory = Library::new(root).unwrap().cache_directory().unwrap();
+    let _cache_cleanup = CacheCleanup(cache_directory);
+
+    let filtered = run_qlty(
+        root,
+        &[
+            "check",
+            "--all",
+            "--filter=cache-repro:fmt",
+            "--no-upgrade-check",
+            "--no-progress",
+        ],
+    );
+    assert!(filtered.status.success(), "{}", command_output(&filtered));
+
+    let unfiltered = run_qlty(
+        root,
+        &[
+            "check",
+            "--all",
+            "--no-formatters",
+            "--no-upgrade-check",
+            "--no-progress",
+        ],
+    );
+    assert_eq!(
+        unfiltered.status.code(),
+        Some(1),
+        "an unfiltered check reused the filtered cache entry\n{}",
+        command_output(&unfiltered)
+    );
+    assert!(
+        command_output(&unfiltered).contains("reproducible lint issue"),
+        "{}",
+        command_output(&unfiltered)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Include active check filters in issue cache keys.
- Use the same filter-aware key for cache reads and writes.
- Add a CLI regression test for a filtered formatter check followed by an unfiltered lint check.

## Root cause

Qlty applies issue filters before it writes a cache-enabled linter result. A formatter-only filter can remove the linter issues and cache the empty result. The cache key did not include the active filters, so a later unfiltered check could reuse that empty result and incorrectly report no issues.

The regression test reproduced this before the fix: the second, unfiltered check exited 0 and printed No issues. It now exits 1 and reports the lint issue.

## Verification

- cargo fmt --check --all
- cargo nextest run --locked --workspace --all-targets --all-features --no-fail-fast
  - 1,096 passed; 2 skipped
- Focused regression test failed before the implementation and passed after it

## Existing unrelated failures

- Clippy with Rust 1.95 reports existing warnings as errors in unchanged files, beginning at qlty-plugins/src/lib.rs:8.
- Workspace doctests fail in the existing qlty-analysis/src/utils/fs.rs example because join_path_string is not imported.
