### PR TITLE
feat(workflows): promote the latest release when version is blank

### DIFF
--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -1,11 +1,11 @@
 name: Promote a Release
-run-name: Promote ${{ inputs.version }} to ${{ inputs.channel }}
+run-name: Promote ${{ inputs.version || 'the latest release' }} to ${{ inputs.channel }}
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "The version to promote (e.g. v1.0.0)"
-        required: true
+        description: "The version to promote (e.g. v1.0.0). Leave blank to promote the latest GitHub release."
+        required: false
         type: string
       channel:
         description: "The channel to promote the version to"
@@ -29,8 +29,31 @@ on:
 permissions:
   contents: read
 jobs:
+  resolve:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - name: Resolve version
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUTS_VERSION: ${{ inputs.version }}
+        run: |
+          VERSION="${INPUTS_VERSION}"
+          if [ -z "$VERSION" ]; then
+            VERSION="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
+            echo "No version provided, promoting the latest release: $VERSION"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "Could not determine a version to promote" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
   test:
     name: ${{ matrix.runner }}
+    needs: resolve
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -45,14 +68,14 @@ jobs:
     steps:
       - name: Install qlty and validate
         env:
-          QLTY_VERSION: ${{ inputs.version }}
+          QLTY_VERSION: ${{ needs.resolve.outputs.version }}
         run: ${{ matrix.command }} && ~/.qlty/bin/qlty version --no-upgrade-check
         shell: sh
   promote:
     permissions:
       contents: read
       id-token: write
-    needs: test
+    needs: [resolve, test]
     runs-on: ubuntu-latest
     steps:
       - name: Setup AWS CLI
@@ -63,7 +86,7 @@ jobs:
           aws-region: ${{ vars.QLTY_RELEASE_AWS_REGION }}
       - name: Upload to S3
         run: |
-          VERSION="${INPUTS_VERSION}"
+          VERSION="${RESOLVED_VERSION}"
           CHANNEL="${INPUTS_CHANNEL}"
           if [ "$CHANNEL" != "latest" ] && [ "$CHANNEL" != "pre-release" ]; then
             echo "Unknown channel: $CHANNEL" >&2
@@ -71,6 +94,6 @@ jobs:
           fi
           aws s3 cp --recursive "${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/v${VERSION#v}/" "${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/${CHANNEL}/"
         env:
-          INPUTS_VERSION: ${{ inputs.version }}
+          RESOLVED_VERSION: ${{ needs.resolve.outputs.version }}
           INPUTS_CHANNEL: ${{ inputs.channel }}
           VARS_QLTY_RELEASE_AWS_S3_DESTINATION: ${{ vars.QLTY_RELEASE_AWS_S3_DESTINATION }}


### PR DESCRIPTION
## Summary

Previously the "Promote a Release" workflow required an explicit version on every manual dispatch. This change makes the `version` input optional: when left blank, the workflow promotes the most recent GitHub release.

## Changes

- The `workflow_dispatch` `version` input is now optional, and its description tells the operator that leaving it blank promotes the latest GitHub release.
- A new `resolve` job passes an explicit version through unchanged, or falls back to `gh release view --json tagName` (which excludes drafts and pre-releases) when the input is blank. It fails loudly if no version can be determined.
- The `test` and `promote` jobs consume the resolved version output instead of reading the input directly.
- The run name shows "Promote the latest release to <channel>" when no version is given.

The `workflow_call` path used by `release.yml` is unchanged and still requires an explicit version.

## Notes

- If the `pre-release` channel is selected with a blank version, the fallback still resolves to the latest *stable* release, since pre-releases are excluded from the latest-release lookup.
- `qlty check` reports one checkov finding (`CKV_GHA_7`) on this file; it fires identically on `main` and is pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)