### PR TITLE
Pass the discovered .tflint.hcl to tflint with --config

### DIFF
--- a/qlty-plugins/plugins/linters/tflint/plugin.toml
+++ b/qlty-plugins/plugins/linters/tflint/plugin.toml
@@ -15,8 +15,9 @@ version_command = "tflint --version"
 description = "A pluggable Terraform linter"
 
 [plugins.definitions.tflint.drivers.lint]
-script = "tflint --format=sarif --force"
-prepare_script = "tflint --init"
+script = "tflint --format=sarif --force ${config_script}"
+config_script = "--config ${config_file}"
+prepare_script = "tflint --init ${config_script}"
 success_codes = [0, 1, 2]
 output = "stdout"
 output_format = "sarif"


### PR DESCRIPTION
## Problem

`tflint` reads `.tflint.hcl` from its own working directory. The driver sets
`runs_from = { type = "target_directory" }`, so in a repository where Terraform lives in
subdirectories, tflint runs from each of those and a repository-root `.tflint.hcl` is
never read.

The failure is silent. No ruleset is named, so none is installed, and the run reports
"no issues" rather than a configuration error. On a 737-file, 125-directory Terraform
tree this looked like a clean AWS ruleset; it was the ruleset never loading.

There is no configuration-side workaround. `qlty` copies config files into the tool
install directory or the workspace root, never into target directories; `[[plugin]]`
has no script override; and the linter environment is built from an allow-list, so
`TFLINT_CONFIG_FILE` does not reach the process. The only thing that works today is a
`.tflint.hcl` in every Terraform directory.

## Change

Use the existing `${config_script}` mechanism — the same shape `knip`, `phpstan`,
`eslint`, `prettier` and `checkstyle` already use — so `--config` is passed only when a
config file was discovered. `${config_file}` expands to an absolute path, so the
invocation directory stops mattering.

## Compatibility

`${config_script}` expands to nothing when no config file is discovered, so for anyone
without a `.tflint.hcl` the invocation is byte-identical to today's. The plugin's
fixtures include no config file, so the snapshots are unaffected.

## Verification

Against a clone of this definition, on a repository with Terraform in subdirectories:

- With a root `.tflint.hcl` naming `terraform-linters/tflint-ruleset-aws`, the AWS rules
  fire — `aws_instance_invalid_type` on a planted `q3.gigantic`, and
  `aws_elasticache_cluster_default_parameter_group` / `aws_acm_certificate_lifecycle`
  across the real tree. On the unpatched definition the same tree reports none of them.
- With no config file present, tflint still runs and reports the bundled `terraform`
  rules exactly as before.
